### PR TITLE
Codegen: implement nested switches in switching providers.

### DIFF
--- a/codegen/impl/src/main/kotlin/AccessStrategyManager.kt
+++ b/codegen/impl/src/main/kotlin/AccessStrategyManager.kt
@@ -113,7 +113,7 @@ internal class AccessStrategyManager(
                             lazyStrategy = if (usage.lazy + usage.provider > 0) {
                                 SlotProviderStrategy(
                                     binding = binding,
-                                    multiFactory = multiFactory.get(),
+                                    slot = multiFactory.get().requestSlot(binding),
                                     cachingProvider = unscopedProviderGenerator.get(),
                                 )
                             } else null

--- a/codegen/impl/src/main/kotlin/ComponentGenerator.kt
+++ b/codegen/impl/src/main/kotlin/ComponentGenerator.kt
@@ -35,9 +35,14 @@ import javax.lang.model.element.Modifier.STATIC
 internal class ComponentGenerator private constructor(
     private val graph: BindingGraph,
     val generatedClassName: ClassName,
+    maxSlotsPerSwitch: Int,
 ) {
-    constructor(graph: BindingGraph): this(
+    constructor(
+        graph: BindingGraph,
+        maxSlotsPerSwitch: Int,
+    ): this(
         graph = graph,
+        maxSlotsPerSwitch = maxSlotsPerSwitch,
         generatedClassName = graph.model.name.let { name ->
             check(name is ClassNameModel)
             // Keep name mangling in sync with loader!
@@ -57,6 +62,7 @@ internal class ComponentGenerator private constructor(
     private val slotSwitchingGenerator = lazyProvider {
         SlotSwitchingGenerator(
             thisGraph = graph,
+            maxSlotsPerSwitch = maxSlotsPerSwitch,
         ).also(::registerContributor)
     }
     private val unscopedProviderGenerator = lazyProvider {
@@ -120,6 +126,7 @@ internal class ComponentGenerator private constructor(
     private val childGenerators: Collection<ComponentGenerator> = graph.children.map { childGraph ->
         ComponentGenerator(
             graph = childGraph,
+            maxSlotsPerSwitch = maxSlotsPerSwitch,
             generatedClassName = generatedClassName.nestedClass(
                 subcomponentNs.name(childGraph.model.name, suffix = "Impl", firstCapital = true)
             ),

--- a/codegen/impl/src/main/kotlin/ComponentGeneratorFacade.kt
+++ b/codegen/impl/src/main/kotlin/ComponentGeneratorFacade.kt
@@ -21,9 +21,11 @@ import com.yandex.yatagan.core.graph.BindingGraph
 
 class ComponentGeneratorFacade(
     graph: BindingGraph,
+    maxSlotsPerSwitch: Int,
 ) {
     private val generator = ComponentGenerator(
         graph = graph,
+        maxSlotsPerSwitch = maxSlotsPerSwitch,
     )
 
     val targetPackageName: String

--- a/codegen/impl/src/main/kotlin/accessStrategies.kt
+++ b/codegen/impl/src/main/kotlin/accessStrategies.kt
@@ -130,12 +130,11 @@ internal class CachingStrategyMultiThread(
 
 internal class SlotProviderStrategy(
     private val binding: Binding,
-    multiFactory: SlotSwitchingGenerator,
+    private val slot: Int,
     cachingProvider: UnscopedProviderGenerator,
 ) : AccessStrategy {
 
     private val providerName = cachingProvider.name
-    private val slot = multiFactory.requestSlot(binding)
 
     override fun generateAccess(
         builder: ExpressionBuilder,

--- a/processor/common/src/main/kotlin/Options.kt
+++ b/processor/common/src/main/kotlin/Options.kt
@@ -63,5 +63,7 @@ class Options(
         val MaxIssueEncounterPaths = IntOption("yatagan.maxIssueEncounterPaths", default = 5)
 
         val UsePlainOutput = BooleanOption("yatagan.usePlainOutput", default = false)
+
+        val MaxSlotsPerSwitch = IntOption("yatagan.experimental.maxSlotsPerSwitch", default = -1)
     }
 }

--- a/processor/common/src/main/kotlin/process.kt
+++ b/processor/common/src/main/kotlin/process.kt
@@ -85,6 +85,7 @@ fun <Source> process(
             try {
                 val generator = ComponentGeneratorFacade(
                     graph = graphRoot,
+                    maxSlotsPerSwitch = delegate.options[Options.MaxSlotsPerSwitch],
                 )
                 delegate.openFileForGenerating(
                     sources = allSourcesSequence(delegate, graphRoot),

--- a/rt/engine/src/main/kotlin/RuntimeComponent.kt
+++ b/rt/engine/src/main/kotlin/RuntimeComponent.kt
@@ -339,7 +339,8 @@ internal class RuntimeComponent(
     }
 
     override fun visitEmpty(binding: EmptyBinding): Any {
-        throw IllegalStateException("Missing binding encountered in `$graph`: $binding")
+        throw IllegalStateException(
+            "Missing binding encountered in `${graph.toString(null)}`: ${binding.toString(null)}")
     }
 
     private inner class EntryPointHandler(val dependency: NodeDependency) : MethodHandler {

--- a/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
@@ -163,6 +163,7 @@ abstract class CompileTestDriverBase private constructor(
         ),
         processorOptions = mapOf(
             Options.MaxIssueEncounterPaths.key to "100",
+            Options.MaxSlotsPerSwitch.key to "100",
         ),
     )
 


### PR DESCRIPTION
Introduce an `yatagan.experimental.maxSlotsPerSwitch`
 option to enable/customize nested switches behavior.
 It's set to infinity by default as before the patch.

Add a "heavy" test-case to trigger this mechanic.

Resolves #8 