### PR TITLE
Fix: Replace `create` with `autoBuilder` in minifier config.

### DIFF
--- a/api/compiled/src/main/resources/META-INF/proguard/yatagan.pro
+++ b/api/compiled/src/main/resources/META-INF/proguard/yatagan.pro
@@ -1,7 +1,7 @@
 # Keep generated components, as they are accessed with a reflection call.
 -keep class **.Yatagan$* {
     # Keep creating methods - called via reflection.
-    public * create();
+    public * autoBuilder();
     public * builder();
 }
 


### PR DESCRIPTION
Fixes #46

Tests for minified builds (Android) are currently planned in #20 