### PR TITLE
Fix: Correctly handle synthetic alias bindings in conflict checks.

### DIFF
--- a/core/graph/impl/src/main/kotlin/bindings/SyntheticAliasBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/SyntheticAliasBindingImpl.kt
@@ -19,17 +19,21 @@ package com.yandex.yatagan.core.graph.impl.bindings
 import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.bindings.AliasBinding
 import com.yandex.yatagan.core.graph.bindings.BaseBinding
+import com.yandex.yatagan.core.graph.bindings.Binding
 import com.yandex.yatagan.core.model.ModuleModel
 import com.yandex.yatagan.core.model.NodeModel
 import com.yandex.yatagan.validation.MayBeInvalid
 import com.yandex.yatagan.validation.Validator
 
 internal class SyntheticAliasBindingImpl(
-    override val source: NodeModel,
+    val sourceBinding: Binding,
     override val target: NodeModel,
-    override val owner: BindingGraph,
 ) : AliasBinding {
-    private val sourceBinding by lazy(LazyThreadSafetyMode.PUBLICATION) { owner.resolveBindingRaw(source) }
+    override val source: NodeModel
+        get() = sourceBinding.target
+
+    override val owner: BindingGraph
+        get() = sourceBinding.owner
 
     override val originModule: ModuleModel? get() = null
     override fun <R> accept(visitor: BaseBinding.Visitor<R>): R {

--- a/core/graph/impl/src/main/kotlin/bindings/utils.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/utils.kt
@@ -19,6 +19,7 @@ package com.yandex.yatagan.core.graph.impl.bindings
 import com.yandex.yatagan.base.intersects
 import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.bindings.AliasBinding
+import com.yandex.yatagan.core.graph.bindings.BaseBinding
 import com.yandex.yatagan.core.graph.bindings.Binding
 import com.yandex.yatagan.core.graph.bindings.ExtensibleBinding
 import com.yandex.yatagan.core.graph.impl.and
@@ -53,4 +54,9 @@ internal fun BindingGraph.canHost(bindingScopes: Set<ScopeModel>): Boolean {
     }
 
     return bindingScopes intersects scopes
+}
+
+internal fun BaseBinding.maybeUnwrapSyntheticAlias(): BaseBinding = when (this) {
+    is SyntheticAliasBindingImpl -> sourceBinding.maybeUnwrapSyntheticAlias()
+    else -> this
 }

--- a/testing/tests/src/test/kotlin/MultibindingsTest.kt
+++ b/testing/tests/src/test/kotlin/MultibindingsTest.kt
@@ -576,10 +576,14 @@ class MultibindingsTest(
                 }
             }
 
+            class Consumer @Inject constructor(val numbers: List<Number>)
+
             @Component(isRoot = false, modules = [SubModule2::class])
             interface SubComponent2 {
                 val numbers: List<Number>
                 @get:Named("qualified") val qInts: List<Int>
+                
+                val consumer: Consumer
                 
                 @Component.Builder interface Builder {
                     fun create(): SubComponent2


### PR DESCRIPTION
Also remove sourceBinding resolution in favor of directly passing it
 to constructor as the latter was possible from the start.

Fixes #58

Note: `SyntheticAliasBindingImpl` is used (among some similar purposes) to bind `List<T>` and `List<? extends T>` nodes to the same binding.
 