### PR TITLE
Enhance: Allow IntoMap.Key annotations to have non-"value" attributes.

### DIFF
--- a/core/model/impl/src/main/kotlin/bindingModelsImpl.kt
+++ b/core/model/impl/src/main/kotlin/bindingModelsImpl.kt
@@ -67,7 +67,7 @@ internal abstract class ModuleHostedBindingBase : ModuleHostedBindingModel {
                 method.getAnnotation(BuiltinAnnotation.IntoMap) != null -> {
                     val key = method.annotations.find { it.isMapKey() }
                     val annotationClass = key?.annotationClass
-                    val valueAttribute = annotationClass?.attributes?.find { it.name == "value" }
+                    val valueAttribute = annotationClass?.attributes?.singleOrNull()
                     val keyValue = valueAttribute?.let { key.getValue(valueAttribute) }
                     BindingTargetModel.MappingContribution(
                         node = target,
@@ -105,7 +105,7 @@ internal abstract class ModuleHostedBindingBase : ModuleHostedBindingModel {
                 }
                 val key = keys.first()
                 val clazz = key.annotationClass
-                val valueAttribute = clazz.attributes.find { it.name == "value" }
+                val valueAttribute = clazz.attributes.singleOrNull()
                 if (valueAttribute == null) {
                     validator.reportError(Errors.missingMapKeyValue(annotationClass = clazz))
                     return@run

--- a/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
@@ -725,7 +725,7 @@ class CoreBindingsFailureTest(
             import javax.inject.*
             import kotlin.reflect.KClass
 
-            @IntoMap.Key annotation class InvalidMapKey1(val foo: Int)
+            @IntoMap.Key annotation class InvalidMapKey1
             @IntoMap.Key annotation class InvalidMapKey2(val value: InvalidMapKey1)
             @IntoMap.Key annotation class InvalidMapKey3(val value: IntArray)
             @IntoMap.Key annotation class ClassKey2(val value: KClass<*>)
@@ -735,10 +735,10 @@ class CoreBindingsFailureTest(
                 @[Binds IntoMap]
                 fun binding1(): Int
                 
-                @[Binds IntoMap InvalidMapKey1(foo = 1)]
+                @[Binds IntoMap InvalidMapKey1]
                 fun binding2(): Int
                 
-                @[Binds IntoMap InvalidMapKey2(InvalidMapKey1(foo = 1))]
+                @[Binds IntoMap InvalidMapKey2(InvalidMapKey1())]
                 fun binding3(): Int
                 
                 @[Binds IntoMap InvalidMapKey3([1, 2, 3])]

--- a/testing/tests/src/test/kotlin/MultibindingsTest.kt
+++ b/testing/tests/src/test/kotlin/MultibindingsTest.kt
@@ -406,7 +406,7 @@ class MultibindingsTest(
             import com.yandex.yatagan.*
             @IntoMap.Key
             @Retention(AnnotationRetention.RUNTIME)
-            annotation class CustomEnumKey(val value: MyEnum = MyEnum.ONE)
+            annotation class CustomEnumKey(val en: MyEnum = MyEnum.ONE)
         """.trimIndent())
         givenJavaSource("test.CustomEnumKeyJava", """
             import com.yandex.yatagan.IntoMap;
@@ -460,7 +460,7 @@ class MultibindingsTest(
                 fun one(): MyApi = Impl1()
                 @[Provides IntoMap CustomEnumKeyJava(MyEnum.TWO)]
                 fun two(): MyApi = Impl2()
-                @[Provides IntoMap CustomEnumKey(MyEnum.THREE)]
+                @[Provides IntoMap CustomEnumKey(en = MyEnum.THREE)]
                 fun three(): MyApi = Impl3()
             }
             

--- a/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/invalid-map-binding.golden.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/invalid-map-binding.golden.txt
@@ -6,7 +6,7 @@ Encountered:
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: Map key `test.InvalidMapKey1` is missing a `value` attribute to be used as a key value
+error: Map key `test.InvalidMapKey1` is missing a single attribute to be used as a key value
 Encountered:
   in graph for root-component test.TestComponent
   in module test.TestModule

--- a/validation/format/src/main/kotlin/Strings.kt
+++ b/validation/format/src/main/kotlin/Strings.kt
@@ -419,7 +419,7 @@ object Strings {
 
         @Covered
         fun missingMapKeyValue(annotationClass: AnnotationDeclaration) =
-            "Map key `$annotationClass` is missing a `value` attribute to be used as a key value".toError()
+            "Map key `$annotationClass` is missing a single attribute to be used as a key value".toError()
 
         @Covered
         fun unsupportedAnnotationValueAsMapKey(annotationClass: AnnotationDeclaration) =


### PR DESCRIPTION
Fixes #41 