### PR TITLE
Fix: Introduce reportDuplicateAliasesAsErrors option.

### DIFF
--- a/api/dynamic/src/main/kotlin/Yatagan.kt
+++ b/api/dynamic/src/main/kotlin/Yatagan.kt
@@ -72,6 +72,21 @@ public object Yatagan {
         }
 
         /**
+         * Whether to report duplicate `@Binds` as errors instead of warnings.
+         *
+         * `false` by default.
+         *
+         * @see <a href="https://github.com/yandex/yatagan/issues/48">issue #48</a>
+         */
+        @Deprecated(
+            "Will be unconditionally enabled, and the switch will be removed in the next major release",
+            level = DeprecationLevel.WARNING,
+        )
+        public fun reportDuplicateAliasesAsErrors(enabled: Boolean): Initializer = apply {
+            params.reportDuplicateAliasesAsErrors = enabled
+        }
+
+        /**
          * If `true`, then Yatagan will try to locate and load compiled implementation in the classpath first.
          * Then, if no required classes found, Yatagan will proceed to utilizing reflection backend.
          * If `false` then Yatagan will just use the reflection backend.
@@ -200,6 +215,7 @@ public object Yatagan {
         override var maxIssueEncounterPaths: Int = 5,
         override var isStrictMode: Boolean = true,
         override var logger: Logger? = null,
+        override var reportDuplicateAliasesAsErrors: Boolean = false,
         var useCompiledImplementationIfAvailable: Boolean = false,
     ) : RuntimeEngine.Params
 }

--- a/core/graph/impl/src/main/kotlin/BindingGraphImpl.kt
+++ b/core/graph/impl/src/main/kotlin/BindingGraphImpl.kt
@@ -50,6 +50,7 @@ import com.yandex.yatagan.validation.format.reportError
 
 internal class BindingGraphImpl(
     private val component: ComponentModel,
+    internal val options: Options,
     override val parent: BindingGraphImpl? = null,
     override val conditionScope: ConditionScope = ConditionScope.Unscoped,
     private val factoryMethodInParent: ComponentFactoryModel? = null,
@@ -119,6 +120,7 @@ internal class BindingGraphImpl(
         },
     )
 
+    internal val localNodes = mutableSetOf<NodeModel>()
     override val localBindings = mutableMapOf<Binding, BindingUsageImpl>()
     override val localConditionLiterals = mutableMapOf<ConditionModel, LiteralUsage>()
     override val localAssistedInjectFactories = mutableSetOf<AssistedInjectFactoryModel>()
@@ -152,6 +154,7 @@ internal class BindingGraphImpl(
             .map { (childComponent, childConditionScope) ->
                 BindingGraphImpl(
                     component = childComponent,
+                    options = options,
                     parent = this,
                     conditionScope = conditionScope and childConditionScope,
                     factoryMethodInParent = component.subComponentFactoryMethods.find {
@@ -186,6 +189,7 @@ internal class BindingGraphImpl(
                 }
                 override fun visitBinding(binding: Binding) = binding
             }
+            localNodes.add(dependency.node)
             // MAYBE: employ local alias resolution cache
             val nonAlias = binding.accept(AliasMaterializeVisitor())
             if (nonAlias.owner == this) {

--- a/core/graph/impl/src/main/kotlin/Options.kt
+++ b/core/graph/impl/src/main/kotlin/Options.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Yandex LLC
+ * Copyright 2023 Yandex LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,12 @@
 
 package com.yandex.yatagan.core.graph.impl
 
-import com.yandex.yatagan.core.graph.BindingGraph
-import com.yandex.yatagan.core.model.ComponentModel
-
 /**
- * Creates [BindingGraph] instance given the root component.
+ * Options, customizing graph building behavior in various ways.
  */
-fun BindingGraph(
-    root: ComponentModel,
-    options: Options,
-): BindingGraph {
-    require(root.isRoot) { "Not reached: can't use non-root component as a root of a binding graph" }
-    return BindingGraphImpl(
-        component = root,
-        options = options,
-    )
-}
+data class Options(
+    /**
+     * Whether to report duplicate aliases as errors instead of warnings.
+     */
+    val reportDuplicateAliasesAsErrors: Boolean,
+)

--- a/processor/common/src/main/kotlin/Options.kt
+++ b/processor/common/src/main/kotlin/Options.kt
@@ -51,6 +51,7 @@ enum class BooleanOption(
 
     StrictMode("yatagan.enableStrictMode", default = true),
     UsePlainOutput("yatagan.usePlainOutput", default = false),
+    ReportDuplicateAliasesAsErrors("yatagan.experimental.reportDuplicateAliasesAsErrors", default = false),
 
     ;
 

--- a/processor/common/src/main/kotlin/process.kt
+++ b/processor/common/src/main/kotlin/process.kt
@@ -22,6 +22,7 @@ import com.yandex.yatagan.codegen.impl.ComponentGeneratorFacade
 import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.childrenSequence
 import com.yandex.yatagan.core.graph.impl.BindingGraph
+import com.yandex.yatagan.core.graph.impl.Options
 import com.yandex.yatagan.core.model.impl.ComponentModel
 import com.yandex.yatagan.validation.ValidationMessage.Kind.Error
 import com.yandex.yatagan.validation.ValidationMessage.Kind.MandatoryWarning
@@ -48,7 +49,12 @@ fun <Source> process(
         val logger = LoggerDecorator(delegate.logger)
         val plugins = loadServices<ValidationPluginProvider>()
         for (rootModel in rootModels) {
-            val graphRoot = BindingGraph(root = rootModel)
+            val graphRoot = BindingGraph(
+                root = rootModel,
+                options = Options(
+                    reportDuplicateAliasesAsErrors = delegate.options[BooleanOption.ReportDuplicateAliasesAsErrors]
+                )
+            )
             val allMessages = buildList {
                 addAll(validate(graphRoot))
                 if (plugins.isNotEmpty()) {

--- a/rt/engine/src/main/kotlin/RuntimeEngine.kt
+++ b/rt/engine/src/main/kotlin/RuntimeEngine.kt
@@ -22,6 +22,7 @@ import com.yandex.yatagan.base.ObjectCacheRegistry
 import com.yandex.yatagan.base.loadServices
 import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.impl.BindingGraph
+import com.yandex.yatagan.core.graph.impl.Options
 import com.yandex.yatagan.core.model.impl.ComponentModel
 import com.yandex.yatagan.lang.InternalLangApi
 import com.yandex.yatagan.lang.LangModelFactory
@@ -55,6 +56,7 @@ class RuntimeEngine<P : RuntimeEngine.Params>(
         val maxIssueEncounterPaths: Int
         val isStrictMode: Boolean
         val logger: Logger?
+        val reportDuplicateAliasesAsErrors: Boolean
     }
 
     fun destroy() {
@@ -79,7 +81,8 @@ class RuntimeEngine<P : RuntimeEngine.Params>(
                 "$componentClass is not a root Yatagan component"
             }
             val graph = BindingGraph(
-                root = componentModel
+                root = componentModel,
+                options = createGraphOptions(),
             )
             val promise = doValidate(graph)
             val factory = promise.awaitOnError {
@@ -112,7 +115,10 @@ class RuntimeEngine<P : RuntimeEngine.Params>(
                 )
             }
 
-            val graph = BindingGraph(componentModel)
+            val graph = BindingGraph(
+                root = componentModel,
+                options = createGraphOptions(),
+            )
             val promise = doValidate(graph)
             builder = RuntimeAutoBuilder(
                 componentClass = componentClass,
@@ -157,6 +163,10 @@ class RuntimeEngine<P : RuntimeEngine.Params>(
             }
         }
     }
+
+    private fun createGraphOptions() = Options(
+        reportDuplicateAliasesAsErrors = params.reportDuplicateAliasesAsErrors,
+    )
 
     private companion object {
         val pluginProviders: List<ValidationPluginProvider> = loadServices()

--- a/testing/tests/src/main/kotlin/CompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/CompileTestDriver.kt
@@ -16,6 +16,7 @@
 
 package com.yandex.yatagan.testing.tests
 
+import com.yandex.yatagan.processor.common.Option
 import com.yandex.yatagan.testing.source_set.SourceSet
 import org.junit.Rule
 import org.junit.rules.TestWatcher
@@ -28,6 +29,8 @@ interface CompileTestDriver : SourceSet {
     fun givenPrecompiledModule(
         sources: SourceSet,
     )
+
+    fun <V : Any> givenOption(option: Option<V>, value: V)
 
     /**
      * Runs the test and validates the output against the golden output file.

--- a/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
@@ -22,6 +22,7 @@ import com.yandex.yatagan.generated.CompiledApiClasspath
 import com.yandex.yatagan.generated.DynamicApiClasspath
 import com.yandex.yatagan.processor.common.IntOption
 import com.yandex.yatagan.processor.common.LoggerDecorator
+import com.yandex.yatagan.processor.common.Option
 import com.yandex.yatagan.testing.source_set.SourceFile
 import com.yandex.yatagan.testing.source_set.SourceSet
 import org.junit.Assert
@@ -39,6 +40,10 @@ abstract class CompileTestDriverBase private constructor(
     private val mainSourceSet: SourceSet,
 ) : CompileTestDriver, SourceSet by mainSourceSet {
     private var precompiledModuleOutputDirs: List<File>? = null
+    private val options = mutableMapOf(
+        IntOption.MaxIssueEncounterPaths.key to "100",
+        IntOption.MaxSlotsPerSwitch.key to "100",
+    )
 
     protected constructor(
         apiType: ApiType = ApiType.Compiled,
@@ -94,6 +99,10 @@ abstract class CompileTestDriverBase private constructor(
     }
 
     abstract fun generatedFilesSubDir(): String?
+
+    override fun <V : Any> givenOption(option: Option<V>, value: V) {
+        options[option.key] = value.toString()
+    }
 
     override fun compileRunAndValidate() {
         val goldenResourcePath = "golden/${testNameRule.testClassSimpleName}/${testNameRule.testMethodName}.golden.txt"
@@ -162,10 +171,7 @@ abstract class CompileTestDriverBase private constructor(
             "-opt-in=com.yandex.yatagan.VariantApi",
             "-P", "plugin:org.jetbrains.kotlin.kapt3:correctErrorTypes=true",
         ),
-        processorOptions = mapOf(
-            IntOption.MaxIssueEncounterPaths.key to "100",
-            IntOption.MaxSlotsPerSwitch.key to "100",
-        ),
+        processorOptions = options,
     )
 
     protected open fun createCompilationArguments() = createBaseCompilationArguments()

--- a/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
@@ -505,6 +505,10 @@ class CoreBindingsFailureTest(
                 val myString: String
             }
             
+            interface Api
+            class Impl1 @Inject constructor(): Api
+            class Impl2 @Inject constructor(): Api
+            
             @Module
             class MyModule {
                 @MyQualifier(Named("hello"))
@@ -518,7 +522,12 @@ class CoreBindingsFailureTest(
                 @Provides fun dep(): Dependency = throw AssertionError()
             }
             
-            @Module(includes = [MyModule::class], subcomponents = [SubComponent::class])
+            @Module interface MyBindsModule {
+                @Binds fun api1(i: Impl1): Api
+                @Binds fun api2(i: Impl2): Api
+            }
+            
+            @Module(includes = [MyModule::class, MyBindsModule::class], subcomponents = [SubComponent::class])
             class MyModule2 {
                 @Provides @IntoList fun one(): Number = 1L
                 @Provides @IntoList fun three(): Number = 3f
@@ -545,6 +554,7 @@ class CoreBindingsFailureTest(
                 val numbers: List<Number>
                 val sub: SubComponent.Builder
                 val string: String
+                val api: Api
 
                 @Component.Builder
                 interface Builder {

--- a/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
@@ -16,6 +16,7 @@
 
 package com.yandex.yatagan.testing.tests
 
+import com.yandex.yatagan.processor.common.BooleanOption
 import com.yandex.yatagan.testing.source_set.SourceSet
 import org.junit.Before
 import org.junit.Test
@@ -570,6 +571,31 @@ class CoreBindingsFailureTest(
             interface SubComponent {
                 val numbers: List<Number>
                 @Component.Builder interface Builder { fun create(): SubComponent }
+            }
+        """.trimIndent())
+
+        compileRunAndValidate()
+    }
+
+    @Test
+    fun `conflicting aliases with an option`() {
+        givenOption(BooleanOption.ReportDuplicateAliasesAsErrors, true)
+        givenKotlinSource("test.TestCase", """
+            import com.yandex.yatagan.*
+            import javax.inject.*
+
+            interface Api
+            class Impl1 @Inject constructor(): Api
+            class Impl2 @Inject constructor(): Api
+
+            @Module interface MyModule {
+              @Binds fun bind1(i: Impl1): Api
+              @Binds fun bind2(i: Impl2): Api
+            }
+
+            @Component(modules = [MyModule::class])
+            interface MyComponent {
+              val api: Api
             }
         """.trimIndent())
 

--- a/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/conflicting-aliases-with-an-option.golden.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/conflicting-aliases-with-an-option.golden.txt
@@ -1,0 +1,6 @@
+error: Conflicting bindings for `test.Api`
+NOTE: Conflicting binding: `alias test.MyModule::bind1(test.Impl1)`
+NOTE: Conflicting binding: `alias test.MyModule::bind2(test.Impl2)`
+Encountered:
+  here: graph for root-component test.MyComponent
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/conflicting-bindings.golden.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/conflicting-bindings.golden.txt
@@ -71,3 +71,11 @@ NOTE: Conflicting binding: `child-component-factory component-creator test.SubCo
 Encountered:
   here: graph for root-component test.MyComponent2
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: Conflicting bindings for `test.Api`
+NOTE: Conflicting binding: `alias test.MyBindsModule::api1(test.Impl1)`
+NOTE: Conflicting binding: `alias test.MyBindsModule::api2(test.Impl2)`
+Encountered:
+  here: graph for root-component test.MyComponent2
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/validation/format/src/main/kotlin/reporting.kt
+++ b/validation/format/src/main/kotlin/reporting.kt
@@ -68,6 +68,8 @@ inline fun Validator.reportMandatoryWarning(message: WarningMessage, block: Vali
     report(buildMandatoryWarning(message = message, block = block))
 }
 
+fun ErrorMessage.demoteToWarning(): WarningMessage = WarningMessage(text)
+
 @PublishedApi
 internal class ValidationMessageBuilderImpl(
     private val kind: ValidationMessage.Kind,


### PR DESCRIPTION
1. Report duplicate `@Binds` as a warning unconditionally.
2. If the option is enabled, report as an error.

Fixes #48 