### PR TITLE
Kapt: Properly fix annotation ordering issue.

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
         }
 
         create("testingLibs") {
-            library("roomCompileTesting", "androidx.room:room-compiler-processing-testing:2.6.0-alpha01")
+            library("roomCompileTesting", "androidx.room:room-compiler-processing-testing:2.6.0-beta01")
             library("junit4", "junit:junit:4.13.2")
             library("mockito-kotlin", "org.mockito.kotlin:mockito-kotlin:4.0.0")
             library("assertj", "org.assertj:assertj-core:3.23.1")

--- a/lang/jap/src/main/kotlin/javaxUtils.kt
+++ b/lang/jap/src/main/kotlin/javaxUtils.kt
@@ -103,6 +103,7 @@ internal val Element.isType
 private val StaticFinal = setOf(Modifier.STATIC, Modifier.FINAL)
 
 private object AsTypeElementOptional : SimpleElementVisitor8<TypeElement?, Unit>() {
+    override fun visitUnknown(e: Element?, p: Unit?) = null
     override fun defaultAction(e: Element?, p: Unit?) = null
     override fun visitType(e: TypeElement?, p: Unit?) = e
 }
@@ -147,6 +148,14 @@ internal fun TypeElement.isFromKotlin(): Boolean {
 internal tailrec fun Element.isFromKotlin(): Boolean {
     // For a random element need to find a type element it belongs to first.
     return asTypeElementOrNull()?.isFromKotlin() ?: (enclosingElement ?: return false).isFromKotlin()
+}
+
+internal fun TypeElement.kotlinMetadataVersion(): IntArray? {
+    return getAnnotation(Metadata::class.java)?.metadataVersion
+}
+
+internal tailrec fun Element.kotlinMetadataVersion(): IntArray? {
+    return asTypeElementOrNull()?.kotlinMetadataVersion() ?: (enclosingElement ?: return null).kotlinMetadataVersion()
 }
 
 internal fun TypeElement.allNonPrivateFields(): Sequence<VariableElement> = sequence {

--- a/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
@@ -170,6 +170,7 @@ abstract class CompileTestDriverBase private constructor(
             "-opt-in=com.yandex.yatagan.ConditionsApi",
             "-opt-in=com.yandex.yatagan.VariantApi",
             "-P", "plugin:org.jetbrains.kotlin.kapt3:correctErrorTypes=true",
+            "-jvm-target=11",
         ),
         processorOptions = options,
     )


### PR DESCRIPTION
As per KT-51087, kapt generated annotations in
 reverse order, which was important for Yatagan.
This CL adds logic to reverse annotations based
 on kotlin metadata version check.

The ultimate reason for the fix was that
`room-compiler-processing-testing` in `2.6.0-beta01` migrated to 1.9.x Kotlin compiler and some tests were broken.

Closes #74