### PR TITLE
Fix: thread access inconsistency between backends.

### DIFF
--- a/codegen/impl/src/main/kotlin/ScopedProviderGenerator.kt
+++ b/codegen/impl/src/main/kotlin/ScopedProviderGenerator.kt
@@ -55,9 +55,6 @@ internal class ScopedProviderGenerator(
                     modifiers(PUBLIC)
                     annotation<Override>()
                     returnType(ClassName.OBJECT)
-                    if (!useDoubleChecking) {
-                        +"%T.assertThreadAccess()".formatCode(Names.ThreadAssertions)
-                    }
                     +"%T local = mValue".formatCode(ClassName.OBJECT)
                     controlFlow("if (local == null)") {
                         if (useDoubleChecking) {
@@ -69,6 +66,7 @@ internal class ScopedProviderGenerator(
                                 }
                             }
                         } else {
+                            +"%T.assertThreadAccess()".formatCode(Names.ThreadAssertions)
                             +"local = mDelegate.%N(mIndex)".formatCode(SlotSwitchingGenerator.FactoryMethodName)
                             +"mValue = local"
                         }

--- a/rt/engine/src/main/kotlin/accessStrategies.kt
+++ b/rt/engine/src/main/kotlin/accessStrategies.kt
@@ -55,8 +55,8 @@ internal class CachingAccessStrategy(
     private var value: Any? = null
 
     override fun get(): Any {
-        ThreadAssertions.assertThreadAccess()
         value?.let { local -> return local }
+        ThreadAssertions.assertThreadAccess()
         return binding.accept(creationVisitor).also { value = it }
     }
     override fun getLazy(): Lazy<*> = this


### PR DESCRIPTION
RT behaved inconsistently with generated code,
 and there was one more inconsistency with the latter itself.

Cover the fix with a test.

Fixes #12 