### PR TITLE
Fix: Properly resolve aliases while computing caching omission.

### DIFF
--- a/codegen/impl/src/main/kotlin/AccessStrategyManager.kt
+++ b/codegen/impl/src/main/kotlin/AccessStrategyManager.kt
@@ -21,7 +21,6 @@ import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.Extensible
 import com.yandex.yatagan.core.graph.bindings.Binding
 import com.yandex.yatagan.core.model.DependencyKind
-import com.yandex.yatagan.core.model.NodeModel
 import com.yandex.yatagan.core.model.ScopeModel
 import com.yandex.yatagan.core.model.component1
 import com.yandex.yatagan.core.model.component2
@@ -43,15 +42,14 @@ internal class AccessStrategyManager(
      */
     private val singleLocalDependentBindingCache: Map<Binding, Binding?> =
         buildMap(thisGraph.localBindings.size) {
-            val allLocalNodes: Map<NodeModel, Binding> = thisGraph.localBindings.keys.associateBy(Binding::target)
             for (binding in thisGraph.localBindings.keys) {
-
                 val dependencies = if (binding.nonStaticConditionProviders.isNotEmpty()) {
                     binding.dependencies + binding.nonStaticConditionProviders
                 } else binding.dependencies
 
                 for ((node, _) in dependencies) {
-                    val dependencyBinding = allLocalNodes[node] ?: continue
+                    val dependencyBinding = thisGraph.resolveBinding(node)
+                        .takeIf { it.owner == thisGraph } ?: continue
                     if (dependencyBinding in this) {
                         // Not the first dependent binding, explicitly put `null` there,
                         //  as it is no longer single

--- a/core/graph/impl/src/main/kotlin/BindingGraphImpl.kt
+++ b/core/graph/impl/src/main/kotlin/BindingGraphImpl.kt
@@ -112,12 +112,13 @@ internal class BindingGraphImpl(
     override val usedParents = mutableSetOf<BindingGraph>()
     override val children: Collection<BindingGraphImpl>
 
+    private val aliasResolveVisitor = object : BaseBinding.Visitor<Binding> {
+        override fun visitAlias(alias: AliasBinding) = resolveBindingRaw(alias.source).accept(this)
+        override fun visitBinding(binding: Binding) = binding
+    }
+
     override fun resolveBinding(node: NodeModel): Binding {
-        class AliasResolveVisitor : BaseBinding.Visitor<Binding> {
-            override fun visitAlias(alias: AliasBinding) = resolveBindingRaw(alias.source).accept(this)
-            override fun visitBinding(binding: Binding) = binding
-        }
-        return resolveBindingRaw(node).accept(AliasResolveVisitor())
+        return resolveBindingRaw(node).accept(aliasResolveVisitor)
     }
 
     override fun resolveBindingRaw(node: NodeModel): BaseBinding {


### PR DESCRIPTION
Before this fix the optimization algorithm couldn't look through
 alias chains thus missing potential cases to optimize.

Closes #35