### PR TITLE
Fix: a duplicate is reported with intrinsic component bindings.

### DIFF
--- a/core/graph/impl/src/main/kotlin/GraphBindingsManager.kt
+++ b/core/graph/impl/src/main/kotlin/GraphBindingsManager.kt
@@ -34,6 +34,7 @@ import com.yandex.yatagan.core.graph.impl.bindings.ComponentInstanceBindingImpl
 import com.yandex.yatagan.core.graph.impl.bindings.ExplicitEmptyBindingImpl
 import com.yandex.yatagan.core.graph.impl.bindings.InjectConstructorProvisionBindingImpl
 import com.yandex.yatagan.core.graph.impl.bindings.InstanceBindingImpl
+import com.yandex.yatagan.core.graph.impl.bindings.IntrinsicBindingMarker
 import com.yandex.yatagan.core.graph.impl.bindings.MapBindingImpl
 import com.yandex.yatagan.core.graph.impl.bindings.MissingBindingImpl
 import com.yandex.yatagan.core.graph.impl.bindings.MultiBindingImpl
@@ -351,6 +352,14 @@ internal class GraphBindingsManager(
                     // There can be no two+ different multi-bindings for the same node in the same graph,
                     //  so here we definitely have bindings from different graphs - no need to check that.
                     if (distinct.all { it is ExtensibleBinding<*> }) continue
+
+                    // Intrinsic bindings are allowed to override each other in child graphs.
+                    if (distinct.all { it is IntrinsicBindingMarker }) {
+                        assert(distinct.distinctBy { it.owner }.size == distinct.size) {
+                            "Not reached: duplicate intrinsic bindings in one graph"
+                        }
+                        continue
+                    }
 
                     validator.reportError(Strings.Errors.conflictingBindings(`for` = node)) {
                         distinct.forEach { binding ->

--- a/core/graph/impl/src/main/kotlin/bindings/ComponentInstanceBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/ComponentInstanceBindingImpl.kt
@@ -24,7 +24,7 @@ import com.yandex.yatagan.validation.format.modelRepresentation
 
 internal class ComponentInstanceBindingImpl(
     graph: BindingGraph,
-) : ComponentInstanceBinding, BindingDefaultsMixin, ComparableByTargetBindingMixin {
+) : ComponentInstanceBinding, BindingDefaultsMixin, ComparableByTargetBindingMixin, IntrinsicBindingMarker {
     override val owner: BindingGraph = graph
     override val target get() = owner.model.asNode()
 

--- a/core/graph/impl/src/main/kotlin/bindings/SubComponentBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/SubComponentBindingImpl.kt
@@ -30,7 +30,7 @@ import com.yandex.yatagan.validation.format.modelRepresentation
 internal class SubComponentBindingImpl(
     override val owner: BindingGraph,
     private val targetComponent: ComponentModel,
-) : SubComponentBinding, ConditionalBindingMixin, ComparableByTargetBindingMixin {
+) : SubComponentBinding, ConditionalBindingMixin, ComparableByTargetBindingMixin, IntrinsicBindingMarker {
     init {
         require(targetComponent.factory == null)
     }

--- a/core/graph/impl/src/main/kotlin/bindings/SubComponentFactoryBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/SubComponentFactoryBindingImpl.kt
@@ -30,7 +30,7 @@ import com.yandex.yatagan.validation.format.modelRepresentation
 internal class SubComponentFactoryBindingImpl(
     override val owner: BindingGraph,
     private val factory: ComponentFactoryModel,
-) : SubComponentBinding, ConditionalBindingMixin, ComparableByTargetBindingMixin {
+) : SubComponentBinding, ConditionalBindingMixin, ComparableByTargetBindingMixin, IntrinsicBindingMarker {
     override val target: NodeModel
         get() = factory.asNode()
 

--- a/core/graph/impl/src/main/kotlin/bindings/mixins.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/mixins.kt
@@ -36,6 +36,11 @@ import com.yandex.yatagan.validation.format.Strings
 import com.yandex.yatagan.validation.format.modelRepresentation
 import com.yandex.yatagan.validation.format.reportError
 
+/**
+ * Binding that is **implicitly** created by the framework, not ordered by the user.
+ */
+internal interface IntrinsicBindingMarker
+
 internal interface BaseBindingDefaultsMixin : BaseBinding {
     override val originModule: ModuleModel?
         get() = null

--- a/testing/tests/src/test/kotlin/ComponentHierarchyKotlinTest.kt
+++ b/testing/tests/src/test/kotlin/ComponentHierarchyKotlinTest.kt
@@ -422,6 +422,7 @@ class ComponentHierarchyKotlinTest(
             interface Sub2Component {
                 val foo: Foo
                 val opt: Optional<FeatureComponent>
+                val s: Sub2Component
             }
 
             @Sub @Component(isRoot = false)


### PR DESCRIPTION
Duplicate binding is reported only if used. The duplicates could be:
1. A sub-component creating binding (if subcomponent has no explicit factory)
2. A current component instance binding (added to every graph).

So (1) is in the parent graph for the sub-component, while the sub-components
 binds itself.

The fix is simple - don't consider intrinsic bindings from different components
 as duplicates, so they work like "overrides".

Fixes the bug introduced by #28.