### PR TITLE
Enhance: Support full-blown subcomponent factory methods.

### DIFF
--- a/core/graph/api/src/main/kotlin/BindingGraph.kt
+++ b/core/graph/api/src/main/kotlin/BindingGraph.kt
@@ -26,7 +26,6 @@ import com.yandex.yatagan.core.model.ComponentFactoryModel
 import com.yandex.yatagan.core.model.ComponentModel
 import com.yandex.yatagan.core.model.ConditionModel
 import com.yandex.yatagan.core.model.ConditionScope
-import com.yandex.yatagan.core.model.HasNodeModel
 import com.yandex.yatagan.core.model.ModuleModel
 import com.yandex.yatagan.core.model.NodeModel
 import com.yandex.yatagan.core.model.ScopeModel
@@ -43,7 +42,7 @@ public interface BindingGraph : MayBeInvalid, Extensible, WithParents<BindingGra
     /**
      * A model behind this graph.
      */
-    public val model: HasNodeModel
+    public val model: ComponentModel
 
     /**
      * Requested bindings that are **hosted** in this component.
@@ -110,9 +109,13 @@ public interface BindingGraph : MayBeInvalid, Extensible, WithParents<BindingGra
     public val scopes: Set<ScopeModel>
 
     /**
-     * Component creator model declared in the underlying model.
+     * Component creator [model][ComponentModel.factory] declared in the underlying model
+     * or the child component factory [method][ComponentModel.subComponentFactoryMethods]
+     * declared in the parent component model.
      *
      * @see [ComponentModel.factory]
+     * @see [ComponentModel.subComponentFactoryMethods]
+     * @see [subComponentFactoryMethods]
      */
     public val creator: ComponentFactoryModel?
 
@@ -129,6 +132,11 @@ public interface BindingGraph : MayBeInvalid, Extensible, WithParents<BindingGra
      * @see [ComponentModel.memberInjectors]
      */
     public val memberInjectors: Collection<GraphMemberInjector>
+
+    /**
+     * @see ComponentModel.subComponentFactoryMethods
+     */
+    public val subComponentFactoryMethods: Collection<GraphSubComponentFactoryMethod>
 
     /**
      * A condition for this graph.

--- a/core/graph/api/src/main/kotlin/GraphSubComponentFactoryMethod.kt
+++ b/core/graph/api/src/main/kotlin/GraphSubComponentFactoryMethod.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.graph
+
+import com.yandex.yatagan.core.model.ComponentFactoryModel
+import com.yandex.yatagan.core.model.SubComponentFactoryMethodModel
+import com.yandex.yatagan.validation.MayBeInvalid
+
+/**
+ * Graph-level abstraction over [com.yandex.yatagan.core.model.ComponentFactoryModel] obtained from
+ * [com.yandex.yatagan.core.model.ComponentModel.subComponentFactoryMethods].
+ */
+public interface GraphSubComponentFactoryMethod : MayBeInvalid {
+    /**
+     * Underlying model.
+     */
+    public val model: SubComponentFactoryMethodModel
+
+    /**
+     * Graph object build from [model.createdComponent][ComponentFactoryModel.createdComponent].
+     * Yields `null` if the [model] is **invalid** in context of the owning graph an no child was actually built from it.
+     */
+    public val createdGraph: BindingGraph?
+}

--- a/core/graph/impl/src/main/kotlin/GraphEntryPointImpl.kt
+++ b/core/graph/impl/src/main/kotlin/GraphEntryPointImpl.kt
@@ -17,6 +17,7 @@
 package com.yandex.yatagan.core.graph.impl
 
 import com.yandex.yatagan.core.graph.GraphEntryPoint
+import com.yandex.yatagan.core.model.ComponentEntryPoint
 import com.yandex.yatagan.core.model.ComponentModel
 import com.yandex.yatagan.core.model.HasNodeModel
 import com.yandex.yatagan.core.model.NodeDependency
@@ -32,7 +33,7 @@ import com.yandex.yatagan.validation.format.reportWarning
 
 internal class GraphEntryPointImpl(
     override val graph: BindingGraphImpl,
-    private val impl: ComponentModel.EntryPoint,
+    private val impl: ComponentEntryPoint,
 ) : GraphEntryPoint, GraphEntryPointBase() {
     override val getter: Method
         get() = impl.getter

--- a/core/graph/impl/src/main/kotlin/GraphSubComponentFactoryMethodImpl.kt
+++ b/core/graph/impl/src/main/kotlin/GraphSubComponentFactoryMethodImpl.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.graph.impl
+
+import com.yandex.yatagan.core.graph.BindingGraph
+import com.yandex.yatagan.core.graph.GraphSubComponentFactoryMethod
+import com.yandex.yatagan.core.model.SubComponentFactoryMethodModel
+import com.yandex.yatagan.validation.MayBeInvalid
+import com.yandex.yatagan.validation.Validator
+import com.yandex.yatagan.validation.format.Strings
+import com.yandex.yatagan.validation.format.reportError
+
+internal class GraphSubComponentFactoryMethodImpl(
+    private val owner: BindingGraphImpl,
+    override val model: SubComponentFactoryMethodModel,
+) : GraphSubComponentFactoryMethod {
+    override val createdGraph: BindingGraph?
+        get() = owner.children.find { it.model == model.createdComponent }
+
+    override fun validate(validator: Validator) {
+        val createdGraph = createdGraph
+        if (createdGraph == null) {
+            validator.reportError(Strings.Errors.componentLoop())
+            return
+        }
+
+        if (createdGraph.conditionScope !in owner.conditionScope) {
+            validator.reportError(Strings.Errors.incompatibleConditionChildComponentFactory(
+                aCondition = createdGraph.conditionScope,
+                bCondition = owner.conditionScope,
+                factory = this,
+            ))
+        }
+    }
+
+    override fun toString(childContext: MayBeInvalid?) = model.toString(null)
+}

--- a/core/graph/impl/src/main/kotlin/bindings/MissingBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/MissingBindingImpl.kt
@@ -20,7 +20,7 @@ import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.bindings.Binding
 import com.yandex.yatagan.core.graph.bindings.EmptyBinding
 import com.yandex.yatagan.core.model.AssistedInjectFactoryModel
-import com.yandex.yatagan.core.model.ComponentFactoryModel
+import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel
 import com.yandex.yatagan.core.model.ComponentModel
 import com.yandex.yatagan.core.model.HasNodeModel
 import com.yandex.yatagan.core.model.InjectConstructorModel
@@ -101,7 +101,7 @@ internal data class MissingBindingImpl(
             throw AssertionError("Not reached: assisted inject factory can't be missing")
         }
 
-        override fun visitComponentFactory(model: ComponentFactoryModel) = reportMissingBinding {
+        override fun visitComponentFactory(model: ComponentFactoryWithBuilderModel) = reportMissingBinding {
             addNote(
                 if (!model.createdComponent.isRoot) {
                     Strings.Notes.subcomponentFactoryInjectionHint(

--- a/core/graph/impl/src/main/kotlin/bindings/SubComponentFactoryBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/SubComponentFactoryBindingImpl.kt
@@ -21,7 +21,7 @@ import com.yandex.yatagan.core.graph.bindings.Binding
 import com.yandex.yatagan.core.graph.bindings.SubComponentBinding
 import com.yandex.yatagan.core.graph.impl.NonStaticConditionDependencies
 import com.yandex.yatagan.core.graph.impl.VariantMatch
-import com.yandex.yatagan.core.model.ComponentFactoryModel
+import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel
 import com.yandex.yatagan.core.model.NodeModel
 import com.yandex.yatagan.core.model.isNever
 import com.yandex.yatagan.validation.MayBeInvalid
@@ -29,7 +29,7 @@ import com.yandex.yatagan.validation.format.modelRepresentation
 
 internal class SubComponentFactoryBindingImpl(
     override val owner: BindingGraph,
-    private val factory: ComponentFactoryModel,
+    private val factory: ComponentFactoryWithBuilderModel,
 ) : SubComponentBinding, ConditionalBindingMixin, ComparableByTargetBindingMixin, IntrinsicBindingMarker {
     override val target: NodeModel
         get() = factory.asNode()

--- a/core/graph/impl/src/main/kotlin/utils.kt
+++ b/core/graph/impl/src/main/kotlin/utils.kt
@@ -18,6 +18,7 @@ package com.yandex.yatagan.core.graph.impl
 
 import com.yandex.yatagan.core.graph.Extensible
 import com.yandex.yatagan.core.graph.WithParents
+import com.yandex.yatagan.core.model.ComponentFactoryModel
 
 internal fun <K, V> mergeMultiMapsForDuplicateCheck(
     fromParent: Map<K, List<V>>?,
@@ -51,4 +52,12 @@ internal fun <C, P> hierarchyExtension(
         override val parent: C?
             get() = delegate.parent?.let { it[key] }
     }
+}
+
+internal interface ComponentFactoryVisitor<R> : ComponentFactoryModel.Visitor<R> {
+    fun visitNull(): R
+}
+
+internal fun <R> ComponentFactoryModel?.accept(visitor: ComponentFactoryVisitor<R>): R {
+    return this?.accept(visitor) ?: visitor.visitNull()
 }

--- a/core/model/api/src/main/kotlin/ComponentEntryPoint.kt
+++ b/core/model/api/src/main/kotlin/ComponentEntryPoint.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.model
+
+import com.yandex.yatagan.lang.Method
+import com.yandex.yatagan.validation.MayBeInvalid
+
+/**
+ * Represents a function/property exposed from a component interface.
+ *
+ * @see ComponentModel.entryPoints
+ */
+public interface ComponentEntryPoint : MayBeInvalid {
+    /**
+     * Method in the component interface corresponding to the entry-point.
+     */
+    public val getter: Method
+
+    /**
+     * A parsed [getter]s return value.
+     */
+    public val dependency: NodeDependency
+}

--- a/core/model/api/src/main/kotlin/ComponentFactoryModel.kt
+++ b/core/model/api/src/main/kotlin/ComponentFactoryModel.kt
@@ -23,12 +23,16 @@ import com.yandex.yatagan.lang.Method
 import com.yandex.yatagan.validation.MayBeInvalid
 
 /**
- * Represents [com.yandex.yatagan.Component.Builder].
+ * Models a factory method which creates a component instance.
+ * Accepts [ModuleModel], [ComponentDependencyModel] and bound instances as parameters.
+ *
+ * This interface is fit to model a child component factory method. Its extension - [ComponentFactoryWithBuilderModel] -
+ * models `@Component.Builder` declaration.
  */
-public interface ComponentFactoryModel : HasNodeModel {
+public interface ComponentFactoryModel : MayBeInvalid {
 
     /**
-     * TODO: doc.
+     * A component which the factory produces.
      */
     public val createdComponent: ComponentModel
 
@@ -42,11 +46,6 @@ public interface ComponentFactoryModel : HasNodeModel {
      * `null` if no appropriate method is found.
      */
     public val factoryMethod: Method?
-
-    /**
-     * TODO: doc.
-     */
-    public val builderInputs: Collection<BuilderInputModel>
 
     /**
      * Encodes actual input data model, that [InputModel] introduces to the graph.
@@ -98,19 +97,14 @@ public interface ComponentFactoryModel : HasNodeModel {
     }
 
     /**
-     * Represents an input parameter of the factory method.
+     * Represents an input parameter of the factory.
      */
     public interface FactoryInputModel : InputModel
 
-    /**
-     * Represents a setter method for the input in builder-like fashion.
-     */
-    public interface BuilderInputModel : InputModel {
-        /**
-         * Actual abstract setter.
-         * Has *single parameter*; return type may be of the builder type itself or
-         * [void][com.yandex.yatagan.lang.Type.isVoid].
-         */
-        public val builderSetter: Method
+    public fun <R> accept(visitor: Visitor<R>): R
+
+    public interface Visitor<R> {
+        public fun visitSubComponentFactoryMethod(model: SubComponentFactoryMethodModel): R
+        public fun visitWithBuilder(model: ComponentFactoryWithBuilderModel): R
     }
 }

--- a/core/model/api/src/main/kotlin/ComponentFactoryWithBuilderModel.kt
+++ b/core/model/api/src/main/kotlin/ComponentFactoryWithBuilderModel.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.model
+
+import com.yandex.yatagan.lang.Method
+
+/**
+ * Represents [com.yandex.yatagan.Component.Builder]. Can be injected.
+ */
+public interface ComponentFactoryWithBuilderModel : ComponentFactoryModel, HasNodeModel {
+    /**
+     * Inputs from [setters][BuilderInputModel.builderSetter] in terms of builder pattern.
+     */
+    public val builderInputs: Collection<BuilderInputModel>
+
+    /**
+     * Represents a setter method for the input in builder-like fashion.
+     */
+    public interface BuilderInputModel : ComponentFactoryModel.InputModel {
+        /**
+         * Actual abstract setter.
+         * Has *single parameter*; return type may be of the builder type itself or
+         * [void][com.yandex.yatagan.lang.Type.isVoid].
+         */
+        public val builderSetter: Method
+    }
+}

--- a/core/model/api/src/main/kotlin/ComponentModel.kt
+++ b/core/model/api/src/main/kotlin/ComponentModel.kt
@@ -39,19 +39,24 @@ public interface ComponentModel : ConditionalHoldingModel, HasNodeModel {
     public val dependencies: Set<ComponentDependencyModel>
 
     /**
-     * A set of [EntryPoint]s in the component.
+     * A list of [EntryPoint]s in the component.
      */
-    public val entryPoints: Set<EntryPoint>
+    public val entryPoints: List<EntryPoint>
 
     /**
-     * A set of [MembersInjectorModel]s defined for this component.
+     * A list of [MembersInjectorModel]s defined for this component.
      */
-    public val memberInjectors: Set<MembersInjectorModel>
+    public val memberInjectors: List<MembersInjectorModel>
+
+    /**
+     * A list of [ComponentFactoryModel]s declared in this component for its children components.
+     */
+    public val subComponentFactoryMethods: List<SubComponentFactoryMethodModel>
 
     /**
      * An optional explicit factory for this component creation.
      */
-    public val factory: ComponentFactoryModel?
+    public val factory: ComponentFactoryWithBuilderModel?
 
     /**
      * Whether this component is marked as a component hierarchy root.

--- a/core/model/api/src/main/kotlin/ComponentModel.kt
+++ b/core/model/api/src/main/kotlin/ComponentModel.kt
@@ -16,9 +16,6 @@
 
 package com.yandex.yatagan.core.model
 
-import com.yandex.yatagan.lang.Method
-import com.yandex.yatagan.validation.MayBeInvalid
-
 /**
  * Represents @[com.yandex.yatagan.Component] annotated class - Component.
  */
@@ -39,9 +36,9 @@ public interface ComponentModel : ConditionalHoldingModel, HasNodeModel {
     public val dependencies: Set<ComponentDependencyModel>
 
     /**
-     * A list of [EntryPoint]s in the component.
+     * A list of [ComponentEntryPoint]s in the component.
      */
-    public val entryPoints: List<EntryPoint>
+    public val entryPoints: List<ComponentEntryPoint>
 
     /**
      * A list of [MembersInjectorModel]s defined for this component.
@@ -74,13 +71,4 @@ public interface ComponentModel : ConditionalHoldingModel, HasNodeModel {
      * `false` otherwise.
      */
     public val requiresSynchronizedAccess: Boolean
-
-    /**
-     * Represents a function/property exposed from a component interface.
-     * All graph building starts from a set of [EntryPoint]s recursively resolving dependencies.
-     */
-    public interface EntryPoint : MayBeInvalid {
-        public val getter: Method
-        public val dependency: NodeDependency
-    }
 }

--- a/core/model/api/src/main/kotlin/HasNodeModel.kt
+++ b/core/model/api/src/main/kotlin/HasNodeModel.kt
@@ -36,7 +36,7 @@ public interface HasNodeModel : ClassBackedModel {
     public interface Visitor<R> {
         public fun visitDefault(): R
         public fun visitComponent(model: ComponentModel): R = visitDefault()
-        public fun visitComponentFactory(model: ComponentFactoryModel): R = visitDefault()
+        public fun visitComponentFactory(model: ComponentFactoryWithBuilderModel): R = visitDefault()
         public fun visitAssistedInjectFactory(model: AssistedInjectFactoryModel): R = visitDefault()
         public fun visitInjectConstructor(model: InjectConstructorModel): R = visitDefault()
     }

--- a/core/model/api/src/main/kotlin/SubComponentFactoryMethodModel.kt
+++ b/core/model/api/src/main/kotlin/SubComponentFactoryMethodModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Yandex LLC
+ * Copyright 2023 Yandex LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package com.yandex.yatagan.core.model.impl
+package com.yandex.yatagan.core.model
 
-import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel
-import com.yandex.yatagan.core.model.ComponentModel
-import com.yandex.yatagan.lang.TypeDeclaration
+import com.yandex.yatagan.lang.Method
 
-fun ComponentModel(declaration: TypeDeclaration): ComponentModel {
-    return ComponentModelImpl(declaration)
-}
+/**
+ * Models a factory method exposed from a parent component to create a child.
+ */
+public interface SubComponentFactoryMethodModel : ComponentFactoryModel {
 
-fun ComponentFactoryWithBuilderModel(declaration: TypeDeclaration): ComponentFactoryWithBuilderModel {
-    return ComponentFactoryWithBuilderModelImpl(declaration)
+    /**
+     * The component creating method to implement.
+     */
+    override val factoryMethod: Method
 }

--- a/core/model/api/src/main/kotlin/modelExtensions.kt
+++ b/core/model/api/src/main/kotlin/modelExtensions.kt
@@ -27,6 +27,12 @@ import com.yandex.yatagan.core.model.DependencyKind.OptionalProvider
 import com.yandex.yatagan.core.model.DependencyKind.Provider
 
 public val ComponentFactoryModel.allInputs: Sequence<InputModel>
+    get() = this.accept(object : ComponentFactoryModel.Visitor<Sequence<InputModel>> {
+        override fun visitSubComponentFactoryMethod(model: SubComponentFactoryMethodModel) = model.factoryInputs.asSequence()
+        override fun visitWithBuilder(model: ComponentFactoryWithBuilderModel) = model.allInputs
+    })
+
+public val ComponentFactoryWithBuilderModel.allInputs: Sequence<InputModel>
     get() = factoryInputs.asSequence() + builderInputs.asSequence()
 
 public val DependencyKind.isOptional: Boolean

--- a/core/model/impl/src/main/kotlin/ComponentEntryPointImpl.kt
+++ b/core/model/impl/src/main/kotlin/ComponentEntryPointImpl.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.model.impl
+
+import com.yandex.yatagan.core.model.ComponentModel
+import com.yandex.yatagan.core.model.NodeDependency
+import com.yandex.yatagan.lang.Method
+import com.yandex.yatagan.validation.MayBeInvalid
+import com.yandex.yatagan.validation.Validator
+import com.yandex.yatagan.validation.format.appendChildContextReference
+import com.yandex.yatagan.validation.format.modelRepresentation
+
+internal class ComponentEntryPointImpl(
+    override val getter: Method,
+    override val dependency: NodeDependency,
+) : ComponentModel.EntryPoint {
+    override fun validate(validator: Validator) {
+        validator.child(dependency.node)
+    }
+
+    override fun toString(childContext: MayBeInvalid?) = modelRepresentation(
+        modelClassName = "entry-point",
+        representation = {
+            append("${getter.name}()")
+            if (childContext == dependency.node) {
+                append(": ")
+                appendChildContextReference(reference = getter.returnType)
+            }
+        },
+    )
+
+    companion object {
+        fun canRepresent(method: Method): Boolean {
+            return method.isAbstract && method.parameters.none()
+        }
+    }
+}

--- a/core/model/impl/src/main/kotlin/ComponentEntryPointImpl.kt
+++ b/core/model/impl/src/main/kotlin/ComponentEntryPointImpl.kt
@@ -16,7 +16,7 @@
 
 package com.yandex.yatagan.core.model.impl
 
-import com.yandex.yatagan.core.model.ComponentModel
+import com.yandex.yatagan.core.model.ComponentEntryPoint
 import com.yandex.yatagan.core.model.NodeDependency
 import com.yandex.yatagan.lang.Method
 import com.yandex.yatagan.validation.MayBeInvalid
@@ -27,7 +27,7 @@ import com.yandex.yatagan.validation.format.modelRepresentation
 internal class ComponentEntryPointImpl(
     override val getter: Method,
     override val dependency: NodeDependency,
-) : ComponentModel.EntryPoint {
+) : ComponentEntryPoint {
     override fun validate(validator: Validator) {
         validator.child(dependency.node)
     }

--- a/core/model/impl/src/main/kotlin/ComponentFactoryWithBuilderModelImpl.kt
+++ b/core/model/impl/src/main/kotlin/ComponentFactoryWithBuilderModelImpl.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.model.impl
+
+import com.yandex.yatagan.base.ObjectCache
+import com.yandex.yatagan.core.model.ComponentFactoryModel
+import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel
+import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel.BuilderInputModel
+import com.yandex.yatagan.core.model.ComponentModel
+import com.yandex.yatagan.core.model.HasNodeModel
+import com.yandex.yatagan.core.model.NodeModel
+import com.yandex.yatagan.lang.BuiltinAnnotation
+import com.yandex.yatagan.lang.LangModelFactory
+import com.yandex.yatagan.lang.Type
+import com.yandex.yatagan.lang.TypeDeclaration
+import com.yandex.yatagan.lang.TypeDeclarationKind
+import com.yandex.yatagan.validation.MayBeInvalid
+import com.yandex.yatagan.validation.Validator
+import com.yandex.yatagan.validation.format.Strings
+import com.yandex.yatagan.validation.format.append
+import com.yandex.yatagan.validation.format.appendChildContextReference
+import com.yandex.yatagan.validation.format.modelRepresentation
+import com.yandex.yatagan.validation.format.reportError
+import com.yandex.yatagan.validation.format.reportWarning
+
+internal class ComponentFactoryWithBuilderModelImpl private constructor(
+    private val factoryDeclaration: TypeDeclaration,
+) : ComponentFactoryModelBase(), ComponentFactoryWithBuilderModel {
+    override val createdComponent: ComponentModel by lazy {
+        val declaration = factoryDeclaration.enclosingType
+            ?: LangModelFactory.createNoType("missing-component-type").declaration
+        ComponentModelImpl(declaration)
+    }
+
+    override val factoryMethod = factoryDeclaration.methods.find {
+        it.isAbstract && it.returnType == createdComponent.type
+    }
+
+    override val type: Type
+        get() = factoryDeclaration.asType()
+
+    override fun asNode(): NodeModel = NodeModelImpl(
+        type = factoryDeclaration.asType(),
+        forQualifier = null,
+    )
+
+    override fun <R> accept(visitor: HasNodeModel.Visitor<R>): R {
+        return visitor.visitComponentFactory(this)
+    }
+
+    override val builderInputs: Collection<BuilderInputModel> = factoryDeclaration.methods.filter {
+        it.isAbstract && it != factoryMethod && it.parameters.count() == 1
+    }.map { method ->
+        object : BuilderInputModel {
+            override val payload: ComponentFactoryModel.InputPayload by lazy(LazyThreadSafetyMode.PUBLICATION) {
+                InputPayload(
+                    param = method.parameters.first(),
+                    hasBindsInstance = { method.getAnnotation(BuiltinAnnotation.BindsInstance) != null },
+                )
+            }
+            override val name get() = method.name
+            override val builderSetter get() = method
+
+            override fun validate(validator: Validator) {
+                validator.child(payload)
+                if (method.parameters.first().getAnnotation(BuiltinAnnotation.BindsInstance) != null) {
+                    validator.reportWarning(Strings.Warnings.ignoredBindsInstance())
+                }
+                if (!method.returnType.isVoid && !method.returnType.isAssignableFrom(factoryDeclaration.asType())) {
+                    validator.reportError(Strings.Errors.invalidBuilderSetterReturn(
+                        creatorType = factoryDeclaration.asType(),
+                    ))
+                }
+            }
+
+            override fun toString(childContext: MayBeInvalid?) = modelRepresentation(
+                modelClassName = "creator-setter",
+                representation = {
+                    append("$name(")
+                    if (childContext != null) {
+                        appendChildContextReference(reference = method.parameters.first())
+                    } else {
+                        append(method.parameters.first())
+                    }
+                    append("): ")
+                    append(method.returnType)
+                }
+            )
+        }
+    }.toList()
+
+
+    override fun toString(childContext: MayBeInvalid?) = modelRepresentation(
+        modelClassName = "component-creator",
+        representation = factoryDeclaration,
+    )
+
+    override fun validate(validator: Validator) {
+        super.validate(validator)
+
+        validator.inline(asNode())
+
+        if (factoryDeclaration.kind != TypeDeclarationKind.Interface) {
+            validator.reportError(Strings.Errors.nonInterfaceCreator())
+        }
+
+        for (method in factoryDeclaration.methods) {
+            if (method == factoryMethod || method.parameters.count() == 1 || !method.isAbstract)
+                continue
+            validator.reportError(Strings.Errors.unknownMethodInCreator(method = method))
+        }
+    }
+
+    override fun <R> accept(visitor: ComponentFactoryModel.Visitor<R>): R {
+        return visitor.visitWithBuilder(this);
+    }
+
+    companion object Factory : ObjectCache<TypeDeclaration, ComponentFactoryWithBuilderModelImpl>() {
+        operator fun invoke(
+            factoryDeclaration: TypeDeclaration,
+        ) = createCached(factoryDeclaration) {
+            ComponentFactoryWithBuilderModelImpl(
+                factoryDeclaration = it,
+            )
+        }
+
+        fun canRepresent(declaration: TypeDeclaration): Boolean {
+            return declaration.getAnnotation(BuiltinAnnotation.Component.Builder) != null
+        }
+    }
+}

--- a/core/model/impl/src/main/kotlin/ComponentModelImpl.kt
+++ b/core/model/impl/src/main/kotlin/ComponentModelImpl.kt
@@ -18,9 +18,9 @@ package com.yandex.yatagan.core.model.impl
 
 import com.yandex.yatagan.base.ObjectCache
 import com.yandex.yatagan.core.model.ComponentDependencyModel
+import com.yandex.yatagan.core.model.ComponentEntryPoint
 import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel
 import com.yandex.yatagan.core.model.ComponentModel
-import com.yandex.yatagan.core.model.ComponentModel.EntryPoint
 import com.yandex.yatagan.core.model.ConditionalHoldingModel
 import com.yandex.yatagan.core.model.HasNodeModel
 import com.yandex.yatagan.core.model.MembersInjectorModel
@@ -176,7 +176,7 @@ internal class ComponentModelImpl private constructor(
     )
 
     private inner class MethodParser {
-        val entryPoints = arrayListOf<EntryPoint>()
+        val entryPoints = arrayListOf<ComponentEntryPoint>()
         val memberInjectors = arrayListOf<MembersInjectorModel>()
         val childComponentFactories = arrayListOf<SubComponentFactoryMethodModel>()
         val unknown = arrayListOf<Method>()

--- a/core/model/impl/src/main/kotlin/NodeModelImpl.kt
+++ b/core/model/impl/src/main/kotlin/NodeModelImpl.kt
@@ -168,7 +168,7 @@ internal class NodeModelImpl private constructor(
         return when {
             inject != null -> InjectConstructorImpl(inject)
             AssistedInjectFactoryModelImpl.canRepresent(declaration) -> AssistedInjectFactoryModelImpl(declaration)
-            ComponentFactoryModelImpl.canRepresent(declaration) -> ComponentFactoryModelImpl(declaration)
+            ComponentFactoryWithBuilderModelImpl.canRepresent(declaration) -> ComponentFactoryWithBuilderModelImpl(declaration)
             ComponentModelImpl.canRepresent(declaration) -> ComponentModelImpl(declaration)
             else -> null
         }

--- a/core/model/impl/src/main/kotlin/SubComponentFactoryMethodImpl.kt
+++ b/core/model/impl/src/main/kotlin/SubComponentFactoryMethodImpl.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.core.model.impl
+
+import com.yandex.yatagan.core.model.ComponentFactoryModel
+import com.yandex.yatagan.core.model.SubComponentFactoryMethodModel
+import com.yandex.yatagan.lang.Method
+import com.yandex.yatagan.validation.MayBeInvalid
+import com.yandex.yatagan.validation.format.modelRepresentation
+
+internal class SubComponentFactoryMethodImpl(
+    override val factoryMethod: Method,
+) : ComponentFactoryModelBase(), SubComponentFactoryMethodModel {
+    override val createdComponent = ComponentModelImpl(factoryMethod.returnType.declaration)
+
+    override fun toString(childContext: MayBeInvalid?) = modelRepresentation(
+        modelClassName = "component-factory-method",
+        representation = factoryMethod,
+    )
+
+    override fun <R> accept(visitor: ComponentFactoryModel.Visitor<R>): R {
+        return visitor.visitSubComponentFactoryMethod(this)
+    }
+
+    companion object {
+        fun canRepresent(method: Method): Boolean {
+            if (!method.isAbstract) return false
+
+            // If no parameters, then it's rather an entry-point than factory.
+            if (method.parameters.none()) return false
+
+            val returnType = method.returnType.declaration
+            if (!ComponentModelImpl.canRepresent(returnType))
+                return false
+
+            return !ComponentModelImpl(returnType).isRoot
+        }
+    }
+}

--- a/rt/engine/src/main/kotlin/RuntimeEngine.kt
+++ b/rt/engine/src/main/kotlin/RuntimeEngine.kt
@@ -21,7 +21,7 @@ import com.yandex.yatagan.base.ObjectCacheRegistry
 import com.yandex.yatagan.base.loadServices
 import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.impl.BindingGraph
-import com.yandex.yatagan.core.model.impl.ComponentFactoryModel
+import com.yandex.yatagan.core.model.impl.ComponentFactoryWithBuilderModel
 import com.yandex.yatagan.core.model.impl.ComponentModel
 import com.yandex.yatagan.lang.InternalLangApi
 import com.yandex.yatagan.lang.LangModelFactory
@@ -71,7 +71,7 @@ class RuntimeEngine<P : RuntimeEngine.Params>(
             }
 
             val graph = BindingGraph(
-                root = ComponentFactoryModel(TypeDeclaration(builderClass)).createdComponent
+                root = ComponentFactoryWithBuilderModel(TypeDeclaration(builderClass)).createdComponent
             )
             val promise = doValidate(graph)
             val factory = promise.awaitOnError {

--- a/rt/engine/src/main/kotlin/RuntimeFactory.kt
+++ b/rt/engine/src/main/kotlin/RuntimeFactory.kt
@@ -34,7 +34,7 @@ internal class RuntimeFactory(
     validationPromise: DynamicValidationDelegate.Promise?,
     private val logger: Logger?,
 ) : InvocationHandlerBase(validationPromise), InvocationHandlerBase.MethodHandler {
-    private val creator = checkNotNull(graph.creator) {
+    private val creator = checkNotNull(graph.model.factory) {
         "Component $graph has no explicit creator (builder/factory)"
     }
 

--- a/testing/tests/src/test/kotlin/CoreBindingsKotlinTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsKotlinTest.kt
@@ -69,6 +69,8 @@ class CoreBindingsKotlinTest(
                 fun getExplicit(): test.ExplicitImpl
                 fun getProviderExplicit(): Provider<test.ExplicitImpl>
                 fun getLazyExplicit(): Lazy<test.ExplicitImpl>
+                
+                fun someNonAbstractMethod() { /*method body*/ }
             }
         """.trimIndent()
         )

--- a/testing/tests/src/test/kotlin/CoreBindingsTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsTest.kt
@@ -99,6 +99,8 @@ class CoreBindingsTest(
                 Lazy<MySimpleClass> getMySimpleClassLazy();
                 Provider<MyScopedClass> getMyScopedClassProvider();
                 Lazy<MyScopedClass> getMyScopedClassLazy();
+                
+                default void someNonAbstractMethod() { }
             }
         """.trimIndent()
         )

--- a/testing/tests/src/test/resources/golden/ComponentCreatorFailureTest/invalid-sub-component-factory-methods.golden.txt
+++ b/testing/tests/src/test/resources/golden/ComponentCreatorFailureTest/invalid-sub-component-factory-methods.golden.txt
@@ -1,0 +1,80 @@
+error: Child components can't have a factory methods declared for them in their parents, if they have an explicit @Component.Builder declared.
+NOTE: Factory method declared here: component-factory-method test.RootComponent1::sub1FactoryMethod(dep: test.MyDependencies): test.SubComponent1
+Encountered:
+  in graph for root-component test.RootComponent1
+  here: graph for component test.SubComponent1
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: Component hierarchy loop detected
+Encountered:
+  in graph for root-component test.RootComponent1
+  in graph for component test.SubComponent3
+  here: component-factory-method test.SubComponent3::createSubComponent3(i: int): test.SubComponent3
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: Declared `component-dependency test.MyDependencies` is not passed to component creator
+Encountered:
+  in graph for root-component test.RootComponent1
+  here: component-factory-method test.RootComponent1::sub2FactoryMethod1(foo: java.lang.Object): test.SubComponent2
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: Missing binding for test.RootComponent2
+NOTE: A dependency seems to be a component, though it does not belong to the current hierarchy.
+Encountered:
+  in graph for root-component test.RootComponent1
+  in entry-point unknown: test.RootComponent2
+                          ^-[*1]-------------
+  here: [1*] <missing>
+             ^~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: Missing binding for test.SubComponent1
+NOTE: A dependency seems to be a child component, try injecting its factory instead.
+Encountered:
+  in graph for root-component test.RootComponent1
+  in entry-point sub1EP: test.SubComponent1
+                         ^-[*1]------------
+  here: [1*] <missing>
+             ^~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: Multiple factory methods detected for a `component test.SubComponent2`
+NOTE: Duplicate declared as `component-factory-method test.RootComponent1::sub2FactoryMethod1(foo: java.lang.Object): test.SubComponent2`
+NOTE: Duplicate declared as `component-factory-method test.RootComponent1::sub2FactoryMethod2(dep: test.MyDependencies): test.SubComponent2`
+Encountered:
+  here: graph for root-component test.RootComponent1
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: Unrecognized type (component dependency?) is present
+NOTE: To bind the instance itself, use @BindInstance marker
+NOTE: To use the instance as component dependency, explicitly declare it in @Component(.., dependencies = [<here>], ..)
+Encountered:
+  in graph for root-component test.RootComponent1
+  in component-factory-method test.RootComponent1::sub2FactoryMethod1(foo: java.lang.Object): test.SubComponent2
+  in creator-method-parameter sub2FactoryMethod1(.., foo: java.lang.Object, ..)
+                                                     ^-[*1]---------------
+  here: [1*] input component-dependency java.lang.Object
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: `graph for component test.SubUnderFeature` with a condition:
+    (1) [test.ConditionProvider.isEnabled]
+cannot be created via component factory method `component-factory-method test.RootComponent1::subUnderFeature(dep: test.MyDependencies): test.SubUnderFeature` of component under condition:`
+    (2) [always-present]
+because component condition (2) does not imply condition (1)
+Encountered:
+  in graph for root-component test.RootComponent1
+  here: component-factory-method test.RootComponent1::subUnderFeature(dep: test.MyDependencies): test.SubUnderFeature
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: `component test.SubComponent1` has an explicitly declared `component-creator test.SubComponent1.Factory` so it can't be created directly.
+Changing the entry-point type to the `test.SubComponent1.Factory` would fix the problem and allow the component to be recognized as a child (if not included explicitly).
+Encountered:
+  in graph for root-component test.RootComponent1
+  here: entry-point sub1EP: test.SubComponent1
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/validation/format/src/main/kotlin/Strings.kt
+++ b/validation/format/src/main/kotlin/Strings.kt
@@ -17,12 +17,14 @@
 package com.yandex.yatagan.validation.format
 
 import com.yandex.yatagan.core.graph.BindingGraph
+import com.yandex.yatagan.core.graph.GraphSubComponentFactoryMethod
 import com.yandex.yatagan.core.graph.bindings.AliasBinding
 import com.yandex.yatagan.core.graph.bindings.BaseBinding
 import com.yandex.yatagan.core.graph.bindings.Binding
 import com.yandex.yatagan.core.model.AssistedInjectFactoryModel
 import com.yandex.yatagan.core.model.ComponentDependencyModel
 import com.yandex.yatagan.core.model.ComponentFactoryModel
+import com.yandex.yatagan.core.model.ComponentFactoryWithBuilderModel
 import com.yandex.yatagan.core.model.ComponentModel
 import com.yandex.yatagan.core.model.ConditionScope
 import com.yandex.yatagan.core.model.ConditionalHoldingModel
@@ -133,6 +135,20 @@ object Strings {
                 .appendLine("` under condition:")
             append(Indent).append("(2) ").append(bCondition).appendLine()
             append("without Optional<..> wrapper, because component condition (2) does not imply condition (1)")
+        }.toError()
+
+        @Covered
+        fun incompatibleConditionChildComponentFactory(
+            aCondition: ConditionScope, bCondition: ConditionScope,
+            factory: GraphSubComponentFactoryMethod,
+        ) = buildRichString {
+            color = TextColor.Inherit
+            append("`").append(factory.createdGraph).appendLine("` with a condition:")
+            append(Indent).append("(1) ").append(aCondition).appendLine()
+            append("cannot be created via component factory method `").append(factory)
+                .appendLine("` of component under condition:`")
+            append(Indent).append("(2) ").append(bCondition).appendLine()
+            append("because component condition (2) does not imply condition (1)")
         }.toError()
 
         @Covered
@@ -439,6 +455,18 @@ object Strings {
                 "@Reusable scope is used along with other scopes which doesn't make much sense. " +
                         "Other scopes can be safely removed without changing the behavior."
                 ).toError()
+
+        @Covered
+        fun conflictingExplicitCreatorAndFactoryMethod() = (
+                "Child components can't have a factory methods declared for them in their parents, " +
+                        "if they have an explicit @Component.Builder declared."
+                ).toError()
+
+        @Covered
+        fun multipleChildComponentFactoryMethodsForComponent(component: ComponentModel) = buildRichString {
+            color = TextColor.Inherit
+            append("Multiple factory methods detected for a `").append(component).append('`')
+        }.toError()
     }
 
     object Warnings {
@@ -481,7 +509,7 @@ object Strings {
         @Covered
         fun subcomponentViaEntryPointWithCreator(
             subcomponent: ComponentModel,
-            creator: ComponentFactoryModel,
+            creator: ComponentFactoryWithBuilderModel,
         ) = buildRichString {
             color = TextColor.Inherit
             append("`").append(subcomponent).append("` has an explicitly declared `")
@@ -543,7 +571,7 @@ object Strings {
         fun missingBecauseUnresolved() = ("The type is unresolved, no binding could be matched for such type.").toNote()
 
         fun subcomponentFactoryInjectionHint(
-            factory: ComponentFactoryModel,
+            factory: ComponentFactoryWithBuilderModel,
             component: ComponentModel,
             owner: BindingGraph,
         ) = buildRichString {
@@ -645,5 +673,15 @@ object Strings {
                 "Unsubstituted type variables are not allowed here. " +
                         "Please, remove the unsupported generic from the containing class."
                 ).toNote()
+
+        @Covered
+        fun factoryMethodDeclaredHere(factory: ComponentFactoryModel) = buildRichString {
+            append("Factory method declared here: ").append(factory)
+        }.toNote()
+
+        @Covered
+        fun duplicateChildComponentFactory(factory: ComponentFactoryModel) = buildRichString {
+            append("Duplicate declared as `").append(factory).append('`')
+        }.toNote()
     }
 }


### PR DESCRIPTION
This CL actually supports more, than vanilla Dagger does. Such methods support everything that `@Component.Builder` supports via factory. This means that `@BindsInstance` and component dependencies are also supported.

Linked to #23 