### PR TITLE
Fix: handle the corner case for duplicate aliases reporting.

### DIFF
--- a/core/graph/impl/src/main/kotlin/GraphBindingsManager.kt
+++ b/core/graph/impl/src/main/kotlin/GraphBindingsManager.kt
@@ -353,7 +353,10 @@ internal class GraphBindingsManager(
                         continue
                     }
 
-                    if (!graph.options.reportDuplicateAliasesAsErrors && distinct.all { it is AliasBinding }) {
+                    if (!graph.options.reportDuplicateAliasesAsErrors
+                        // All duplicates are aliases, except at most one (that was valid before the fix)
+                        && distinct.count { it is AliasBinding } >= (distinct.size - 1)
+                    ) {
                         validator.reportWarning(Strings.Errors.conflictingBindings(`for` = node).demoteToWarning()) {
                             distinct.forEach { binding ->
                                 addNote(Strings.Notes.duplicateBinding(binding))

--- a/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
@@ -521,6 +521,7 @@ class CoreBindingsFailureTest(
                 @Provides fun c1() : MyComponent1 = throw AssertionError()
                 @Named("flag") @Provides fun bool() = true
                 @Provides fun dep(): Dependency = throw AssertionError()
+                @Provides fun provideApi(): Api = throw AssertionError()
             }
             
             @Module interface MyBindsModule {

--- a/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/conflicting-bindings.golden.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/conflicting-bindings.golden.txt
@@ -74,6 +74,7 @@ Encountered:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 warning: Conflicting bindings for `test.Api`
+NOTE: Conflicting binding: `provision test.MyModule::provideApi()`
 NOTE: Conflicting binding: `alias test.MyBindsModule::api1(test.Impl1)`
 NOTE: Conflicting binding: `alias test.MyBindsModule::api2(test.Impl2)`
 Encountered:


### PR DESCRIPTION
The case where there is at most one non-alias binding among the duplicates
 is reported as error, whereas should be a warning.

Linked to #48