### PR TITLE
Testing: Introduce validation against "golden" generated code.

### DIFF
--- a/base/src/main/kotlin/util.kt
+++ b/base/src/main/kotlin/util.kt
@@ -89,6 +89,10 @@ inline fun <K, V> Array<out Pair<K, V>>.forEachBi(block: (K, V) -> Unit) {
     forEach { (k, v) -> block(k, v) }
 }
 
+fun <T, R> Iterable<T>.sortedWithBy(comparator: Comparator<R>, selector: (T) -> R): List<T> {
+    return sortedWith(Comparator.comparing(selector, comparator))
+}
+
 inline fun <T : Any> traverseDepthFirstWithPath(
     roots: Iterable<T>,
     childrenOf: (T) -> Iterable<T>,

--- a/codegen/impl/src/main/kotlin/AccessStrategyManager.kt
+++ b/codegen/impl/src/main/kotlin/AccessStrategyManager.kt
@@ -31,6 +31,7 @@ import javax.inject.Singleton
 @Singleton
 internal class AccessStrategyManager @Inject constructor(
     private val thisGraph: BindingGraph,
+    private val options: ComponentGenerator.Options,
     private val cachingStrategySingleThreadFactory: CachingStrategySingleThreadFactory,
     private val cachingStrategyMultiThreadFactory: CachingStrategyMultiThreadFactory,
     private val slotProviderStrategyFactory: SlotProviderStrategyFactory,
@@ -187,8 +188,10 @@ internal class AccessStrategyManager @Inject constructor(
     )
 
     override fun generate(builder: TypeSpecBuilder) {
-        strategies.values.forEach {
-            it.generateInComponent(builder)
+        strategies.entries.let { strategies ->
+            if (options.sortMethodsForTesting) strategies.sortedBy { it.key } else strategies
+        }.forEach { (_, strategy) ->
+            strategy.generateInComponent(builder)
         }
     }
 

--- a/codegen/impl/src/main/kotlin/CollectionBindingGenerator.kt
+++ b/codegen/impl/src/main/kotlin/CollectionBindingGenerator.kt
@@ -30,8 +30,10 @@ import javax.inject.Singleton
 internal class CollectionBindingGenerator @Inject constructor (
     @MethodsNamespace methodsNs: Namespace,
     private val thisGraph: BindingGraph,
+    options: ComponentGenerator.Options,
 ) : MultiBindingGeneratorBase<MultiBinding>(
     methodsNs = methodsNs,
+    options = options,
     bindings = thisGraph.localBindings.keys.filterIsInstance<MultiBinding>(),
     accessorPrefix = "manyOf",
 ) {

--- a/codegen/impl/src/main/kotlin/ComponentGeneratorFacade.kt
+++ b/codegen/impl/src/main/kotlin/ComponentGeneratorFacade.kt
@@ -25,6 +25,7 @@ class ComponentGeneratorFacade(
     maxSlotsPerSwitch: Int,
     enableThreadChecks: Boolean,
     enableProvisionNullChecks: Boolean,
+    sortMethodsForTesting: Boolean,
 ) {
     private val component = Yatagan.builder(GeneratorComponent.Factory::class.java).create(
         graph = graph,
@@ -32,6 +33,7 @@ class ComponentGeneratorFacade(
             maxSlotsPerSwitch = maxSlotsPerSwitch,
             enableProvisionNullChecks = enableProvisionNullChecks,
             enableThreadChecks = enableThreadChecks,
+            sortMethodsForTesting = sortMethodsForTesting,
         ),
     )
 

--- a/codegen/impl/src/main/kotlin/MapBindingGenerator.kt
+++ b/codegen/impl/src/main/kotlin/MapBindingGenerator.kt
@@ -32,8 +32,10 @@ import javax.inject.Singleton
 internal class MapBindingGenerator @Inject constructor(
     @MethodsNamespace methodsNs: Namespace,
     private val thisGraph: BindingGraph,
+    options: ComponentGenerator.Options,
 ) : MultiBindingGeneratorBase<MapBinding>(
     methodsNs = methodsNs,
+    options = options,
     bindings = thisGraph.localBindings.keys.filterIsInstance<MapBinding>(),
     accessorPrefix = "mapOf",
 ) {

--- a/codegen/impl/src/main/kotlin/MultiBindingGeneratorBase.kt
+++ b/codegen/impl/src/main/kotlin/MultiBindingGeneratorBase.kt
@@ -24,6 +24,7 @@ import com.yandex.yatagan.core.graph.bindings.Binding
 
 internal abstract class MultiBindingGeneratorBase<B : Binding>(
     private val bindings: List<B>,
+    private val options: ComponentGenerator.Options,
     methodsNs: Namespace,
     accessorPrefix: String,
 ) : ComponentGenerator.Contributor {
@@ -50,6 +51,7 @@ internal abstract class MultiBindingGeneratorBase<B : Binding>(
     }
 
     override fun generate(builder: TypeSpecBuilder) = with(builder) {
+        val bindings = if (options.sortMethodsForTesting) bindings.sorted() else bindings
         for (binding in bindings) {
             method(accessorNames[binding]!!) {
                 modifiers(/*package-private*/)

--- a/lang/api/src/main/kotlin/Field.kt
+++ b/lang/api/src/main/kotlin/Field.kt
@@ -20,7 +20,7 @@ package com.yandex.yatagan.lang
  * Models a field from a JVM point of view.
  * Properties are not modeled by this.
  */
-public interface Field : Member {
+public interface Field : Member, Comparable<Field> {
 
     /**
      * Type of the field.

--- a/lang/api/src/main/kotlin/extensions.kt
+++ b/lang/api/src/main/kotlin/extensions.kt
@@ -95,3 +95,27 @@ public inline fun LangModelFactory.getProviderType(parameter: Type, isCovariant:
         isCovariant = isCovariant,
     )
 }
+
+public operator fun Member.compareTo(other: Member): Int {
+    return MemberComparator.compare(this, other)
+}
+
+public object MemberComparator : Comparator<Member> {
+    override fun compare(one: Member, other: Member): Int = one.accept(object : Member.Visitor<Int> {
+        override fun visitMethod(model: Method): Int {
+            val thisMethod = model
+            return other.accept(object : Member.Visitor<Int> {
+                override fun visitMethod(model: Method) = thisMethod.compareTo(model)
+                override fun visitField(model: Field) = +1  // Method is greater than field by convention
+            })
+        }
+
+        override fun visitField(model: Field): Int {
+            val thisField = model
+            return other.accept(object : Member.Visitor<Int> {
+                override fun visitMethod(model: Method) = -1  // Field is lesser than method by convention
+                override fun visitField(model: Field) = thisField.compareTo(model)
+            })
+        }
+    })
+}

--- a/lang/common/src/main/kotlin/FieldBase.kt
+++ b/lang/common/src/main/kotlin/FieldBase.kt
@@ -25,4 +25,14 @@ abstract class FieldBase : Field {
     }
 
     final override fun toString() = "$owner::$name: $type"
+
+    final override fun compareTo(other: Field): Int {
+        if (this === other) return 0
+
+        name.compareTo(other.name).let { if (it != 0) return it }
+        owner.compareTo(other.owner).let { if (it != 0) return it }
+        type.compareTo(other.type).let { if (it != 0) return it }
+
+        return 0
+    }
 }

--- a/processor/common/src/main/kotlin/Options.kt
+++ b/processor/common/src/main/kotlin/Options.kt
@@ -54,6 +54,7 @@ enum class BooleanOption(
     ReportDuplicateAliasesAsErrors("yatagan.experimental.reportDuplicateAliasesAsErrors", default = false),
     OmitThreadChecks("yatagan.experimental.omitThreadChecks", default = false),
     OmitProvisionNullChecks("yatagan.experimental.omitProvisionNullChecks", default = false),
+    SortMethodsForTesting("yatagan.internal.testing.sortMethods", default = false),
 
     ;
 

--- a/processor/common/src/main/kotlin/process.kt
+++ b/processor/common/src/main/kotlin/process.kt
@@ -94,6 +94,7 @@ fun <Source> process(
                     maxSlotsPerSwitch = delegate.options[IntOption.MaxSlotsPerSwitch],
                     enableThreadChecks = !delegate.options[BooleanOption.OmitThreadChecks],
                     enableProvisionNullChecks = !delegate.options[BooleanOption.OmitProvisionNullChecks],
+                    sortMethodsForTesting = delegate.options[BooleanOption.SortMethodsForTesting],
                 )
                 delegate.openFileForGenerating(
                     sources = allSourcesSequence(delegate, graphRoot),

--- a/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
@@ -20,6 +20,7 @@ import androidx.room.compiler.processing.util.compiler.TestCompilationArguments
 import androidx.room.compiler.processing.util.compiler.compile
 import com.yandex.yatagan.generated.CompiledApiClasspath
 import com.yandex.yatagan.generated.DynamicApiClasspath
+import com.yandex.yatagan.processor.common.BooleanOption
 import com.yandex.yatagan.processor.common.IntOption
 import com.yandex.yatagan.processor.common.LoggerDecorator
 import com.yandex.yatagan.processor.common.Option
@@ -43,6 +44,7 @@ abstract class CompileTestDriverBase private constructor(
     private val options = mutableMapOf(
         IntOption.MaxIssueEncounterPaths.key to "100",
         IntOption.MaxSlotsPerSwitch.key to "100",
+        BooleanOption.SortMethodsForTesting.key to "true",
     )
 
     protected constructor(
@@ -52,7 +54,7 @@ abstract class CompileTestDriverBase private constructor(
     override val testNameRule = TestNameRule()
 
     final override fun givenPrecompiledModule(sources: SourceSet) {
-        if(precompiledModuleOutputDirs != null) {
+        if (precompiledModuleOutputDirs != null) {
             throw UnsupportedOperationException("Multiple precompiled modules are not supported")
         }
 
@@ -105,7 +107,9 @@ abstract class CompileTestDriverBase private constructor(
     }
 
     override fun compileRunAndValidate() {
-        val goldenResourcePath = "golden/${testNameRule.testClassSimpleName}/${testNameRule.testMethodName}.golden.txt"
+        val goldenResourceBasePath = "golden/${testNameRule.testClassSimpleName}/${testNameRule.testMethodName}"
+        val goldenResourcePath = "$goldenResourceBasePath.golden.txt"
+        val goldenCodeResourcePath = "$goldenResourceBasePath.golden-code.txt"
 
         val (workingDir, runtimeClasspath, messageLog, success, generatedFiles) = doCompile()
         val strippedLog = normalizeMessages(messageLog)
@@ -119,6 +123,24 @@ abstract class CompileTestDriverBase private constructor(
                 goldenSourcePath.writeText(strippedLog)
             }
             println("Updated $goldenSourcePath")
+
+            if (generatedFilesSubDir() != null) {
+                val goldenCodeSourcePath = Path(goldenSourceDirForUpdate).resolve(goldenCodeResourcePath)
+                if (generatedFiles.isEmpty()) {
+                    goldenCodeSourcePath.deleteIfExists()
+                } else {
+                    goldenCodeSourcePath.parent.createDirectories()
+                    goldenCodeSourcePath.writeText(buildString {
+                        for (generatedFile in generatedFiles) {
+                            appendLine(MessageSeparator)
+                            append("Name: ").appendLine(generatedFile.relativePath)
+                            appendLine(generatedFile.contents)
+                        }
+                        appendLine(MessageSeparator)
+                    })
+                }
+                println("Updated $goldenCodeResourcePath")
+            }
             return
         }
 
@@ -143,11 +165,22 @@ abstract class CompileTestDriverBase private constructor(
             }
         } finally {
             generatedFilesSubDir()?.let { generatedFilesSubDir ->
+                val goldenFiles = GoldenSourceRegex.findAll(
+                    javaClass.getResourceAsStream("/$goldenCodeResourcePath")
+                        ?.bufferedReader()?.readText() ?: ""
+                ).associateByTo(
+                    destination = mutableMapOf(),
+                    keySelector = { it.groupValues[1] },
+                    valueTransform = { it.groupValues[2].trim() },
+                )
                 for (generatedFile in generatedFiles) {
                     val fileUrl = "file://" + workingDir
                         .resolve(generatedFilesSubDir)
                         .resolve(generatedFile.relativePath).absolutePath
                     println("Generated $fileUrl")
+                    val goldenContents = goldenFiles.remove(generatedFile.relativePath) ?: "<unexpected file>"
+                    Assert.assertEquals("Generated file '${generatedFile.relativePath}' doesn't match the golden",
+                        goldenContents, generatedFile.contents.trim())
                 }
             }
         }
@@ -211,6 +244,9 @@ abstract class CompileTestDriverBase private constructor(
         private val AnsiColorSequenceRegex = "\u001b\\[.*?m".toRegex()
 
         private val MessageSeparator = "~".repeat(80)
+
+        private val GoldenSourceRegex = """$MessageSeparator\nName: (.*?)\n(.*?)(?=$MessageSeparator)"""
+            .toRegex(RegexOption.DOT_MATCHES_ALL)
 
         val goldenSourceDirForUpdate: String? = System.getProperty("com.yandex.yatagan.updateGoldenFiles")
 

--- a/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/CompileTestDriverBase.kt
@@ -165,11 +165,13 @@ abstract class CompileTestDriverBase private constructor(
         inheritClasspath = false,
         javacArguments = listOf(
             "-Xdiags:verbose",
+            "-parameters",
         ),
         kotlincArguments = listOf(
             "-opt-in=com.yandex.yatagan.ConditionsApi",
             "-opt-in=com.yandex.yatagan.VariantApi",
             "-P", "plugin:org.jetbrains.kotlin.kapt3:correctErrorTypes=true",
+            "-java-parameters",
         ),
         processorOptions = options,
     )

--- a/testing/tests/src/main/kotlin/DynamicCompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/DynamicCompileTestDriver.kt
@@ -114,8 +114,6 @@ class DynamicCompileTestDriver(
     override fun createCompilationArguments() = super.createCompilationArguments().let {
         it.copy(
             sources = it.sources + runnerSource,
-            javacArguments = it.javacArguments + "-parameters",
-            kotlincArguments = it.kotlincArguments + "-java-parameters",
             kaptProcessors = listOf(accumulator),
         )
     }

--- a/testing/tests/src/main/kotlin/compileTestDrivers.kt
+++ b/testing/tests/src/main/kotlin/compileTestDrivers.kt
@@ -32,11 +32,11 @@ internal fun compileTestDrivers(
     }
 
     val providers = buildList {
-        if (includeKsp) {
-            add(NamedProvider(::KspCompileTestDriver, name = "KSP"))
-        }
         if (includeJap) {
             add(NamedProvider(::JapCompileTestDriver, name = "JAP"))
+        }
+        if (includeKsp) {
+            add(NamedProvider(::KspCompileTestDriver, name = "KSP"))
         }
         if (includeRt) {
             add(NamedProvider(::DynamicCompileTestDriver, name = "RT"))

--- a/testing/tests/src/test/kotlin/ConditionsTest.kt
+++ b/testing/tests/src/test/kotlin/ConditionsTest.kt
@@ -594,8 +594,10 @@ class ConditionsTest(
                 }
             }
             
-            @Condition(Features::class, "fooBar")
-            @Condition(Features::class, "isEnabledB")
+            @AllConditions(
+                Condition(Features::class, "fooBar"),
+                Condition(Features::class, "isEnabledB"),
+            )
             @AnyCondition(
                 Condition(Features::class, "getFeatureC.isEnabled"),                                
                 Condition(Features::class, "isEnabledB"),
@@ -609,20 +611,22 @@ class ConditionsTest(
             )
             annotation class ComplexFeature1
             
-            @AnyCondition(
-                Condition(Features::class, "fooBar"),
+            @AnyConditions(
+                AnyCondition(
+                    Condition(Features::class, "fooBar"),
+                ),
+                AnyCondition(
+                    Condition(Features::class, EnabledB),
+                ),
+                AnyCondition(
+                    Condition(Features::class, "getFeatureC.isEnabled"),                                
+                    Condition(Features::class, condition = EnabledB),                                
+                ),
+                AnyCondition(
+                    Condition(Features::class, "getFeatureC.isEnabled"),                                
+                    Condition(value = Features::class, condition = "isEnabledB"),                                
+                ),
             )
-            @AnyCondition(
-                Condition(Features::class, EnabledB),
-            )
-            @AnyCondition(
-                Condition(Features::class, "getFeatureC.isEnabled"),                                
-                Condition(Features::class, condition = EnabledB),                                
-            )
-            @AnyCondition(
-                Condition(Features::class, "getFeatureC.isEnabled"),                                
-                Condition(value = Features::class, condition = "isEnabledB"),                                
-            )            
             annotation class ComplexFeature2
             
             @Conditional(ComplexFeature1::class)               
@@ -630,7 +634,7 @@ class ConditionsTest(
             @Conditional(ComplexFeature2::class)
             class ClassB @Inject constructor(a: Provider<ClassA>)
             
-            @Component            
+            @Component
             interface MyComponent {
                 val a: Optional<ClassA>                        
             }

--- a/testing/tests/src/test/kotlin/HeavyTest.kt
+++ b/testing/tests/src/test/kotlin/HeavyTest.kt
@@ -29,8 +29,6 @@ import javax.inject.Provider
 @OptIn(ExperimentalGenerationApi::class)
 class HeavyTest(
     driverProvider: Provider<CompileTestDriverBase>,
-    private val params: GenerationParams,
-    private val name: String,
 ) : CompileTestDriver by driverProvider.get() {
     companion object {
         private val baseParams = GenerationParams(
@@ -59,25 +57,30 @@ class HeavyTest(
         )
 
         @JvmStatic
-        @Parameterized.Parameters(name = "{0} - {2}")
-        fun parameters() = compileTestDrivers().flatMap {
-            listOf(
-                arrayOf(it, baseParams, "Tall & Thin"),
-                arrayOf(it, baseParams.copy(
-                    componentTreeMaxDepth = 1,
-                    totalGraphNodesCount = 600,
-                    totalRootCount = 2,
-                    maxEntryPointsPerComponent = 60,
-                ), "Fat & Flat"),
-            )
-        }
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters() = compileTestDrivers()
     }
 
     @Test
-    fun procedural() {
-        println("Running '$name' heavy test")
+    fun `procedural - Tall & Thin`() {
         generate(
-            params = params,
+            params = baseParams,
+            testMethodName = "test",
+            output = this,
+        )
+
+        compileRunAndValidate()
+    }
+
+    @Test
+    fun `procedural - Fat & Flat`() {
+        generate(
+            params = baseParams.copy(
+                componentTreeMaxDepth = 1,
+                totalGraphNodesCount = 600,
+                totalRootCount = 2,
+                maxEntryPointsPerComponent = 60,
+            ),
             testMethodName = "test",
             output = this,
         )

--- a/testing/tests/src/test/resources/golden/AccessControlTest/-Binds-declarations-can-be-package-private.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/AccessControlTest/-Binds-declarations-can-be-package-private.golden-code.txt
@@ -1,0 +1,58 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final boolean mMyFeatureSEnabled = MyFeature.sEnabled;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api getApi() {
+    return new MyClassA();
+  }
+
+  @Override
+  public Api getApi2() {
+    return this.mMyFeatureSEnabled ? new MyClassB() : new MyClassA();
+  }
+
+  @Override
+  public Optional<Api> getApi3() {
+    return Optional.empty();
+  }
+
+  @Override
+  public MyClassD getD() {
+    return new MyClassD();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentCreatorFailureTest/invalid-sub-component-factory-methods.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentCreatorFailureTest/invalid-sub-component-factory-methods.golden-code.txt
@@ -1,0 +1,60 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$RootComponent2.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$RootComponent2 implements RootComponent2 {
+  private Yatagan$RootComponent2() {
+  }
+
+  @Override
+  public SubComponent1.Factory sub1EP() {
+    return new SubComponent1Impl.ComponentFactoryImpl();
+  }
+
+  public static AutoBuilder<Yatagan$RootComponent2> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponent1Impl implements SubComponent1 {
+    final MyDependencies mMyDependencies;
+
+    SubComponent1Impl(MyDependencies pDep) {
+      this.mMyDependencies = Checks.checkInputNotNull(pDep);
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent1.Factory {
+      ComponentFactoryImpl() {
+      }
+
+      @Override
+      public SubComponent1 create(MyDependencies dep) {
+        return new SubComponent1Impl(dep);
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$RootComponent2> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$RootComponent2> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$RootComponent2 create() {
+      return new Yatagan$RootComponent2();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentCreatorFailureTest/missing-creator.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentCreatorFailureTest/missing-creator.golden-code.txt
@@ -1,0 +1,36 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$AnotherRootComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$AnotherRootComponent implements AnotherRootComponent {
+  private Yatagan$AnotherRootComponent() {
+  }
+
+  public static AutoBuilder<Yatagan$AnotherRootComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$AnotherRootComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$AnotherRootComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$AnotherRootComponent create() {
+      return new Yatagan$AnotherRootComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentDependenciesKotlinTest/component-dependencies-basic-case.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentDependenciesKotlinTest/component-dependencies-basic-case.golden-code.txt
@@ -1,0 +1,125 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyApplicationComponent.java
+package test;
+
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyApplicationComponent implements MyApplicationComponent {
+  Yatagan$MyApplicationComponent() {
+  }
+
+  @Override
+  public MyApplicationManager getAppManager() {
+    return new MyApplicationManagerImpl();
+  }
+
+  public static MyApplicationComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements MyApplicationComponent.Factory {
+    @Override
+    public MyApplicationComponent create() {
+      return new Yatagan$MyApplicationComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyActivityComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyActivityComponent implements MyActivityComponent {
+  final MyApplicationComponent mMyApplicationComponent;
+
+  Yatagan$MyActivityComponent(MyApplicationComponent pApp) {
+    this.mMyApplicationComponent = Checks.checkInputNotNull(pApp);
+  }
+
+  @Override
+  public MyApplicationManager getAppManager() {
+    return this.mMyApplicationComponent.getAppManager();
+  }
+
+  @Override
+  public Lazy<MyApplicationManager> getAppManagerLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<MyApplicationManager> getAppManagerProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.mMyApplicationComponent.getAppManager();
+      default: throw new AssertionError();
+    }
+  }
+
+  public static MyActivityComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyActivityComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyActivityComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$MyActivityComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$MyActivityComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements MyActivityComponent.Factory {
+    @Override
+    public MyActivityComponent create(MyApplicationComponent app) {
+      return new Yatagan$MyActivityComponent(app);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentDependenciesKotlinTest/component-dependencies-dependency-component-instance-is-available-for-inject.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentDependenciesKotlinTest/component-dependencies-dependency-component-instance-is-available-for-inject.golden-code.txt
@@ -1,0 +1,120 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyApplicationComponent.java
+package test;
+
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyApplicationComponent implements MyApplicationComponent {
+  Yatagan$MyApplicationComponent() {
+  }
+
+  public static MyApplicationComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements MyApplicationComponent.Factory {
+    @Override
+    public MyApplicationComponent create() {
+      return new Yatagan$MyApplicationComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyActivityComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyActivityComponent implements MyActivityComponent {
+  final MyApplicationComponent mMyApplicationComponent;
+
+  Yatagan$MyActivityComponent(MyApplicationComponent pApp) {
+    this.mMyApplicationComponent = Checks.checkInputNotNull(pApp);
+  }
+
+  @Override
+  public MyApplicationComponent getApp() {
+    return this.mMyApplicationComponent;
+  }
+
+  @Override
+  public Lazy<MyApplicationComponent> getAppLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<MyApplicationComponent> getAppProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.mMyApplicationComponent;
+      default: throw new AssertionError();
+    }
+  }
+
+  public static MyActivityComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyActivityComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyActivityComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$MyActivityComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$MyActivityComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements MyActivityComponent.Factory {
+    @Override
+    public MyActivityComponent create(MyApplicationComponent app) {
+      return new Yatagan$MyActivityComponent(app);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentDependenciesKotlinTest/plain-interfaces-are-allowed-as-dependencies.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentDependenciesKotlinTest/plain-interfaces-are-allowed-as-dependencies.golden-code.txt
@@ -1,0 +1,34 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final Dependencies mDependencies;
+
+  Yatagan$MyComponent(Dependencies pDep) {
+    this.mDependencies = Checks.checkInputNotNull(pDep);
+  }
+
+  @Override
+  public MyClass getMyClass() {
+    return this.mDependencies.getMyClass();
+  }
+
+  public static MyComponent.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements MyComponent.Builder {
+    @Override
+    public MyComponent create(Dependencies dep) {
+      return new Yatagan$MyComponent(dep);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/alias-binding-across-component-boundary.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/alias-binding-across-component-boundary.golden-code.txt
@@ -1,0 +1,61 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final MyImpl mImpl;
+
+  Yatagan$TestComponent(MyImpl pImpl) {
+    this.mImpl = Checks.checkInputNotNull(pImpl);
+  }
+
+  @Override
+  public TestSubComponent.Creator getSub() {
+    return new TestSubComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  public static TestComponent.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class TestSubComponentImpl implements TestSubComponent {
+    final Yatagan$TestComponent mTestComponent;
+
+    TestSubComponentImpl(Yatagan$TestComponent pTestComponent) {
+      this.mTestComponent = pTestComponent;
+    }
+
+    @Override
+    public Consumer getConsumer() {
+      return new Consumer(this.mTestComponent.mImpl);
+    }
+
+    private static final class ComponentFactoryImpl implements TestSubComponent.Creator {
+      Yatagan$TestComponent fTestComponent;
+
+      ComponentFactoryImpl(Yatagan$TestComponent fTestComponent) {
+        this.fTestComponent = fTestComponent;
+      }
+
+      @Override
+      public TestSubComponent create() {
+        return new TestSubComponentImpl(this.fTestComponent);
+      }
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Creator {
+    @Override
+    public TestComponent create(MyImpl impl) {
+      return new Yatagan$TestComponent(impl);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/create-builder-auto-builder-usage.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/create-builder-auto-builder-usage.golden-code.txt
@@ -1,0 +1,145 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$ComponentFoo.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Arrays;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$ComponentFoo implements ComponentFoo {
+  final MyModule mMyModule;
+
+  private Yatagan$ComponentFoo(MyModule pMyModule) {
+    this.mMyModule = pMyModule != null ? pMyModule : new MyModule();
+  }
+
+  @Override
+  public int getI() {
+    return Checks.checkProvisionNotNull(this.mMyModule.getI());
+  }
+
+  public static AutoBuilder<Yatagan$ComponentFoo> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$ComponentFoo> {
+    private MyModule mMyModule;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$ComponentFoo> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == MyModule.class) {
+        this.mMyModule = (MyModule) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(MyModule.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$ComponentFoo create() {
+      return new Yatagan$ComponentFoo(this.mMyModule);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$ComponentBar.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Arrays;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$ComponentBar implements ComponentBar {
+  final MyDependency1 mMyDependency1;
+
+  final MyDependency2 mMyDependency2;
+
+  final MyModule2 mMyModule2;
+
+  private Yatagan$ComponentBar(MyDependency1 pMyDependency1, MyDependency2 pMyDependency2,
+      MyModule2 pMyModule2) {
+    this.mMyDependency1 = pMyDependency1;
+    this.mMyDependency2 = pMyDependency2;
+    this.mMyModule2 = pMyModule2;
+  }
+
+  @Override
+  public int getI() {
+    return Checks.checkProvisionNotNull(this.mMyModule2.getI());
+  }
+
+  public static AutoBuilder<Yatagan$ComponentBar> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$ComponentBar> {
+    private MyDependency1 mMyDependency1;
+
+    private MyDependency2 mMyDependency2;
+
+    private MyModule2 mMyModule2;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$ComponentBar> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == MyDependency1.class) {
+        this.mMyDependency1 = (MyDependency1) input;
+      } else if (inputClass == MyDependency2.class) {
+        this.mMyDependency2 = (MyDependency2) input;
+      } else if (inputClass == MyModule2.class) {
+        this.mMyModule2 = (MyModule2) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(MyDependency1.class, MyDependency2.class, MyModule2.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$ComponentBar create() {
+      if (this.mMyDependency1 == null) {
+        Checks.reportMissingAutoBuilderInput(MyDependency1.class);
+      }
+      if (this.mMyDependency2 == null) {
+        Checks.reportMissingAutoBuilderInput(MyDependency2.class);
+      }
+      if (this.mMyModule2 == null) {
+        Checks.reportMissingAutoBuilderInput(MyModule2.class);
+      }
+      return new Yatagan$ComponentBar(this.mMyDependency1, this.mMyDependency2, this.mMyModule2);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$ComponentBaz.java
+package test;
+
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$ComponentBaz implements ComponentBaz {
+  Yatagan$ComponentBaz() {
+  }
+
+  public static ComponentBaz.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements ComponentBaz.Builder {
+    @Override
+    public ComponentBase create() {
+      return new Yatagan$ComponentBaz();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/implicit-subcomponent-inclusion.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/implicit-subcomponent-inclusion.golden-code.txt
@@ -1,0 +1,316 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$RootComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Double;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$RootComponent implements RootComponent {
+  private Object mFooInstance;
+
+  final Features mFeatures;
+
+  Yatagan$RootComponent(Features pFeatures) {
+    this.mFeatures = Checks.checkInputNotNull(pFeatures);
+  }
+
+  @Override
+  public SubComponent1.Builder getSub1() {
+    return new SubComponent1Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Provider<SubComponent2> getSub2() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Lazy<SubComponent2> getSub2lazy() {
+    return new CachingProviderImpl(this, 1);
+  }
+
+  @Override
+  public SubComponent3 createSubComponent3(MyDep dep, MyModule mod, double d) {
+    return new SubComponent3Impl(this, dep, mod, d);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheFoo();
+      case 1: return new SubComponent2Impl(this);
+      default: throw new AssertionError();
+    }
+  }
+
+  Foo cacheFoo() {
+    Object local = this.mFooInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Foo();
+      this.mFooInstance = local;
+    }
+    return (Foo) local;
+  }
+
+  public static RootComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponent1Impl implements SubComponent1 {
+    final Yatagan$RootComponent mRootComponent;
+
+    private byte mFeaturesIsEnabled;
+
+    SubComponent1Impl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public Optional<FeatureComponent> getOpt() {
+      return this.optOfFeatureComponent();
+    }
+
+    Optional optOfFeatureComponent() {
+      return this.featuresIsEnabled() ? Optional.of(new FeatureComponentImpl(this.mRootComponent)) : Optional.empty();
+    }
+
+    boolean featuresIsEnabled() {
+      if (this.mFeaturesIsEnabled == 0x0) {
+        this.mFeaturesIsEnabled = (byte) ((this.mRootComponent.mFeatures.isEnabled()) ? 0x1 : 0x2);
+      }
+      return this.mFeaturesIsEnabled == 0x1;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class FeatureComponentImpl implements FeatureComponent {
+      final Yatagan$RootComponent mRootComponent;
+
+      private FeatureComponentImpl(Yatagan$RootComponent pRootComponent) {
+        this.mRootComponent = pRootComponent;
+      }
+
+      @Override
+      public Provider<Foo> getFoo() {
+        return new ProviderImpl(this.mRootComponent, 0);
+      }
+
+      @Override
+      public FeatureComponent2 createFeatureComponent2(MyDep dep) {
+        return new FeatureComponent2Impl(dep);
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class FeatureComponent2Impl implements FeatureComponent2 {
+        final MyDep mMyDep;
+
+        FeatureComponent2Impl(MyDep pDep) {
+          this.mMyDep = Checks.checkInputNotNull(pDep);
+        }
+
+        @Override
+        public MyDep getDep() {
+          return this.mMyDep;
+        }
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent1.Builder {
+      Yatagan$RootComponent fRootComponent;
+
+      ComponentFactoryImpl(Yatagan$RootComponent fRootComponent) {
+        this.fRootComponent = fRootComponent;
+      }
+
+      @Override
+      public SubComponent1 create() {
+        return new SubComponent1Impl(this.fRootComponent);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponent2Impl implements SubComponent2 {
+    final Yatagan$RootComponent mRootComponent;
+
+    private SubComponent2Impl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public Foo getFoo() {
+      return this.mRootComponent.cacheFoo();
+    }
+
+    @Override
+    public Sub2Component getSub2() {
+      return new Sub2ComponentImpl(this.mRootComponent);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class Sub2ComponentImpl implements Sub2Component {
+      final Yatagan$RootComponent mRootComponent;
+
+      private byte mFeaturesIsEnabled;
+
+      private Sub2ComponentImpl(Yatagan$RootComponent pRootComponent) {
+        this.mRootComponent = pRootComponent;
+      }
+
+      @Override
+      public Foo getFoo() {
+        return this.mRootComponent.cacheFoo();
+      }
+
+      @Override
+      public Optional<FeatureComponent> getOpt() {
+        return this.optOfFeatureComponent();
+      }
+
+      @Override
+      public Sub2Component getS() {
+        return this;
+      }
+
+      Optional optOfFeatureComponent() {
+        return this.featuresIsEnabled() ? Optional.of(new FeatureComponentImpl(this.mRootComponent)) : Optional.empty();
+      }
+
+      boolean featuresIsEnabled() {
+        if (this.mFeaturesIsEnabled == 0x0) {
+          this.mFeaturesIsEnabled = (byte) ((this.mRootComponent.mFeatures.isEnabled()) ? 0x1 : 0x2);
+        }
+        return this.mFeaturesIsEnabled == 0x1;
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class FeatureComponentImpl implements FeatureComponent {
+        final Yatagan$RootComponent mRootComponent;
+
+        private FeatureComponentImpl(Yatagan$RootComponent pRootComponent) {
+          this.mRootComponent = pRootComponent;
+        }
+
+        @Override
+        public Provider<Foo> getFoo() {
+          return new ProviderImpl(this.mRootComponent, 0);
+        }
+
+        @Override
+        public FeatureComponent2 createFeatureComponent2(MyDep dep) {
+          return new FeatureComponent2Impl(dep);
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+        static final class FeatureComponent2Impl implements FeatureComponent2 {
+          final MyDep mMyDep;
+
+          FeatureComponent2Impl(MyDep pDep) {
+            this.mMyDep = Checks.checkInputNotNull(pDep);
+          }
+
+          @Override
+          public MyDep getDep() {
+            return this.mMyDep;
+          }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponent3Impl implements SubComponent3 {
+    final Double mD;
+
+    final MyDep mMyDep;
+
+    final MyModule mMyModule;
+
+    final Yatagan$RootComponent mRootComponent;
+
+    SubComponent3Impl(Yatagan$RootComponent pRootComponent, MyDep pDep, MyModule pMod, Double pD) {
+      this.mRootComponent = pRootComponent;
+      this.mMyDep = Checks.checkInputNotNull(pDep);
+      this.mMyModule = Checks.checkInputNotNull(pMod);
+      this.mD = Checks.checkInputNotNull(pD);
+    }
+
+    @Override
+    public MyDep getD() {
+      return this.mMyDep;
+    }
+
+    @Override
+    public double getD2() {
+      return this.mD;
+    }
+
+    @Override
+    public Foo getFoo() {
+      return this.mRootComponent.cacheFoo();
+    }
+
+    @Override
+    public int getI() {
+      return Checks.checkProvisionNotNull(this.mMyModule.getI());
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$RootComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$RootComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$RootComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$RootComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements RootComponent.Factory {
+    @Override
+    public RootComponent create(Features features) {
+      return new Yatagan$RootComponent(features);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/subcomponents-advanced-case.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/subcomponents-advanced-case.golden-code.txt
@@ -1,0 +1,314 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyApplicationComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyApplicationComponent implements MyApplicationComponent {
+  private Object mMyApplicationControllerImplInstance;
+
+  final String mAppId;
+
+  Yatagan$MyApplicationComponent(String pAppId) {
+    this.mAppId = Checks.checkInputNotNull(pAppId);
+  }
+
+  @Override
+  public MyActivityComponent.Factory getActivityFactory() {
+    return new MyActivityComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessMyApplicationManagerImpl();
+      case 1: return this.mAppId;
+      default: throw new AssertionError();
+    }
+  }
+
+  MyApplicationControllerImpl cacheMyApplicationControllerImpl() {
+    Object local = this.mMyApplicationControllerImplInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyApplicationControllerImpl();
+      this.mMyApplicationControllerImplInstance = local;
+    }
+    return (MyApplicationControllerImpl) local;
+  }
+
+  MyApplicationManagerImpl accessMyApplicationManagerImpl() {
+    return new MyApplicationManagerImpl(this.cacheMyApplicationControllerImpl(), this.mAppId);
+  }
+
+  public static MyApplicationComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyActivityComponentImpl implements MyActivityComponent {
+    final String mId;
+
+    final Yatagan$MyApplicationComponent mMyApplicationComponent;
+
+    MyActivityComponentImpl(Yatagan$MyApplicationComponent pMyApplicationComponent, String pId) {
+      this.mMyApplicationComponent = pMyApplicationComponent;
+      this.mId = Checks.checkInputNotNull(pId);
+    }
+
+    @Override
+    public MyApplicationManager getAppManager() {
+      return this.accessMyApplicationManagerImpl();
+    }
+
+    @Override
+    public Lazy<MyApplicationManager> getAppManagerLazy() {
+      return new CachingProviderImpl(this, 1);
+    }
+
+    @Override
+    public Provider<MyApplicationManager> getAppManagerProvider() {
+      return new ProviderImpl(this, 1);
+    }
+
+    @Override
+    public MyFragmentComponent.Factory getFragmentFactory() {
+      return new MyFragmentComponentImpl.ComponentFactoryImpl(this.mMyApplicationComponent, this);
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.mId;
+        case 1: return this.accessMyApplicationManagerImpl();
+        default: throw new AssertionError();
+      }
+    }
+
+    MyApplicationManagerImpl accessMyApplicationManagerImpl() {
+      return new MyApplicationManagerImpl(this.mMyApplicationComponent.cacheMyApplicationControllerImpl(), this.mMyApplicationComponent.mAppId);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class MyFragmentComponentImpl implements MyFragmentComponent {
+      private Object mFragmentControllerInstance;
+
+      final Yatagan$MyApplicationComponent mMyApplicationComponent;
+
+      final MyActivityComponentImpl mMyActivityComponent;
+
+      MyFragmentComponentImpl(Yatagan$MyApplicationComponent pMyApplicationComponent,
+          MyActivityComponentImpl pMyActivityComponent) {
+        this.mMyApplicationComponent = pMyApplicationComponent;
+        this.mMyActivityComponent = pMyActivityComponent;
+      }
+
+      @Override
+      public MyApplicationManager getAppManager() {
+        return this.accessMyApplicationManagerImpl();
+      }
+
+      @Override
+      public Lazy<MyApplicationManager> getAppManagerLazy() {
+        return new CachingProviderImpl(this, 0);
+      }
+
+      @Override
+      public Provider<MyApplicationManager> getAppManagerProvider() {
+        return new ProviderImpl(this, 0);
+      }
+
+      @Override
+      public FragmentController getFragment() {
+        return this.cacheFragmentController();
+      }
+
+      Object switch$$access(int slot) {
+        switch(slot) {
+          case 0: return this.accessMyApplicationManagerImpl();
+          default: throw new AssertionError();
+        }
+      }
+
+      FragmentController cacheFragmentController() {
+        Object local = this.mFragmentControllerInstance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new FragmentController(new MyActivityController(this.mMyApplicationComponent, new Yatagan$MyApplicationComponent.CachingProviderImpl(this.mMyApplicationComponent, 1), new MyActivityComponentImpl.ProviderImpl(this.mMyActivityComponent, 0)));
+          this.mFragmentControllerInstance = local;
+        }
+        return (FragmentController) local;
+      }
+
+      MyApplicationManagerImpl accessMyApplicationManagerImpl() {
+        return new MyApplicationManagerImpl(this.mMyApplicationComponent.cacheMyApplicationControllerImpl(), this.mMyApplicationComponent.mAppId);
+      }
+
+      static final class ProviderImpl implements Lazy {
+        private final MyFragmentComponentImpl mDelegate;
+
+        private final int mIndex;
+
+        ProviderImpl(MyFragmentComponentImpl delegate, int index) {
+          this.mDelegate = delegate;
+          this.mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          return this.mDelegate.switch$$access(this.mIndex);
+        }
+      }
+
+      private static final class CachingProviderImpl implements Lazy {
+        private final MyFragmentComponentImpl mDelegate;
+
+        private final int mIndex;
+
+        private Object mValue;
+
+        CachingProviderImpl(MyFragmentComponentImpl factory, int index) {
+          mDelegate = factory;
+          mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          Object local = mValue;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = mDelegate.switch$$access(mIndex);
+            mValue = local;
+          }
+          return local;
+        }
+      }
+
+      private static final class ComponentFactoryImpl implements MyFragmentComponent.Factory {
+        Yatagan$MyApplicationComponent fMyApplicationComponent;
+
+        MyActivityComponentImpl fMyActivityComponent;
+
+        ComponentFactoryImpl(Yatagan$MyApplicationComponent fMyApplicationComponent,
+            MyActivityComponentImpl fMyActivityComponent) {
+          this.fMyApplicationComponent = fMyApplicationComponent;
+          this.fMyActivityComponent = fMyActivityComponent;
+        }
+
+        @Override
+        public MyFragmentComponent create() {
+          return new MyFragmentComponentImpl(this.fMyApplicationComponent, this.fMyActivityComponent);
+        }
+      }
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final MyActivityComponentImpl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(MyActivityComponentImpl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final MyActivityComponentImpl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(MyActivityComponentImpl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements MyActivityComponent.Factory {
+      Yatagan$MyApplicationComponent fMyApplicationComponent;
+
+      ComponentFactoryImpl(Yatagan$MyApplicationComponent fMyApplicationComponent) {
+        this.fMyApplicationComponent = fMyApplicationComponent;
+      }
+
+      @Override
+      public MyActivityComponent create(String id) {
+        return new MyActivityComponentImpl(this.fMyApplicationComponent, id);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyApplicationComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyApplicationComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$MyApplicationComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$MyApplicationComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements MyApplicationComponent.Factory {
+    @Override
+    public MyApplicationComponent create(String appId) {
+      return new Yatagan$MyApplicationComponent(appId);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/subcomponents-basic-case.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/subcomponents-basic-case.golden-code.txt
@@ -1,0 +1,161 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyApplicationComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyApplicationComponent implements MyApplicationComponent {
+  Yatagan$MyApplicationComponent() {
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new MyApplicationManagerImpl();
+      default: throw new AssertionError();
+    }
+  }
+
+  public static MyApplicationComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyActivityComponentImpl implements MyActivityComponent {
+    final Yatagan$MyApplicationComponent mMyApplicationComponent;
+
+    MyActivityComponentImpl(Yatagan$MyApplicationComponent pMyApplicationComponent) {
+      this.mMyApplicationComponent = pMyApplicationComponent;
+    }
+
+    @Override
+    public MyApplicationManager getAppManager() {
+      return new MyApplicationManagerImpl();
+    }
+
+    @Override
+    public Lazy<MyApplicationManager> getAppManagerLazy() {
+      return new CachingProviderImpl(this, 0);
+    }
+
+    @Override
+    public Provider<MyApplicationManager> getAppManagerProvider() {
+      return new ProviderImpl(this, 0);
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return new MyApplicationManagerImpl();
+        default: throw new AssertionError();
+      }
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final MyActivityComponentImpl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(MyActivityComponentImpl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final MyActivityComponentImpl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(MyActivityComponentImpl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements MyActivityComponent.Factory {
+      Yatagan$MyApplicationComponent fMyApplicationComponent;
+
+      ComponentFactoryImpl(Yatagan$MyApplicationComponent fMyApplicationComponent) {
+        this.fMyApplicationComponent = fMyApplicationComponent;
+      }
+
+      @Override
+      public MyActivityComponent create() {
+        return new MyActivityComponentImpl(this.fMyApplicationComponent);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyApplicationComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyApplicationComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$MyApplicationComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$MyApplicationComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements MyApplicationComponent.Factory {
+    @Override
+    public MyApplicationComponent create() {
+      return new Yatagan$MyApplicationComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/subcomponents-one-more-advanced-case.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ComponentHierarchyKotlinTest/subcomponents-one-more-advanced-case.golden-code.txt
@@ -1,0 +1,308 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$ApplicationComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$ApplicationComponent implements ApplicationComponent {
+  private Object mSingletonClassInstance;
+
+  private Yatagan$ApplicationComponent() {
+  }
+
+  @Override
+  public MainActivityComponent.Factory getMainActivity() {
+    return new MainActivityComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public SettingsActivityComponent.Factory getSettingsActivity() {
+    return new SettingsActivityComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  SingletonClass cacheSingletonClass() {
+    Object local = this.mSingletonClassInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new SingletonClass();
+      this.mSingletonClassInstance = local;
+    }
+    return (SingletonClass) local;
+  }
+
+  public static AutoBuilder<Yatagan$ApplicationComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MainActivityComponentImpl implements MainActivityComponent {
+    private Object mActivityScopedClassInstance;
+
+    final Yatagan$ApplicationComponent mApplicationComponent;
+
+    MainActivityComponentImpl(Yatagan$ApplicationComponent pApplicationComponent) {
+      this.mApplicationComponent = pApplicationComponent;
+    }
+
+    @Override
+    public CameraFragmentComponent.Factory getCameraFragmentComponent() {
+      return new CameraFragmentComponentImpl.ComponentFactoryImpl(this);
+    }
+
+    @Override
+    public ProfileFragmentComponent.Factory getProfileFragmentComponent() {
+      return new ProfileFragmentComponentImpl.ComponentFactoryImpl(this, this.mApplicationComponent);
+    }
+
+    @Override
+    public RootClass rootClass() {
+      return Checks.checkProvisionNotNull(ApplicationModule.Companion.rootClass());
+    }
+
+    ActivityScopedClass cacheActivityScopedClass() {
+      Object local = this.mActivityScopedClassInstance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new ActivityScopedClass();
+        this.mActivityScopedClassInstance = local;
+      }
+      return (ActivityScopedClass) local;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class CameraFragmentComponentImpl implements CameraFragmentComponent {
+      final MainActivityComponentImpl mMainActivityComponent;
+
+      CameraFragmentComponentImpl(MainActivityComponentImpl pMainActivityComponent) {
+        this.mMainActivityComponent = pMainActivityComponent;
+      }
+
+      @Override
+      public CameraSettings cameraSettings() {
+        return new CameraSettings(new DefaultTheme());
+      }
+
+      private static final class ComponentFactoryImpl implements CameraFragmentComponent.Factory {
+        MainActivityComponentImpl fMainActivityComponent;
+
+        ComponentFactoryImpl(MainActivityComponentImpl fMainActivityComponent) {
+          this.fMainActivityComponent = fMainActivityComponent;
+        }
+
+        @Override
+        public CameraFragmentComponent create() {
+          return new CameraFragmentComponentImpl(this.fMainActivityComponent);
+        }
+      }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class ProfileFragmentComponentImpl implements ProfileFragmentComponent {
+      final MainActivityComponentImpl mMainActivityComponent;
+
+      final Yatagan$ApplicationComponent mApplicationComponent;
+
+      ProfileFragmentComponentImpl(MainActivityComponentImpl pMainActivityComponent,
+          Yatagan$ApplicationComponent pApplicationComponent) {
+        this.mMainActivityComponent = pMainActivityComponent;
+        this.mApplicationComponent = pApplicationComponent;
+      }
+
+      @Override
+      public Activity activity() {
+        return Checks.checkProvisionNotNull(MainActivityModule.INSTANCE.activity());
+      }
+
+      @Override
+      public ActivityScopedClass activityScoped() {
+        return this.mMainActivityComponent.cacheActivityScopedClass();
+      }
+
+      @Override
+      public SingletonClass singleton() {
+        return this.mApplicationComponent.cacheSingletonClass();
+      }
+
+      private static final class ComponentFactoryImpl implements ProfileFragmentComponent.Factory {
+        MainActivityComponentImpl fMainActivityComponent;
+
+        Yatagan$ApplicationComponent fApplicationComponent;
+
+        ComponentFactoryImpl(MainActivityComponentImpl fMainActivityComponent,
+            Yatagan$ApplicationComponent fApplicationComponent) {
+          this.fMainActivityComponent = fMainActivityComponent;
+          this.fApplicationComponent = fApplicationComponent;
+        }
+
+        @Override
+        public ProfileFragmentComponent create() {
+          return new ProfileFragmentComponentImpl(this.fMainActivityComponent, this.fApplicationComponent);
+        }
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements MainActivityComponent.Factory {
+      Yatagan$ApplicationComponent fApplicationComponent;
+
+      ComponentFactoryImpl(Yatagan$ApplicationComponent fApplicationComponent) {
+        this.fApplicationComponent = fApplicationComponent;
+      }
+
+      @Override
+      public MainActivityComponent create() {
+        return new MainActivityComponentImpl(this.fApplicationComponent);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SettingsActivityComponentImpl implements SettingsActivityComponent {
+    private Object mActivityScopedClassInstance;
+
+    final SettingsActivityFragmentModule mSettingsActivityFragmentModule;
+
+    final Yatagan$ApplicationComponent mApplicationComponent;
+
+    SettingsActivityComponentImpl(Yatagan$ApplicationComponent pApplicationComponent,
+        SettingsActivityFragmentModule pSettingsActivityFragmentModule) {
+      this.mApplicationComponent = pApplicationComponent;
+      this.mSettingsActivityFragmentModule = Checks.checkInputNotNull(pSettingsActivityFragmentModule);
+    }
+
+    @Override
+    public ProfileFragmentComponent.Factory getProfileFragmentComponent() {
+      return new ProfileFragmentComponentImpl.ComponentFactoryImpl(this, this.mApplicationComponent);
+    }
+
+    @Override
+    public ProfileSettingsFragmentComponent.Factory getProfileSettingsFragmentComponent() {
+      return new ProfileSettingsFragmentComponentImpl.ComponentFactoryImpl(this);
+    }
+
+    @Override
+    public RootClass rootClass() {
+      return Checks.checkProvisionNotNull(ApplicationModule.Companion.rootClass());
+    }
+
+    ActivityScopedClass cacheActivityScopedClass() {
+      Object local = this.mActivityScopedClassInstance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new ActivityScopedClass();
+        this.mActivityScopedClassInstance = local;
+      }
+      return (ActivityScopedClass) local;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class ProfileSettingsFragmentComponentImpl implements ProfileSettingsFragmentComponent {
+      final SettingsActivityComponentImpl mSettingsActivityComponent;
+
+      ProfileSettingsFragmentComponentImpl(
+          SettingsActivityComponentImpl pSettingsActivityComponent) {
+        this.mSettingsActivityComponent = pSettingsActivityComponent;
+      }
+
+      @Override
+      public CameraSettings cameraSettings() {
+        return new CameraSettings(new DarkTheme());
+      }
+
+      private static final class ComponentFactoryImpl implements ProfileSettingsFragmentComponent.Factory {
+        SettingsActivityComponentImpl fSettingsActivityComponent;
+
+        ComponentFactoryImpl(SettingsActivityComponentImpl fSettingsActivityComponent) {
+          this.fSettingsActivityComponent = fSettingsActivityComponent;
+        }
+
+        @Override
+        public ProfileSettingsFragmentComponent create() {
+          return new ProfileSettingsFragmentComponentImpl(this.fSettingsActivityComponent);
+        }
+      }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class ProfileFragmentComponentImpl implements ProfileFragmentComponent {
+      final SettingsActivityComponentImpl mSettingsActivityComponent;
+
+      final Yatagan$ApplicationComponent mApplicationComponent;
+
+      ProfileFragmentComponentImpl(SettingsActivityComponentImpl pSettingsActivityComponent,
+          Yatagan$ApplicationComponent pApplicationComponent) {
+        this.mSettingsActivityComponent = pSettingsActivityComponent;
+        this.mApplicationComponent = pApplicationComponent;
+      }
+
+      @Override
+      public Activity activity() {
+        return Checks.checkProvisionNotNull(this.mSettingsActivityComponent.mSettingsActivityFragmentModule.activity());
+      }
+
+      @Override
+      public ActivityScopedClass activityScoped() {
+        return this.mSettingsActivityComponent.cacheActivityScopedClass();
+      }
+
+      @Override
+      public SingletonClass singleton() {
+        return this.mApplicationComponent.cacheSingletonClass();
+      }
+
+      private static final class ComponentFactoryImpl implements ProfileFragmentComponent.Factory {
+        SettingsActivityComponentImpl fSettingsActivityComponent;
+
+        Yatagan$ApplicationComponent fApplicationComponent;
+
+        ComponentFactoryImpl(SettingsActivityComponentImpl fSettingsActivityComponent,
+            Yatagan$ApplicationComponent fApplicationComponent) {
+          this.fSettingsActivityComponent = fSettingsActivityComponent;
+          this.fApplicationComponent = fApplicationComponent;
+        }
+
+        @Override
+        public ProfileFragmentComponent create() {
+          return new ProfileFragmentComponentImpl(this.fSettingsActivityComponent, this.fApplicationComponent);
+        }
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements SettingsActivityComponent.Factory {
+      Yatagan$ApplicationComponent fApplicationComponent;
+
+      ComponentFactoryImpl(Yatagan$ApplicationComponent fApplicationComponent) {
+        this.fApplicationComponent = fApplicationComponent;
+      }
+
+      @Override
+      public SettingsActivityComponent create(
+          SettingsActivityFragmentModule settingsActivityFragmentModule) {
+        return new SettingsActivityComponentImpl(this.fApplicationComponent, settingsActivityFragmentModule);
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$ApplicationComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$ApplicationComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$ApplicationComponent create() {
+      return new Yatagan$ApplicationComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/-Binds-with-multiple-alternatives.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/-Binds-with-multiple-alternatives.golden-code.txt
@@ -1,0 +1,246 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mJavaxInjectNamedValueV4SomeApiInstance;
+
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Optional<SomeApi> getApiV1() {
+    return this.optOfImplA();
+  }
+
+  @Override
+  public Optional<Lazy<SomeApi>> getApiV1Lazy() {
+    return this.optOfTestImplA();
+  }
+
+  @Override
+  public Optional<Provider<SomeApi>> getApiV1Provider() {
+    return this.optOfTestImplA1();
+  }
+
+  @Override
+  public Optional<SomeApi> getApiV2() {
+    return this.optOfJavaxInjectNamedValueV2SomeApi();
+  }
+
+  @Override
+  public Optional<Lazy<SomeApi>> getApiV2Lazy() {
+    return this.optOfJavaxInjectNamedValueV2TestSomeApi();
+  }
+
+  @Override
+  public Optional<Provider<SomeApi>> getApiV2Provider() {
+    return this.optOfJavaxInjectNamedValueV2TestSomeApi1();
+  }
+
+  @Override
+  public Optional<SomeApi> getApiV3() {
+    return this.optOfJavaxInjectNamedValueV3SomeApi();
+  }
+
+  @Override
+  public Optional<Lazy<SomeApi>> getApiV3Lazy() {
+    return this.optOfJavaxInjectNamedValueV3TestSomeApi();
+  }
+
+  @Override
+  public Optional<Provider<SomeApi>> getApiV3Provider() {
+    return this.optOfJavaxInjectNamedValueV3TestSomeApi1();
+  }
+
+  @Override
+  public Optional<SomeApi> getApiV4() {
+    return this.optOfJavaxInjectNamedValueV4SomeApi();
+  }
+
+  @Override
+  public Optional<Lazy<SomeApi>> getApiV4Lazy() {
+    return this.optOfJavaxInjectNamedValueV4TestSomeApi();
+  }
+
+  @Override
+  public Optional<Provider<SomeApi>> getApiV4Provider() {
+    return this.optOfJavaxInjectNamedValueV4TestSomeApi1();
+  }
+
+  @Override
+  public Optional<Provider<SomeApi>> getApiV5Provider() {
+    return this.optOfJavaxInjectNamedValueV5TestSomeApi();
+  }
+
+  @Override
+  public Optional<SomeApiBase> getBase() {
+    return this.optOfSomeApiBase();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new ImplA();
+      case 1: return this.accessJavaxInjectNamedValueV2SomeApi();
+      case 2: return this.accessJavaxInjectNamedValueV3SomeApi();
+      case 3: return this.cacheJavaxInjectNamedValueV4SomeApi();
+      case 4: return this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? this.cacheJavaxInjectNamedValueV4SomeApi() : this.cacheJavaxInjectNamedValueV4SomeApi();
+      default: throw new AssertionError();
+    }
+  }
+
+  Optional optOfJavaxInjectNamedValueV5SomeApi() {
+    return this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? Optional.of(this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? this.cacheJavaxInjectNamedValueV4SomeApi() : this.cacheJavaxInjectNamedValueV4SomeApi()) : Optional.empty();
+  }
+
+  Optional optOfJavaxInjectNamedValueV5TestSomeApi() {
+    return this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? Optional.of(new ProviderImpl(this, 4)) : Optional.empty();
+  }
+
+  Optional optOfSomeApiBase() {
+    return this.mFeaturesFooBar || this.mFeaturesIsEnabledB || this.mFeaturesFooBar ? Optional.of(this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? this.cacheJavaxInjectNamedValueV4SomeApi() : new BaseImpl()) : Optional.empty();
+  }
+
+  SomeApi accessJavaxInjectNamedValueV2SomeApi() {
+    return this.mFeaturesFooBar ? new ImplA() : new Stub();
+  }
+
+  Optional optOfJavaxInjectNamedValueV2SomeApi() {
+    return Optional.of(this.accessJavaxInjectNamedValueV2SomeApi());
+  }
+
+  Optional optOfJavaxInjectNamedValueV2TestSomeApi() {
+    return Optional.of(new CachingProviderImpl(this, 1));
+  }
+
+  Optional optOfJavaxInjectNamedValueV2TestSomeApi1() {
+    return Optional.of(new ProviderImpl(this, 1));
+  }
+
+  SomeApi accessJavaxInjectNamedValueV3SomeApi() {
+    return this.mFeaturesFooBar ? new ImplA() : this.mFeaturesIsEnabledB ? new ImplB() : new Stub();
+  }
+
+  Optional optOfJavaxInjectNamedValueV3SomeApi() {
+    return Optional.of(this.accessJavaxInjectNamedValueV3SomeApi());
+  }
+
+  Optional optOfJavaxInjectNamedValueV3TestSomeApi() {
+    return Optional.of(new CachingProviderImpl(this, 2));
+  }
+
+  Optional optOfJavaxInjectNamedValueV3TestSomeApi1() {
+    return Optional.of(new ProviderImpl(this, 2));
+  }
+
+  SomeApi cacheJavaxInjectNamedValueV4SomeApi() {
+    Object local = this.mJavaxInjectNamedValueV4SomeApiInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = this.mFeaturesFooBar ? new ImplA() : new ImplB();
+      this.mJavaxInjectNamedValueV4SomeApiInstance = local;
+    }
+    return (SomeApi) local;
+  }
+
+  Optional optOfJavaxInjectNamedValueV4SomeApi() {
+    return this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? Optional.of(this.cacheJavaxInjectNamedValueV4SomeApi()) : Optional.empty();
+  }
+
+  Optional optOfJavaxInjectNamedValueV4TestSomeApi() {
+    return this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? Optional.of(new ProviderImpl(this, 3)) : Optional.empty();
+  }
+
+  Optional optOfJavaxInjectNamedValueV4TestSomeApi1() {
+    return this.mFeaturesFooBar || this.mFeaturesIsEnabledB ? Optional.of(new ProviderImpl(this, 3)) : Optional.empty();
+  }
+
+  Optional optOfImplA() {
+    return this.mFeaturesFooBar ? Optional.of(new ImplA()) : Optional.empty();
+  }
+
+  Optional optOfTestImplA() {
+    return this.mFeaturesFooBar ? Optional.of(new CachingProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  Optional optOfTestImplA1() {
+    return this.mFeaturesFooBar ? Optional.of(new ProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/assisted-factory-under-conditions.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/assisted-factory-under-conditions.golden-code.txt
@@ -1,0 +1,54 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  private Yatagan$MyComponent() {
+  }
+
+  @Override
+  public Optional<MyClassBFactory> getF() {
+    return this.optOfMyClassBFactory();
+  }
+
+  Optional optOfMyClassBFactory() {
+    return this.mFeaturesFooBar ? Optional.of(this.new MyClassBFactoryImpl()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private final class MyClassBFactoryImpl implements MyClassBFactory {
+    @Override
+    public MyClassB create(int i) {
+      return new MyClassB(i, new MyClassA());
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/complex-condition-expression.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/complex-condition-expression.golden-code.txt
@@ -1,0 +1,158 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  private byte mFeaturesIsEnabledB;
+
+  private byte mFeaturesGetFeatureC_isEnabled;
+
+  private byte mSomeClassConditions_getSomeCondition1;
+
+  private byte mSomeClassSomeCondition2;
+
+  private byte mSomeClassGetSomeCondition3;
+
+  private byte mSomeClassGetSomeCondition4;
+
+  private byte mSomeClassSomeCondition5;
+
+  private byte mSomeClassSomeCondition6;
+
+  private byte mSomeClassConditions_getSomeCondition6;
+
+  private Yatagan$MyComponent() {
+  }
+
+  @Override
+  public Optional<ClassA> getA() {
+    return this.optOfClassA();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessClassA();
+      default: throw new AssertionError();
+    }
+  }
+
+  ClassA accessClassA() {
+    return new ClassA(new ClassB(new ProviderImpl(this, 0)));
+  }
+
+  Optional optOfClassA() {
+    return this.mFeaturesFooBar && this.featuresIsEnabledB() && (this.featuresGetFeatureC_isEnabled() || this.featuresIsEnabledB() || this.someClassConditions_getSomeCondition1() || this.someClassSomeCondition2() || this.someClassGetSomeCondition3() || this.someClassGetSomeCondition4() || this.someClassSomeCondition5() || this.someClassSomeCondition6() || this.someClassConditions_getSomeCondition6()) ? Optional.of(this.accessClassA()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  boolean featuresIsEnabledB() {
+    if (this.mFeaturesIsEnabledB == 0x0) {
+      this.mFeaturesIsEnabledB = (byte) ((Features.isEnabledB()) ? 0x1 : 0x2);
+    }
+    return this.mFeaturesIsEnabledB == 0x1;
+  }
+
+  boolean featuresGetFeatureC_isEnabled() {
+    if (this.mFeaturesGetFeatureC_isEnabled == 0x0) {
+      this.mFeaturesGetFeatureC_isEnabled = (byte) ((Features.getFeatureC().isEnabled()) ? 0x1 : 0x2);
+    }
+    return this.mFeaturesGetFeatureC_isEnabled == 0x1;
+  }
+
+  boolean someClassConditions_getSomeCondition1() {
+    if (this.mSomeClassConditions_getSomeCondition1 == 0x0) {
+      this.mSomeClassConditions_getSomeCondition1 = (byte) ((SomeClass.Conditions.getSomeCondition1()) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassConditions_getSomeCondition1 == 0x1;
+  }
+
+  boolean someClassSomeCondition2() {
+    if (this.mSomeClassSomeCondition2 == 0x0) {
+      this.mSomeClassSomeCondition2 = (byte) ((SomeClass.someCondition2) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassSomeCondition2 == 0x1;
+  }
+
+  boolean someClassGetSomeCondition3() {
+    if (this.mSomeClassGetSomeCondition3 == 0x0) {
+      this.mSomeClassGetSomeCondition3 = (byte) ((SomeClass.getSomeCondition3()) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassGetSomeCondition3 == 0x1;
+  }
+
+  boolean someClassGetSomeCondition4() {
+    if (this.mSomeClassGetSomeCondition4 == 0x0) {
+      this.mSomeClassGetSomeCondition4 = (byte) ((SomeClass.getSomeCondition4()) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassGetSomeCondition4 == 0x1;
+  }
+
+  boolean someClassSomeCondition5() {
+    if (this.mSomeClassSomeCondition5 == 0x0) {
+      this.mSomeClassSomeCondition5 = (byte) ((SomeClass.someCondition5()) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassSomeCondition5 == 0x1;
+  }
+
+  boolean someClassSomeCondition6() {
+    if (this.mSomeClassSomeCondition6 == 0x0) {
+      this.mSomeClassSomeCondition6 = (byte) ((SomeClass.someCondition6) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassSomeCondition6 == 0x1;
+  }
+
+  boolean someClassConditions_getSomeCondition6() {
+    if (this.mSomeClassConditions_getSomeCondition6 == 0x0) {
+      this.mSomeClassConditions_getSomeCondition6 = (byte) ((SomeClass.Conditions.getSomeCondition6()) ? 0x1 : 0x2);
+    }
+    return this.mSomeClassConditions_getSomeCondition6 == 0x1;
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/condition-expressions-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/condition-expressions-test.golden-code.txt
@@ -1,0 +1,121 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+  private byte mFeaturesGetFeatureC_isEnabled;
+
+  private byte mHelperGetA;
+
+  private byte mC3Companion_c1CompanionEnabled;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Optional<ClassA> getA() {
+    return this.optOfClassA();
+  }
+
+  @Override
+  public Optional<ClassB> getB() {
+    return this.optOfClassB();
+  }
+
+  @Override
+  public Optional<ClassC> getC() {
+    return this.optOfClassC();
+  }
+
+  @Override
+  public Optional<ClassD> getD() {
+    return this.optOfClassD();
+  }
+
+  @Override
+  public Optional<ClassE> getE() {
+    return this.optOfClassE();
+  }
+
+  @Override
+  public Optional<ClassF> getF() {
+    return this.optOfClassF();
+  }
+
+  Optional optOfClassA() {
+    return (this.mFeaturesFooBar && this.mFeaturesIsEnabledB || this.featuresGetFeatureC_isEnabled()) && this.mFeaturesFooBar ? Optional.of(new ClassA()) : Optional.empty();
+  }
+
+  Optional optOfClassB() {
+    return this.mFeaturesFooBar && !(this.mFeaturesIsEnabledB || !this.featuresGetFeatureC_isEnabled()) ? Optional.of(new ClassB()) : Optional.empty();
+  }
+
+  Optional optOfClassC() {
+    return this.mFeaturesFooBar || !this.helperGetA() ? Optional.of(new ClassC()) : Optional.empty();
+  }
+
+  Optional optOfClassD() {
+    return this.mFeaturesIsEnabledB && !(this.mFeaturesFooBar || !this.helperGetA()) || this.mFeaturesFooBar && !(this.mFeaturesIsEnabledB || !this.featuresGetFeatureC_isEnabled()) && this.c3Companion_c1CompanionEnabled() ? Optional.of(new ClassD()) : Optional.empty();
+  }
+
+  Optional optOfClassE() {
+    return this.mFeaturesIsEnabledB && !(this.mFeaturesFooBar || !this.helperGetA()) || this.mFeaturesFooBar && !(this.mFeaturesIsEnabledB || !this.featuresGetFeatureC_isEnabled()) && this.c3Companion_c1CompanionEnabled() ? Optional.of(new ClassE()) : Optional.empty();
+  }
+
+  Optional optOfClassF() {
+    return this.mFeaturesIsEnabledB || (this.mFeaturesFooBar || !this.helperGetA()) && !this.mFeaturesFooBar && this.mFeaturesFooBar ? Optional.of(new ClassF()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  boolean featuresGetFeatureC_isEnabled() {
+    if (this.mFeaturesGetFeatureC_isEnabled == 0x0) {
+      this.mFeaturesGetFeatureC_isEnabled = (byte) ((Features.getFeatureC().isEnabled()) ? 0x1 : 0x2);
+    }
+    return this.mFeaturesGetFeatureC_isEnabled == 0x1;
+  }
+
+  boolean helperGetA() {
+    if (this.mHelperGetA == 0x0) {
+      this.mHelperGetA = (byte) ((new Helper().getA()) ? 0x1 : 0x2);
+    }
+    return this.mHelperGetA == 0x1;
+  }
+
+  boolean c3Companion_c1CompanionEnabled() {
+    if (this.mC3Companion_c1CompanionEnabled == 0x0) {
+      this.mC3Companion_c1CompanionEnabled = (byte) ((C3.Companion.c1CompanionEnabled()) ? 0x1 : 0x2);
+    }
+    return this.mC3Companion_c1CompanionEnabled == 0x1;
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/conditional-provide-basic-case.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/conditional-provide-basic-case.golden-code.txt
@@ -1,0 +1,197 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestMainComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestMainComponent implements TestMainComponent {
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  private Yatagan$TestMainComponent() {
+  }
+
+  @Override
+  public Optional<Api> getApi() {
+    return this.optOfApi();
+  }
+
+  @Override
+  public Optional<Lazy<Api>> getApiLazy() {
+    return this.optOfTestApi();
+  }
+
+  @Override
+  public Optional<Api> getNamedApi() {
+    return this.optOfJavaxInjectNamedValueApi();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.INSTANCE.provideApi());
+      default: throw new AssertionError();
+    }
+  }
+
+  Optional optOfApi() {
+    return this.mFeaturesFooBar ? Optional.of(Checks.checkProvisionNotNull(MyModule.INSTANCE.provideApi())) : Optional.empty();
+  }
+
+  Optional optOfTestApi() {
+    return this.mFeaturesFooBar ? Optional.of(new CachingProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  Optional optOfJavaxInjectNamedValueApi() {
+    return Optional.of(Checks.checkProvisionNotNull(MyModule.INSTANCE.provideNamedApi()));
+  }
+
+  public static AutoBuilder<Yatagan$TestMainComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestMainComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestMainComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestMainComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestMainComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestMainComponent create() {
+      return new Yatagan$TestMainComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestCustomComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestCustomComponent implements TestCustomComponent {
+  final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+  private Yatagan$TestCustomComponent() {
+  }
+
+  @Override
+  public Optional<Api> getApi() {
+    return this.optOfApi();
+  }
+
+  @Override
+  public Optional<Lazy<Api>> getApiLazy() {
+    return this.optOfTestApi();
+  }
+
+  @Override
+  public Optional<Api> getNamedApi() {
+    return Optional.empty();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.INSTANCE.provideApi());
+      default: throw new AssertionError();
+    }
+  }
+
+  Optional optOfApi() {
+    return this.mFeaturesIsEnabledB ? Optional.of(Checks.checkProvisionNotNull(MyModule.INSTANCE.provideApi())) : Optional.empty();
+  }
+
+  Optional optOfTestApi() {
+    return this.mFeaturesIsEnabledB ? Optional.of(new CachingProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestCustomComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestCustomComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestCustomComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestCustomComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestCustomComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestCustomComponent create() {
+      return new Yatagan$TestCustomComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/conditions-in-component-hierarchy.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/conditions-in-component-hierarchy.golden-code.txt
@@ -1,0 +1,89 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Optional<ClassA> getA() {
+    return this.optOfClassA();
+  }
+
+  @Override
+  public TestSubComponent.Factory getSub() {
+    return new TestSubComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  Optional optOfClassA() {
+    return this.mFeaturesFooBar ? Optional.of(new ClassA()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class TestSubComponentImpl implements TestSubComponent {
+    final Yatagan$TestComponent mTestComponent;
+
+    final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+    TestSubComponentImpl(Yatagan$TestComponent pTestComponent) {
+      this.mTestComponent = pTestComponent;
+    }
+
+    @Override
+    public Optional<ClassB> getB() {
+      return this.optOfClassB();
+    }
+
+    Optional optOfClassA() {
+      return this.mTestComponent.mFeaturesFooBar ? Optional.of(new ClassA()) : Optional.empty();
+    }
+
+    Optional optOfClassB() {
+      return this.mFeaturesIsEnabledB ? Optional.of(new ClassB(this.optOfClassA())) : Optional.empty();
+    }
+
+    private static final class ComponentFactoryImpl implements TestSubComponent.Factory {
+      Yatagan$TestComponent fTestComponent;
+
+      ComponentFactoryImpl(Yatagan$TestComponent fTestComponent) {
+        this.fTestComponent = fTestComponent;
+      }
+
+      @Override
+      public TestSubComponent create() {
+        return new TestSubComponentImpl(this.fTestComponent);
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/conditions-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/conditions-test.golden-code.txt
@@ -1,0 +1,98 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mMyClassInstance;
+
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Optional<MyClass> getOpt() {
+    return this.optOfMyClass();
+  }
+
+  @Override
+  public Optional<Provider<MyClass>> getProvider() {
+    return this.optOfTestMyClass();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheMyClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  MyClass cacheMyClass() {
+    Object local = this.mMyClassInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClass(new ClassA(), new ClassB());
+      this.mMyClassInstance = local;
+    }
+    return (MyClass) local;
+  }
+
+  Optional optOfMyClass() {
+    return this.mFeaturesFooBar && this.mFeaturesIsEnabledB ? Optional.of(this.cacheMyClass()) : Optional.empty();
+  }
+
+  Optional optOfTestMyClass() {
+    return this.mFeaturesFooBar && this.mFeaturesIsEnabledB ? Optional.of(new ProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/const-val-conditions.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/const-val-conditions.golden-code.txt
@@ -1,0 +1,65 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final boolean mCompiledConditionHELLO = CompiledCondition.HELLO;
+
+  private byte mConstantsIS_ENABLED;
+
+  private byte mCompiledConditionKtFOO;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Optional<TestClass> getTest() {
+    return this.optOfTestClass();
+  }
+
+  Optional optOfTestClass() {
+    return this.mCompiledConditionHELLO && this.constantsIS_ENABLED() && this.compiledConditionKtFOO() ? Optional.of(new TestClass()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  boolean constantsIS_ENABLED() {
+    if (this.mConstantsIS_ENABLED == 0x0) {
+      this.mConstantsIS_ENABLED = (byte) ((Constants.IS_ENABLED) ? 0x1 : 0x2);
+    }
+    return this.mConstantsIS_ENABLED == 0x1;
+  }
+
+  boolean compiledConditionKtFOO() {
+    if (this.mCompiledConditionKtFOO == 0x0) {
+      this.mCompiledConditionKtFOO = (byte) ((CompiledConditionKt.FOO) ? 0x1 : 0x2);
+    }
+    return this.mCompiledConditionKtFOO == 0x1;
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/flavor-based-alternative-binding-in-component-hierarchy.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/flavor-based-alternative-binding-in-component-hierarchy.golden-code.txt
@@ -1,0 +1,299 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyBrowserComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyBrowserComponent implements MyBrowserComponent {
+  private Yatagan$MyBrowserComponent() {
+  }
+
+  @Override
+  public MyApiComponent.Factory getApiC() {
+    return new MyApiComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessApi();
+      default: throw new AssertionError();
+    }
+  }
+
+  Api accessApi() {
+    return new ImplA();
+  }
+
+  Optional optOfApi() {
+    return Optional.of(this.accessApi());
+  }
+
+  Optional optOfTestApi() {
+    return Optional.of(new ProviderImpl(this, 0));
+  }
+
+  public static AutoBuilder<Yatagan$MyBrowserComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyApiComponentImpl implements MyApiComponent {
+    final Yatagan$MyBrowserComponent mMyBrowserComponent;
+
+    MyApiComponentImpl(Yatagan$MyBrowserComponent pMyBrowserComponent) {
+      this.mMyBrowserComponent = pMyBrowserComponent;
+    }
+
+    @Override
+    public Optional<Api> getApi() {
+      return this.mMyBrowserComponent.optOfApi();
+    }
+
+    @Override
+    public Optional<Provider<Api>> getApiProvider() {
+      return this.mMyBrowserComponent.optOfTestApi();
+    }
+
+    private static final class ComponentFactoryImpl implements MyApiComponent.Factory {
+      Yatagan$MyBrowserComponent fMyBrowserComponent;
+
+      ComponentFactoryImpl(Yatagan$MyBrowserComponent fMyBrowserComponent) {
+        this.fMyBrowserComponent = fMyBrowserComponent;
+      }
+
+      @Override
+      public MyApiComponent create() {
+        return new MyApiComponentImpl(this.fMyBrowserComponent);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyBrowserComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyBrowserComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyBrowserComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyBrowserComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyBrowserComponent create() {
+      return new Yatagan$MyBrowserComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MySearchAppComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MySearchAppComponent implements MySearchAppComponent {
+  private Yatagan$MySearchAppComponent() {
+  }
+
+  @Override
+  public MyApiComponent.Factory getApiC() {
+    return new MyApiComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessApi();
+      default: throw new AssertionError();
+    }
+  }
+
+  Api accessApi() {
+    return new ImplB();
+  }
+
+  Optional optOfApi() {
+    return Optional.of(this.accessApi());
+  }
+
+  Optional optOfTestApi() {
+    return Optional.of(new ProviderImpl(this, 0));
+  }
+
+  public static AutoBuilder<Yatagan$MySearchAppComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyApiComponentImpl implements MyApiComponent {
+    final Yatagan$MySearchAppComponent mMySearchAppComponent;
+
+    MyApiComponentImpl(Yatagan$MySearchAppComponent pMySearchAppComponent) {
+      this.mMySearchAppComponent = pMySearchAppComponent;
+    }
+
+    @Override
+    public Optional<Api> getApi() {
+      return this.mMySearchAppComponent.optOfApi();
+    }
+
+    @Override
+    public Optional<Provider<Api>> getApiProvider() {
+      return this.mMySearchAppComponent.optOfTestApi();
+    }
+
+    private static final class ComponentFactoryImpl implements MyApiComponent.Factory {
+      Yatagan$MySearchAppComponent fMySearchAppComponent;
+
+      ComponentFactoryImpl(Yatagan$MySearchAppComponent fMySearchAppComponent) {
+        this.fMySearchAppComponent = fMySearchAppComponent;
+      }
+
+      @Override
+      public MyApiComponent create() {
+        return new MyApiComponentImpl(this.fMySearchAppComponent);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MySearchAppComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MySearchAppComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MySearchAppComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MySearchAppComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MySearchAppComponent create() {
+      return new Yatagan$MySearchAppComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyProductComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyProductComponent implements MyProductComponent {
+  private Yatagan$MyProductComponent() {
+  }
+
+  @Override
+  public MyApiComponent.Factory getApiC() {
+    return new MyApiComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  public static AutoBuilder<Yatagan$MyProductComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyApiComponentImpl implements MyApiComponent {
+    final Yatagan$MyProductComponent mMyProductComponent;
+
+    MyApiComponentImpl(Yatagan$MyProductComponent pMyProductComponent) {
+      this.mMyProductComponent = pMyProductComponent;
+    }
+
+    @Override
+    public Optional<Api> getApi() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Provider<Api>> getApiProvider() {
+      return Optional.empty();
+    }
+
+    private static final class ComponentFactoryImpl implements MyApiComponent.Factory {
+      Yatagan$MyProductComponent fMyProductComponent;
+
+      ComponentFactoryImpl(Yatagan$MyProductComponent fMyProductComponent) {
+        this.fMyProductComponent = fMyProductComponent;
+      }
+
+      @Override
+      public MyApiComponent create() {
+        return new MyApiComponentImpl(this.fMyProductComponent);
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyProductComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyProductComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyProductComponent create() {
+      return new Yatagan$MyProductComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/flavors-inheritance-in-component-hierarchy.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/flavors-inheritance-in-component-hierarchy.golden-code.txt
@@ -1,0 +1,129 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyBrowserComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyBrowserComponent implements MyBrowserComponent {
+  private Yatagan$MyBrowserComponent() {
+  }
+
+  @Override
+  public MyComponent.Factory getMyC() {
+    return new MyComponentImpl.ComponentFactoryImpl();
+  }
+
+  public static AutoBuilder<Yatagan$MyBrowserComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyComponentImpl implements MyComponent {
+    MyComponentImpl() {
+    }
+
+    @Override
+    public Optional<Impl> getImpl() {
+      return this.optOfImpl();
+    }
+
+    Optional optOfImpl() {
+      return Optional.of(new Impl());
+    }
+
+    private static final class ComponentFactoryImpl implements MyComponent.Factory {
+      ComponentFactoryImpl() {
+      }
+
+      @Override
+      public MyComponent create() {
+        return new MyComponentImpl();
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyBrowserComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyBrowserComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyBrowserComponent create() {
+      return new Yatagan$MyBrowserComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MySearchAppComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MySearchAppComponent implements MySearchAppComponent {
+  private Yatagan$MySearchAppComponent() {
+  }
+
+  @Override
+  public MyComponent.Factory getMyC() {
+    return new MyComponentImpl.ComponentFactoryImpl();
+  }
+
+  public static AutoBuilder<Yatagan$MySearchAppComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyComponentImpl implements MyComponent {
+    MyComponentImpl() {
+    }
+
+    @Override
+    public Optional<Impl> getImpl() {
+      return Optional.empty();
+    }
+
+    private static final class ComponentFactoryImpl implements MyComponent.Factory {
+      ComponentFactoryImpl() {
+      }
+
+      @Override
+      public MyComponent create() {
+        return new MyComponentImpl();
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MySearchAppComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MySearchAppComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MySearchAppComponent create() {
+      return new Yatagan$MySearchAppComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/flavors-test-ruled-out-variant-binding-requested-as-optional.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/flavors-test-ruled-out-variant-binding-requested-as-optional.golden-code.txt
@@ -1,0 +1,101 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestPhoneComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestPhoneComponent implements TestPhoneComponent {
+  private Yatagan$TestPhoneComponent() {
+  }
+
+  @Override
+  public Optional<MyPhoneSpecificClass> getPhone() {
+    return this.optOfMyPhoneSpecificClass();
+  }
+
+  @Override
+  public Optional<MyTabletSpecificClass> getTablet() {
+    return Optional.empty();
+  }
+
+  Optional optOfMyPhoneSpecificClass() {
+    return Optional.of(new MyPhoneSpecificClass());
+  }
+
+  public static AutoBuilder<Yatagan$TestPhoneComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestPhoneComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestPhoneComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestPhoneComponent create() {
+      return new Yatagan$TestPhoneComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestTabletComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestTabletComponent implements TestTabletComponent {
+  private Yatagan$TestTabletComponent() {
+  }
+
+  @Override
+  public Optional<MyPhoneSpecificClass> getPhone() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<MyTabletSpecificClass> getTablet() {
+    return this.optOfMyTabletSpecificClass();
+  }
+
+  Optional optOfMyTabletSpecificClass() {
+    return Optional.of(new MyTabletSpecificClass());
+  }
+
+  public static AutoBuilder<Yatagan$TestTabletComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestTabletComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestTabletComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestTabletComponent create() {
+      return new Yatagan$TestTabletComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/flavors-test-subcomponents-under-feature.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/flavors-test-subcomponents-under-feature.golden-code.txt
@@ -1,0 +1,105 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestPhoneComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestPhoneComponent implements TestPhoneComponent {
+  private Yatagan$TestPhoneComponent() {
+  }
+
+  @Override
+  public Optional<MyFeatureActivityComponent.Factory> getMyFeatureActivity() {
+    return Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestPhoneComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestPhoneComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestPhoneComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestPhoneComponent create() {
+      return new Yatagan$TestPhoneComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestTabletComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestTabletComponent implements TestTabletComponent {
+  final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+  private Yatagan$TestTabletComponent() {
+  }
+
+  @Override
+  public Optional<MyFeatureActivityComponent.Factory> getMyFeatureActivity() {
+    return this.optOfMyFeatureActivityComponentFactory();
+  }
+
+  Optional optOfMyFeatureActivityComponentFactory() {
+    return this.mFeaturesIsEnabledB ? Optional.of(new MyFeatureActivityComponentImpl.ComponentFactoryImpl()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestTabletComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class MyFeatureActivityComponentImpl implements MyFeatureActivityComponent {
+    MyFeatureActivityComponentImpl() {
+    }
+
+    private static final class ComponentFactoryImpl implements MyFeatureActivityComponent.Factory {
+      ComponentFactoryImpl() {
+      }
+
+      @Override
+      public MyFeatureActivityComponent create() {
+        return new MyFeatureActivityComponentImpl();
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestTabletComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestTabletComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestTabletComponent create() {
+      return new Yatagan$TestTabletComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/flavors-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/flavors-test.golden-code.txt
@@ -1,0 +1,177 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestPhoneComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestPhoneComponent implements TestPhoneComponent {
+  final boolean mFeaturesFooBar = Features.fooBar();
+
+  private Yatagan$TestPhoneComponent() {
+  }
+
+  @Override
+  public Optional<MyClass> getDirect() {
+    return this.optOfMyClass();
+  }
+
+  @Override
+  public Optional<MyClass> getOpt() {
+    return this.optOfMyClass();
+  }
+
+  @Override
+  public Optional<Provider<MyClass>> getProvider() {
+    return this.optOfTestMyClass();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new MyClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  Optional optOfMyClass() {
+    return this.mFeaturesFooBar ? Optional.of(new MyClass()) : Optional.empty();
+  }
+
+  Optional optOfTestMyClass() {
+    return this.mFeaturesFooBar ? Optional.of(new ProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestPhoneComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestPhoneComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestPhoneComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestPhoneComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestPhoneComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestPhoneComponent create() {
+      return new Yatagan$TestPhoneComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestTabletComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestTabletComponent implements TestTabletComponent {
+  final boolean mFeaturesIsEnabledB = Features.isEnabledB();
+
+  private Yatagan$TestTabletComponent() {
+  }
+
+  @Override
+  public Optional<MyClass> getDirect() {
+    return this.optOfMyClass();
+  }
+
+  @Override
+  public Optional<MyClass> getOpt() {
+    return this.optOfMyClass();
+  }
+
+  @Override
+  public Optional<Provider<MyClass>> getProvider() {
+    return this.optOfTestMyClass();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new MyClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  Optional optOfMyClass() {
+    return this.mFeaturesIsEnabledB ? Optional.of(new MyClass()) : Optional.empty();
+  }
+
+  Optional optOfTestMyClass() {
+    return this.mFeaturesIsEnabledB ? Optional.of(new ProviderImpl(this, 0)) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$TestTabletComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestTabletComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestTabletComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestTabletComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestTabletComponent> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestTabletComponent create() {
+      return new Yatagan$TestTabletComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/lazy-condition-evaluation.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/lazy-condition-evaluation.golden-code.txt
@@ -1,0 +1,76 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final boolean mFeaturesINSTANCE_getDisabled = Features.INSTANCE.getDisabled();
+
+  private byte mFeaturesINSTANCE_getNotReached;
+
+  final boolean mFeaturesINSTANCE_getDisabled2 = Features.INSTANCE.getDisabled2();
+
+  private byte mFeaturesINSTANCE_getNotReached2;
+
+  private Yatagan$MyComponent() {
+  }
+
+  @Override
+  public Optional<ClassA> getA() {
+    return this.optOfClassA();
+  }
+
+  @Override
+  public Optional<ClassB> getB() {
+    return this.optOfClassB();
+  }
+
+  Optional optOfClassA() {
+    return this.mFeaturesINSTANCE_getDisabled && this.featuresINSTANCE_getNotReached() ? Optional.of(new ClassA()) : Optional.empty();
+  }
+
+  Optional optOfClassB() {
+    return this.mFeaturesINSTANCE_getDisabled2 && this.featuresINSTANCE_getNotReached2() ? Optional.of(new ClassB()) : Optional.empty();
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  boolean featuresINSTANCE_getNotReached() {
+    if (this.mFeaturesINSTANCE_getNotReached == 0x0) {
+      this.mFeaturesINSTANCE_getNotReached = (byte) ((Features.INSTANCE.getNotReached()) ? 0x1 : 0x2);
+    }
+    return this.mFeaturesINSTANCE_getNotReached == 0x1;
+  }
+
+  boolean featuresINSTANCE_getNotReached2() {
+    if (this.mFeaturesINSTANCE_getNotReached2 == 0x0) {
+      this.mFeaturesINSTANCE_getNotReached2 = (byte) ((Features.INSTANCE.getNotReached2()) ? 0x1 : 0x2);
+    }
+    return this.mFeaturesINSTANCE_getNotReached2 == 0x1;
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ConditionsTest/non-static-conditions.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ConditionsTest/non-static-conditions.golden-code.txt
@@ -1,0 +1,125 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mFeatureProvider3Instance;
+
+  final FeatureProvider mFeatures;
+
+  private byte mFeatureProviderIsEnabledA;
+
+  private byte mFeatureProviderIsEnabledB;
+
+  private byte mFeatureProviderIsEnabledC;
+
+  private byte mFeatureProvider2IsEnabledD;
+
+  private byte mF3IsEnabledE;
+
+  Yatagan$TestComponent(FeatureProvider pFeatures) {
+    this.mFeatures = Checks.checkInputNotNull(pFeatures);
+  }
+
+  @Override
+  public Optional<ClassA> getA() {
+    return this.optOfClassA();
+  }
+
+  @Override
+  public Optional<ClassB> getB() {
+    return this.optOfClassB();
+  }
+
+  @Override
+  public Optional<ClassC> getC() {
+    return this.optOfClassC();
+  }
+
+  @Override
+  public Optional<FeatureProvider3> getF3() {
+    return this.optOfFeatureProvider3();
+  }
+
+  Optional optOfClassA() {
+    return this.featureProviderIsEnabledA() ? Optional.of(new ClassA()) : Optional.empty();
+  }
+
+  Optional optOfClassB() {
+    return this.featureProviderIsEnabledA() && this.featureProviderIsEnabledB() ? Optional.of(new ClassB(this.optOfClassC(), new ClassA())) : Optional.empty();
+  }
+
+  Optional optOfClassC() {
+    return this.featureProviderIsEnabledC() && this.featureProvider2IsEnabledD() && this.f3IsEnabledE() ? Optional.of(new ClassC()) : Optional.empty();
+  }
+
+  FeatureProvider3 cacheFeatureProvider3() {
+    Object local = this.mFeatureProvider3Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new FeatureProvider3();
+      this.mFeatureProvider3Instance = local;
+    }
+    return (FeatureProvider3) local;
+  }
+
+  Optional optOfFeatureProvider3() {
+    return this.featureProviderIsEnabledC() ? Optional.of(this.cacheFeatureProvider3()) : Optional.empty();
+  }
+
+  public static TestComponent.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  boolean featureProviderIsEnabledA() {
+    if (this.mFeatureProviderIsEnabledA == 0x0) {
+      this.mFeatureProviderIsEnabledA = (byte) ((this.mFeatures.isEnabledA()) ? 0x1 : 0x2);
+    }
+    return this.mFeatureProviderIsEnabledA == 0x1;
+  }
+
+  boolean featureProviderIsEnabledB() {
+    if (this.mFeatureProviderIsEnabledB == 0x0) {
+      this.mFeatureProviderIsEnabledB = (byte) ((this.mFeatures.isEnabledB()) ? 0x1 : 0x2);
+    }
+    return this.mFeatureProviderIsEnabledB == 0x1;
+  }
+
+  boolean featureProviderIsEnabledC() {
+    if (this.mFeatureProviderIsEnabledC == 0x0) {
+      this.mFeatureProviderIsEnabledC = (byte) ((this.mFeatures.isEnabledC()) ? 0x1 : 0x2);
+    }
+    return this.mFeatureProviderIsEnabledC == 0x1;
+  }
+
+  boolean featureProvider2IsEnabledD() {
+    if (this.mFeatureProvider2IsEnabledD == 0x0) {
+      this.mFeatureProvider2IsEnabledD = (byte) ((new FeatureProvider2().isEnabledD()) ? 0x1 : 0x2);
+    }
+    return this.mFeatureProvider2IsEnabledD == 0x1;
+  }
+
+  boolean f3IsEnabledE() {
+    if (this.mF3IsEnabledE == 0x0) {
+      this.mF3IsEnabledE = (byte) ((this.cacheFeatureProvider3().isEnabledE()) ? 0x1 : 0x2);
+    }
+    return this.mF3IsEnabledE == 0x1;
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Builder {
+    @Override
+    public TestComponent create(FeatureProvider features) {
+      return new Yatagan$TestComponent(features);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/rebind-scope-is-forbidden.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/rebind-scope-is-forbidden.golden-code.txt
@@ -1,0 +1,41 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Number;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Number getNumber() {
+    return Checks.checkProvisionNotNull(TestModule.Companion.integer());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/advanced-member-inject.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/advanced-member-inject.golden-code.txt
@@ -1,0 +1,70 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final Integer mArg;
+
+  final MyModule mMyModule;
+
+  Yatagan$TestComponent(MyModule pModule, Integer pArg) {
+    this.mMyModule = Checks.checkInputNotNull(pModule);
+    this.mArg = Checks.checkInputNotNull(pArg);
+  }
+
+  @Override
+  public void inject(Derived d) {
+    d.apiProp = Checks.checkProvisionNotNull(this.mMyModule.a());
+    d.baseLateInitProp = Checks.checkProvisionNotNull(this.mMyModule.a());
+    d.baseLateInitPropK = Checks.checkProvisionNotNull(this.mMyModule.b());
+    d.javaBaseField = new ProviderImpl(this, 0);
+    d.javaBaseField2 = this.mArg;
+    d.setLateInitProp(Checks.checkProvisionNotNull(this.mMyModule.a()));
+    d.setLateInitPropK(Checks.checkProvisionNotNull(this.mMyModule.c()));
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.mArg;
+      default: throw new AssertionError();
+    }
+  }
+
+  public static TestComponent.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Creator {
+    @Override
+    public TestComponent create(MyModule module, int arg) {
+      return new Yatagan$TestComponent(module, arg);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Module-instance.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Module-instance.golden-code.txt
@@ -1,0 +1,96 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final MyModule mMyModule;
+
+  Yatagan$TestComponent(MyModule pModule) {
+    this.mMyModule = Checks.checkInputNotNull(pModule);
+  }
+
+  @Override
+  public Api get() {
+    return Checks.checkProvisionNotNull(this.mMyModule.provides());
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(this.mMyModule.provides());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static TestComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Factory {
+    @Override
+    public TestComponent create(MyModule module) {
+      return new Yatagan$TestComponent(module);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Module-object.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Module-object.golden-code.txt
@@ -1,0 +1,118 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.provides());
+  }
+
+  @Override
+  public ExplicitImpl getExplicit() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesExplicit());
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Lazy<ExplicitImpl> getLazyExplicit() {
+    return new CachingProviderImpl(this, 1);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<ExplicitImpl> getProviderExplicit() {
+    return new ProviderImpl(this, 1);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.INSTANCE.provides());
+      case 1: return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesExplicit());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Module-with-companion-object.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Module-with-companion-object.golden-code.txt
@@ -1,0 +1,118 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return Checks.checkProvisionNotNull(MyModule.Companion.provides());
+  }
+
+  @Override
+  public ExplicitImpl getExplicit() {
+    return Checks.checkProvisionNotNull(MyModule.providesExplicit());
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Lazy<ExplicitImpl> getLazyExplicit() {
+    return new CachingProviderImpl(this, 1);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<ExplicitImpl> getProviderExplicit() {
+    return new ProviderImpl(this, 1);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.Companion.provides());
+      case 1: return Checks.checkProvisionNotNull(MyModule.providesExplicit());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Provides-property.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Provides-property.golden-code.txt
@@ -1,0 +1,102 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api api() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.getApi());
+  }
+
+  @Override
+  public Lazy<Api> lazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> provider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.INSTANCE.getApi());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Provides-with-dependencies-in-companion.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-Provides-with-dependencies-in-companion.golden-code.txt
@@ -1,0 +1,102 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return Checks.checkProvisionNotNull(MyModule.Companion.get());
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.Companion.get());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-consume-Lazy-wildcard-type-test-.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-consume-Lazy-wildcard-type-test-.golden-code.txt
@@ -1,0 +1,81 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Object b() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.classB(new CachingProviderImpl(this, 1)));
+  }
+
+  @Override
+  public ClassA get() {
+    return new ClassA(new CachingProviderImpl(this, 0));
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new ClassB();
+      case 1: return Checks.checkProvisionNotNull(MyModule.INSTANCE.classC());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-nested-component-class.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-nested-component-class.golden-code.txt
@@ -1,0 +1,60 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TopLevelClass$Component2.java
+package test;
+
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TopLevelClass$Component2 implements TopLevelClass.Component2 {
+  Yatagan$TopLevelClass$Component2() {
+  }
+
+  public static TopLevelClass.Component2.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements TopLevelClass.Component2.Builder {
+    @Override
+    public TopLevelClass.Component2 c() {
+      return new Yatagan$TopLevelClass$Component2();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TopLevelClass$NestedClass$Component1.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TopLevelClass$NestedClass$Component1 implements TopLevelClass.NestedClass.Component1 {
+  private Yatagan$TopLevelClass$NestedClass$Component1() {
+  }
+
+  public static AutoBuilder<Yatagan$TopLevelClass$NestedClass$Component1> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TopLevelClass$NestedClass$Component1> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TopLevelClass$NestedClass$Component1> provideInput(I input,
+        Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TopLevelClass$NestedClass$Component1 create() {
+      return new Yatagan$TopLevelClass$NestedClass$Component1();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-properties-as-entry-points.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-properties-as-entry-points.golden-code.txt
@@ -1,0 +1,102 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api getApi() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.api());
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.INSTANCE.api());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-provide-Any.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-provide-Any.golden-code.txt
@@ -1,0 +1,41 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Object get() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.provides());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-provide-array-type.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-provide-array-type.golden-code.txt
@@ -1,0 +1,131 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Double;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Consumer<Double> getC() {
+    return new Consumer(Checks.checkProvisionNotNull(MyModule.INSTANCE.providesIntArray()), new ProviderImpl(this, 0), Checks.checkProvisionNotNull(MyModule.INSTANCE.providesDoubleArray()), new ProviderImpl(this, 1), Checks.checkProvisionNotNull(MyModule.INSTANCE.providesStringArray()), new ProviderImpl(this, 2));
+  }
+
+  @Override
+  public Double[] getDouble2() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesDoubleArray());
+  }
+
+  @Override
+  public Provider<Double[]> getDoubleProvider() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public int[] getInt2() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesIntArray());
+  }
+
+  @Override
+  public Lazy<int[]> getIntLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<int[]> getIntProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public String[] getString2() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesStringArray());
+  }
+
+  @Override
+  public Provider<String[]> getStringProvider() {
+    return new ProviderImpl(this, 2);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesIntArray());
+      case 1: return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesDoubleArray());
+      case 2: return Checks.checkProvisionNotNull(MyModule.INSTANCE.providesStringArray());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-provide-list-of-strings.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-provide-list-of-strings.golden-code.txt
@@ -1,0 +1,42 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import java.util.List;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public List<String> get() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.provides());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-universal-builder-support-variance-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-universal-builder-support-variance-test.golden-code.txt
@@ -1,0 +1,121 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Set;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final Consumer<? super Foo> mFooConsumer;
+
+  final Consumer<? super Baz> mBazConsumer;
+
+  final Object mObj;
+
+  final Object mSetBar;
+
+  final Set<Baz> mSetBazs;
+
+  final Object mSetFoo;
+
+  final Set<Bar> mSetSetOfBar;
+
+  final Set<? extends Foo> mSetSetOfFoo;
+
+  final Dependency mDependency;
+
+  Yatagan$TestComponent(Dependency pDep, Consumer<? super Foo> pFooConsumer,
+      Consumer<? super Baz> pBazConsumer, Object pObj, Object pSetBar, Set<Baz> pSetBazs,
+      Object pSetFoo, Set<Bar> pSetSetOfBar, Set<? extends Foo> pSetSetOfFoo) {
+    this.mDependency = Checks.checkInputNotNull(pDep);
+    this.mFooConsumer = Checks.checkInputNotNull(pFooConsumer);
+    this.mBazConsumer = Checks.checkInputNotNull(pBazConsumer);
+    this.mObj = Checks.checkInputNotNull(pObj);
+    this.mSetBar = Checks.checkInputNotNull(pSetBar);
+    this.mSetBazs = Checks.checkInputNotNull(pSetBazs);
+    this.mSetFoo = Checks.checkInputNotNull(pSetFoo);
+    this.mSetSetOfBar = Checks.checkInputNotNull(pSetSetOfBar);
+    this.mSetSetOfFoo = Checks.checkInputNotNull(pSetSetOfFoo);
+  }
+
+  @Override
+  public MyClass get() {
+    return new MyClass(this.mSetFoo, this.mSetBar, this.mObj, this.mSetSetOfFoo, this.mSetBazs, this.mSetSetOfBar, this.mFooConsumer, this.mBazConsumer, this.mDependency.getWrapper());
+  }
+
+  @Override
+  public Set<Bar> getBars() {
+    return this.mSetSetOfBar;
+  }
+
+  @Override
+  public Set<Bar> getBars2() {
+    return this.mSetSetOfBar;
+  }
+
+  @Override
+  public Set<Baz> getBazs() {
+    return this.mSetBazs;
+  }
+
+  @Override
+  public Set<? extends Foo> getFoos() {
+    return this.mSetSetOfFoo;
+  }
+
+  public static TestComponent.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Creator {
+    private Object mSetBar;
+
+    private Set<Baz> mSetBazs;
+
+    private Object mSetFoo;
+
+    private Set<Bar> mSetSetOfBar;
+
+    private Set<? extends Foo> mSetSetOfFoo;
+
+    @Override
+    public TestComponent.Creator setBar(Object obj) {
+      this.mSetBar = obj;
+      return this;
+    }
+
+    @Override
+    public void setBazs(Set<Baz> bazs) {
+      this.mSetBazs = bazs;
+    }
+
+    @Override
+    public CreatorBase setFoo(Object obj) {
+      this.mSetFoo = obj;
+      return this;
+    }
+
+    @Override
+    public TestComponent.Creator setSetOfBar(Set<Bar> bars) {
+      this.mSetSetOfBar = bars;
+      return this;
+    }
+
+    @Override
+    public void setSetOfFoo(Set<? extends Foo> foos) {
+      this.mSetSetOfFoo = foos;
+    }
+
+    @Override
+    public TestComponent create(Dependency dep, Consumer<? super Foo> fooConsumer,
+        Consumer<? super Baz> bazConsumer, Object obj) {
+      return new Yatagan$TestComponent(dep, fooConsumer, bazConsumer, obj, this.mSetBar, this.mSetBazs, this.mSetFoo, this.mSetSetOfBar, this.mSetSetOfFoo);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-with-factory-BindsInstance.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-component-with-factory-BindsInstance.golden-code.txt
@@ -1,0 +1,96 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final MyClass mInstance;
+
+  Yatagan$TestComponent(MyClass pInstance) {
+    this.mInstance = Checks.checkInputNotNull(pInstance);
+  }
+
+  @Override
+  public MyClass get() {
+    return this.mInstance;
+  }
+
+  @Override
+  public Lazy<MyClass> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<MyClass> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.mInstance;
+      default: throw new AssertionError();
+    }
+  }
+
+  public static TestComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Factory {
+    @Override
+    public TestComponent create(MyClass instance) {
+      return new Yatagan$TestComponent(instance);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-members-inject.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/basic-members-inject.golden-code.txt
@@ -1,0 +1,96 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mClassAInstance;
+
+  private Object mClassBInstance;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public void injectFoo(Foo foo) {
+    foo.bye = new ProviderImpl(this, 0);
+    foo.setA(this.cacheClassA());
+    foo.setB(this.cacheClassB());
+    foo.setBye2(new ProviderImpl(this, 0));
+    foo.setHelloA(new ProviderImpl(this, 1));
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheClassB();
+      case 1: return this.cacheClassA();
+      default: throw new AssertionError();
+    }
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA();
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  ClassB cacheClassB() {
+    Object local = this.mClassBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassB();
+      this.mClassBInstance = local;
+    }
+    return (ClassB) local;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/complex-annotation-as-qualifier-in-java.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/complex-annotation-as-qualifier-in-java.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return new ClassA(Checks.checkProvisionNotNull(MyModule.any()));
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/complex-annotation-as-qualifier.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/complex-annotation-as-qualifier.golden-code.txt
@@ -1,0 +1,49 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Arrays;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final MyModule mMyModule;
+
+  private Yatagan$TestComponent(MyModule pMyModule) {
+    this.mMyModule = pMyModule != null ? pMyModule : new MyModule();
+  }
+
+  @Override
+  public ClassA getA() {
+    return new ClassA(Checks.checkProvisionNotNull(this.mMyModule.getAny()));
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    private MyModule mMyModule;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == MyModule.class) {
+        this.mMyModule = (MyModule) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(MyModule.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent(this.mMyModule);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/trivially-constructable-module.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/trivially-constructable-module.golden-code.txt
@@ -1,0 +1,84 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Arrays;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final MyModule mMyModule;
+
+  private Yatagan$MyComponent(MyModule pMyModule) {
+    this.mMyModule = pMyModule != null ? pMyModule : new MyModule();
+  }
+
+  @Override
+  public Object get() {
+    return Checks.checkProvisionNotNull(this.mMyModule.provides());
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    private MyModule mMyModule;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == MyModule.class) {
+        this.mMyModule = (MyModule) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(MyModule.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent(this.mMyModule);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent2.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent2 implements MyComponent2 {
+  final MyModule mMyModule;
+
+  Yatagan$MyComponent2() {
+    this.mMyModule = new MyModule();
+  }
+
+  @Override
+  public Object get() {
+    return Checks.checkProvisionNotNull(this.mMyModule.provides());
+  }
+
+  public static MyComponent2.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements MyComponent2.Factory {
+    @Override
+    public MyComponent2 build() {
+      return new Yatagan$MyComponent2();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/type-variables-in-inject-constructor.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsKotlinTest/type-variables-in-inject-constructor.golden-code.txt
@@ -1,0 +1,78 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  private Yatagan$MyComponent() {
+  }
+
+  @Override
+  public Optional<Object> getAny() {
+    return Optional.empty();
+  }
+
+  @Override
+  public SomeClass<DependencyA> getClazz() {
+    return new SomeClass(new DependencyA());
+  }
+
+  @Override
+  public Provider<SomeClass<DependencyB<DependencyA>>> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new SomeClass(new DependencyB(new DependencyA()));
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/-Binds-alias-is-allowed-to-be-duplicated.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/-Binds-alias-is-allowed-to-be-duplicated.golden-code.txt
@@ -1,0 +1,57 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public SubComponent createSub() {
+    return new SubComponentImpl();
+  }
+
+  @Override
+  public Object getObj() {
+    return new TestClass();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponentImpl implements SubComponent {
+    private SubComponentImpl() {
+    }
+
+    @Override
+    public Object getObj() {
+      return new TestClass();
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/assisted-inject-in-subcomponents.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/assisted-inject-in-subcomponents.golden-code.txt
@@ -1,0 +1,170 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$RootComponent.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$RootComponent implements RootComponent {
+  private Object mClassBInstance;
+
+  final Dep mDep;
+
+  final RootModule mRootModule;
+
+  Yatagan$RootComponent(Dep pDep) {
+    this.mDep = Checks.checkInputNotNull(pDep);
+    this.mRootModule = new RootModule();
+  }
+
+  @Override
+  public SubComponent.Creator getSub() {
+    return new SubComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheClassB();
+      default: throw new AssertionError();
+    }
+  }
+
+  ClassB cacheClassB() {
+    Object local = this.mClassBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassB();
+      this.mClassBInstance = local;
+    }
+    return (ClassB) local;
+  }
+
+  public static RootComponent.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponentImpl implements SubComponent {
+    private Object mClassAInstance;
+
+    final Yatagan$RootComponent mRootComponent;
+
+    SubComponentImpl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public FooFactory getFactory() {
+      return this.new FooFactoryImpl();
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.cacheClassA();
+        case 1: return new ClassC();
+        default: throw new AssertionError();
+      }
+    }
+
+    ClassA cacheClassA() {
+      Object local = this.mClassAInstance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new ClassA(new Yatagan$RootComponent.ProviderImpl(this.mRootComponent, 0), new CachingProviderImpl(this, 1));
+        this.mClassAInstance = local;
+      }
+      return (ClassA) local;
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final SubComponentImpl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(SubComponentImpl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final SubComponentImpl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(SubComponentImpl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private final class FooFactoryImpl implements FooFactory {
+      @Override
+      public Foo create(int number) {
+        return new Foo(new ProviderImpl(SubComponentImpl.this, 0), SubComponentImpl.this.mRootComponent.mDep, SubComponentImpl.this.mRootComponent.mDep.getInput(), Checks.checkProvisionNotNull(SubComponentImpl.this.mRootComponent.mRootModule.provide(SubComponentImpl.this.mRootComponent.mDep)), number);
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent.Creator {
+      Yatagan$RootComponent fRootComponent;
+
+      ComponentFactoryImpl(Yatagan$RootComponent fRootComponent) {
+        this.fRootComponent = fRootComponent;
+      }
+
+      @Override
+      public SubComponent create() {
+        return new SubComponentImpl(this.fRootComponent);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$RootComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$RootComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements RootComponent.Creator {
+    @Override
+    public RootComponent create(Dep dep) {
+      return new Yatagan$RootComponent(dep);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-assisted-inject.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-assisted-inject.golden-code.txt
@@ -1,0 +1,90 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mScopedDepInstance;
+
+  final String mString;
+
+  Yatagan$TestComponent(String pString) {
+    this.mString = Checks.checkInputNotNull(pString);
+  }
+
+  @Override
+  public FooFactory fooFactory() {
+    return this.new FooFactoryImpl();
+  }
+
+  ScopedDep cacheScopedDep() {
+    Object local = this.mScopedDepInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ScopedDep();
+      this.mScopedDepInstance = local;
+    }
+    return (ScopedDep) local;
+  }
+
+  public static TestComponent.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponentImpl implements SubComponent {
+    final Yatagan$TestComponent mTestComponent;
+
+    SubComponentImpl(Yatagan$TestComponent pTestComponent) {
+      this.mTestComponent = pTestComponent;
+    }
+
+    @Override
+    public FooFactory fooFactory() {
+      return this.mTestComponent.new FooFactoryImpl();
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent.Builder {
+      Yatagan$TestComponent fTestComponent;
+
+      ComponentFactoryImpl(Yatagan$TestComponent fTestComponent) {
+        this.fTestComponent = fTestComponent;
+      }
+
+      @Override
+      public SubComponent create() {
+        return new SubComponentImpl(this.fTestComponent);
+      }
+    }
+  }
+
+  private final class FooFactoryImpl implements FooFactory {
+    @Override
+    public Foo createFoo(int count1, int count2, String value) {
+      return new Foo(Yatagan$TestComponent.this.cacheScopedDep(), new UnscopedDep(), Yatagan$TestComponent.this.mString, count2, Yatagan$TestComponent.this.new BarFactoryImpl(), count1, value);
+    }
+  }
+
+  private final class BarFactoryImpl implements BarFactory {
+    @Override
+    public Bar buildBar(int count2, int count1, String value) {
+      return new Bar(count1, count2, value);
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Factory {
+    @Override
+    public TestComponent create(String string) {
+      return new Yatagan$TestComponent(string);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-Provides-with-dependencies.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-Provides-with-dependencies.golden-code.txt
@@ -1,0 +1,119 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mMyScopedClassInstance;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return this.accessApi();
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessApi();
+      case 1: return this.cacheMyScopedClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  Api accessApi() {
+    return Checks.checkProvisionNotNull(MyModule.provides(new ProviderImpl(this, 1), new MySimpleClass(this.cacheMyScopedClass())));
+  }
+
+  MyScopedClass cacheMyScopedClass() {
+    Object local = this.mMyScopedClassInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyScopedClass();
+      this.mMyScopedClassInstance = local;
+    }
+    return (MyScopedClass) local;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-add-imports-to-generated-component.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-add-imports-to-generated-component.golden-code.txt
@@ -1,0 +1,41 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import utils.MySimpleClass;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyProvider get() {
+    return new MyProvider(new MySimpleClass());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-convert-class-to-primitive-type.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-convert-class-to-primitive-type.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public int get() {
+    return Checks.checkProvisionNotNull(MyModule.provides());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-cyclic-reference-with-Provider-edge.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-cyclic-reference-with-Provider-edge.golden-code.txt
@@ -1,0 +1,70 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyClassA get() {
+    return this.accessMyClassA();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessMyClassA();
+      default: throw new AssertionError();
+    }
+  }
+
+  MyClassA accessMyClassA() {
+    return new MyClassA(new MyClassB(new ProviderImpl(this, 0)));
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-direct-Provider-and-Lazy-entry-points.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-direct-Provider-and-Lazy-entry-points.golden-code.txt
@@ -1,0 +1,134 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mMyScopedClassInstance;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyScopedClass getMyScopedClass() {
+    return this.cacheMyScopedClass();
+  }
+
+  @Override
+  public Lazy<MyScopedClass> getMyScopedClassLazy() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Provider<MyScopedClass> getMyScopedClassProvider() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public MySimpleClass getMySimpleClass() {
+    return this.accessMySimpleClass();
+  }
+
+  @Override
+  public Lazy<MySimpleClass> getMySimpleClassLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<MySimpleClass> getMySimpleClassProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessMySimpleClass();
+      case 1: return this.cacheMyScopedClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  MyScopedClass cacheMyScopedClass() {
+    Object local = this.mMyScopedClassInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyScopedClass();
+      this.mMyScopedClassInstance = local;
+    }
+    return (MyScopedClass) local;
+  }
+
+  MySimpleClass accessMySimpleClass() {
+    return new MySimpleClass(this.cacheMyScopedClass());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-module-includes-inherited-methods.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-module-includes-inherited-methods.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return new Impl();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-provide-Object.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-provide-Object.golden-code.txt
@@ -1,0 +1,41 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Object get() {
+    return Checks.checkProvisionNotNull(MyModule.provides());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-provide-array-type.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-provide-array-type.golden-code.txt
@@ -1,0 +1,136 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Double;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Consumer<Double> c() {
+    return new Consumer(Checks.checkProvisionNotNull(MyModule.providesIntArray()), new ProviderImpl(this, 0), Checks.checkProvisionNotNull(MyModule.providesDoubleArray()), new ProviderImpl(this, 1), Checks.checkProvisionNotNull(MyModule.providesStringArray()), new ProviderImpl(this, 2));
+  }
+
+  @Override
+  public Double[] getDouble() {
+    return Checks.checkProvisionNotNull(MyModule.providesDoubleArray());
+  }
+
+  @Override
+  public Provider<Double[]> getDoubleProvider() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public int[] getInt() {
+    return Checks.checkProvisionNotNull(MyModule.providesIntArray());
+  }
+
+  @Override
+  public Lazy<int[]> getIntLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<int[]> getIntProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public String[] getString() {
+    return Checks.checkProvisionNotNull(MyModule.providesStringArray());
+  }
+
+  @Override
+  public Lazy<String[]> getStringLazy() {
+    return new CachingProviderImpl(this, 2);
+  }
+
+  @Override
+  public Provider<String[]> getStringProvider() {
+    return new ProviderImpl(this, 2);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.providesIntArray());
+      case 1: return Checks.checkProvisionNotNull(MyModule.providesDoubleArray());
+      case 2: return Checks.checkProvisionNotNull(MyModule.providesStringArray());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-provide-primitive-type.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-provide-primitive-type.golden-code.txt
@@ -1,0 +1,103 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public int get() {
+    return Checks.checkProvisionNotNull(MyModule.provides());
+  }
+
+  @Override
+  public Lazy<Integer> getIntLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Integer> getIntProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.provides());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-simple-Binds.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-simple-Binds.golden-code.txt
@@ -1,0 +1,102 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return new Impl();
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return new Impl();
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-simple-Provides.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-component-simple-Provides.golden-code.txt
@@ -1,0 +1,102 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Api get() {
+    return Checks.checkProvisionNotNull(MyModule.provides());
+  }
+
+  @Override
+  public Lazy<Api> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<Api> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.provides());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-members-inject.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/basic-members-inject.golden-code.txt
@@ -1,0 +1,42 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public void injectFoo(Foo foo) {
+    foo.helloA = new ClassA();
+    foo.setClassA(new ClassA());
+    foo.setClassB(new ClassB());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/component-inherits-the-same-method-from-multiple-interfaces.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/component-inherits-the-same-method-from-multiple-interfaces.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  private Yatagan$MyComponent() {
+  }
+
+  @Override
+  public ClassA classA() {
+    return new ClassA();
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/creator-inputs-are-null-checked.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/creator-inputs-are-null-checked.golden-code.txt
@@ -1,0 +1,76 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Character;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final Integer mI1;
+
+  final Long mI2;
+
+  final Character mSetChar;
+
+  final Double mSetDouble;
+
+  Yatagan$MyComponent(Integer pI1, Long pI2, Character pSetChar, Double pSetDouble) {
+    this.mI1 = Checks.checkInputNotNull(pI1);
+    this.mI2 = Checks.checkInputNotNull(pI2);
+    this.mSetChar = Checks.checkInputNotNull(pSetChar);
+    this.mSetDouble = Checks.checkInputNotNull(pSetDouble);
+  }
+
+  @Override
+  public char getChar() {
+    return this.mSetChar;
+  }
+
+  @Override
+  public double getDouble() {
+    return this.mSetDouble;
+  }
+
+  @Override
+  public int getInt() {
+    return this.mI1;
+  }
+
+  @Override
+  public long getLong() {
+    return this.mI2;
+  }
+
+  public static MyComponent.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements MyComponent.Builder {
+    private Character mSetChar;
+
+    private Double mSetDouble;
+
+    @Override
+    public void setChar(char c) {
+      this.mSetChar = c;
+    }
+
+    @Override
+    public void setDouble(Double d) {
+      this.mSetDouble = d;
+    }
+
+    @Override
+    public MyComponent create(int i1, long i2) {
+      return new Yatagan$MyComponent(i1, i2, this.mSetChar, this.mSetDouble);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/java-component-declaration-with-builder-and-nested-dependency.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/java-component-declaration-with-builder-and-nested-dependency.golden-code.txt
@@ -1,0 +1,29 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final TestComponent.Dependency mTestComponentDependency;
+
+  Yatagan$TestComponent(TestComponent.Dependency pDep) {
+    this.mTestComponentDependency = Checks.checkInputNotNull(pDep);
+  }
+
+  public static TestComponent.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements TestComponent.Builder {
+    @Override
+    public TestComponent create(TestComponent.Dependency dep) {
+      return new Yatagan$TestComponent(dep);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/java-component-interface-extends-kotlin-one-with-properties.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/java-component-interface-extends-kotlin-one-with-properties.golden-code.txt
@@ -1,0 +1,41 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import mod.SomeClass;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public SomeClass getSomeClass() {
+    return new SomeClass();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/multiple-scopes.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/multiple-scopes.golden-code.txt
@@ -1,0 +1,160 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponentA.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponentA implements MyComponentA {
+  private Object mClassAInstance;
+
+  private Yatagan$MyComponentA() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return this.cacheClassA();
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA();
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  public static AutoBuilder<Yatagan$MyComponentA> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponentA> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponentA> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponentA create() {
+      return new Yatagan$MyComponentA();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponentB.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponentB implements MyComponentB {
+  private Object mClassAInstance;
+
+  private Yatagan$MyComponentB() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return this.cacheClassA();
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA();
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  public static AutoBuilder<Yatagan$MyComponentB> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponentB> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponentB> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponentB create() {
+      return new Yatagan$MyComponentB();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponentC.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponentC implements MyComponentC {
+  private Object mClassAInstance;
+
+  private Yatagan$MyComponentC() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return this.cacheClassA();
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA();
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  public static AutoBuilder<Yatagan$MyComponentC> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponentC> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponentC> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponentC create() {
+      return new Yatagan$MyComponentC();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/provision-results-are-null-checked.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/provision-results-are-null-checked.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public int getInteger() {
+    return Checks.checkProvisionNotNull(MyModule.provideNullInt());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/trivially-constructable-module.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/trivially-constructable-module.golden-code.txt
@@ -1,0 +1,50 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Arrays;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  final MyModule mMyModule;
+
+  private Yatagan$MyComponent(MyModule pMyModule) {
+    this.mMyModule = pMyModule != null ? pMyModule : new MyModule();
+  }
+
+  @Override
+  public Object get() {
+    return Checks.checkProvisionNotNull(this.mMyModule.provides());
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    private MyModule mMyModule;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == MyModule.class) {
+        this.mMyModule = (MyModule) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(MyModule.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent(this.mMyModule);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/CoreBindingsTest/type-parameters-and-multi-bindings.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsTest/type-parameters-and-multi-bindings.golden-code.txt
@@ -1,0 +1,119 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  private Object mCollectionDeferredMySpecificDeferredEventInstance;
+
+  private Object mMyClass2Instance;
+
+  private Yatagan$MyComponent() {
+  }
+
+  @Override
+  public List<Deferred<? extends MySpecificDeferredEvent>> deferred() {
+    return this.accessListDeferredMySpecificDeferredEvent();
+  }
+
+  @Override
+  public Provider<List<Deferred<? extends MySpecificDeferredEvent>>> deferredProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessListDeferredMySpecificDeferredEvent();
+      case 1: return new MyClass1();
+      case 2: return this.cacheMyClass2();
+      case 3: return new MyClass3();
+      default: throw new AssertionError();
+    }
+  }
+
+  Collection<Deferred<? extends MySpecificDeferredEvent>> cacheCollectionDeferredMySpecificDeferredEvent(
+      ) {
+    Object local = this.mCollectionDeferredMySpecificDeferredEventInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(MyModule.collection1());
+      this.mCollectionDeferredMySpecificDeferredEventInstance = local;
+    }
+    return (Collection<Deferred<? extends MySpecificDeferredEvent>>) local;
+  }
+
+  MyClass2 cacheMyClass2() {
+    Object local = this.mMyClass2Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClass2();
+      this.mMyClass2Instance = local;
+    }
+    return (MyClass2) local;
+  }
+
+  List<Deferred<? extends MySpecificDeferredEvent>> accessListDeferredMySpecificDeferredEvent() {
+    return this.manyOfListDeferredMySpecificDeferredEvent();
+  }
+
+  List<Deferred<? extends MySpecificDeferredEvent>> manyOfListDeferredMySpecificDeferredEvent() {
+    final List<Deferred<? extends MySpecificDeferredEvent>> c = new ArrayList<>(7);
+    c.addAll(this.cacheCollectionDeferredMySpecificDeferredEvent());
+    c.addAll(Checks.checkProvisionNotNull(MyModule.collection2()));
+    c.add(Checks.checkProvisionNotNull(MyModule.foo5(new ProviderImpl(this, 3))));
+    c.add(new Deferred(new ProviderImpl(this, 1)));
+    c.add(new Deferred(new ProviderImpl(this, 2)));
+    c.add(new Deferred(new ProviderImpl(this, 3)));
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$MyComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MyComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyComponent create() {
+      return new Yatagan$MyComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/GenericClassesTest/a-few-simple-parameterized-classes.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/GenericClassesTest/a-few-simple-parameterized-classes.golden-code.txt
@@ -1,0 +1,85 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Boolean;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyClass<Boolean> getBool() {
+    return Checks.checkProvisionNotNull(MyModule.getMyClassBool());
+  }
+
+  @Override
+  public MyClass<Integer> getInt() {
+    return Checks.checkProvisionNotNull(MyModule.getMyClassInt());
+  }
+
+  @Override
+  public Provider<MyClass<Boolean>> getProviderBool() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Provider<MyClass<Integer>> getProviderInt() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.getMyClassInt());
+      case 1: return Checks.checkProvisionNotNull(MyModule.getMyClassBool());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/GenericClassesTest/generic-is-parametrized.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/GenericClassesTest/generic-is-parametrized.golden-code.txt
@@ -1,0 +1,84 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyClass<MySecondClass<Object>> getObj() {
+    return Checks.checkProvisionNotNull(MyModule.getMyClassObj());
+  }
+
+  @Override
+  public Provider<MyClass<MySecondClass<String>>> getProviderBool() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Provider<MyClass<MySecondClass<Object>>> getProviderInt() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public MyClass<MySecondClass<String>> getStr() {
+    return Checks.checkProvisionNotNull(MyModule.getMyClassStr());
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.getMyClassObj());
+      case 1: return Checks.checkProvisionNotNull(MyModule.getMyClassStr());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/GenericClassesTest/generic-parameters-are-empty.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/GenericClassesTest/generic-parameters-are-empty.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyClass get() {
+    return Checks.checkProvisionNotNull(MyModule.getMyClassObj());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/GenericClassesTest/java-raw-types.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/GenericClassesTest/java-raw-types.golden-code.txt
@@ -1,0 +1,49 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyGenericClass get() {
+    return new MyGenericClass();
+  }
+
+  @Override
+  public MyGenericClass2 get2() {
+    return new MyGenericClass2();
+  }
+
+  @Override
+  public void inject(TestComponentBase.Injector i) {
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/GenericClassesTest/jvm-wildcard-annotations-are-honored.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/GenericClassesTest/jvm-wildcard-annotations-are-honored.golden-code.txt
@@ -1,0 +1,73 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Arrays;
+import java.util.List;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final TestModule mTestModule;
+
+  private Yatagan$TestComponent(TestModule pTestModule) {
+    this.mTestModule = pTestModule != null ? pTestModule : new TestModule();
+  }
+
+  @Override
+  public List<List<Api>> getApis() {
+    return Checks.checkProvisionNotNull(this.mTestModule.someListOfApi());
+  }
+
+  @Override
+  public Consumer getConsumer() {
+    return new Consumer(Checks.checkProvisionNotNull(this.mTestModule.someListOfApi()), Checks.checkProvisionNotNull(this.mTestModule.someListOfApi()), Checks.checkProvisionNotNull(this.mTestModule.someListOfImpl()), Checks.checkProvisionNotNull(this.mTestModule.someListOfImpl()), Checks.checkProvisionNotNull(this.mTestModule.handler()), Checks.checkProvisionNotNull(this.mTestModule.handler2()));
+  }
+
+  @Override
+  public Function1<String, Unit> getHandler() {
+    return Checks.checkProvisionNotNull(this.mTestModule.handler());
+  }
+
+  @Override
+  public Function1<Api, Unit> getHandler2() {
+    return Checks.checkProvisionNotNull(this.mTestModule.handler2());
+  }
+
+  @Override
+  public List<List<Impl>> getImpls() {
+    return Checks.checkProvisionNotNull(this.mTestModule.someListOfImpl());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    private TestModule mTestModule;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == TestModule.class) {
+        this.mTestModule = (TestModule) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(TestModule.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent(this.mTestModule);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/GenericClassesTest/simple-parameterized-class.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/GenericClassesTest/simple-parameterized-class.golden-code.txt
@@ -1,0 +1,103 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public MyClass<Integer> get() {
+    return Checks.checkProvisionNotNull(MyModule.getMyClassInt());
+  }
+
+  @Override
+  public Lazy<MyClass<Integer>> getLazy() {
+    return new CachingProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<MyClass<Integer>> getProvider() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(MyModule.getMyClassInt());
+      default: throw new AssertionError();
+    }
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/HeavyTest/procedural-Fat-Flat.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/HeavyTest/procedural-Fat-Flat.golden-code.txt
@@ -1,0 +1,9651 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$Component_602.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$Component_602 implements Component_602 {
+  private Object mNode_306Instance;
+
+  private Object mNode_139Instance;
+
+  private Object mNode_502Instance;
+
+  private Object mNode_422Instance;
+
+  private Object mNode_242Instance;
+
+  private Object mNode_290Instance;
+
+  private Object mNode_193Instance;
+
+  private Object mNode_580Instance;
+
+  private Object mNode_401Instance;
+
+  private Object mNode_194Instance;
+
+  private Object mNode_375Instance;
+
+  private Object mNode_445Instance;
+
+  private Object mNode_463Instance;
+
+  private Object mNode_499Instance;
+
+  private Object mNode_424Instance;
+
+  private Object mNode_64Instance;
+
+  private Object mNode_379Instance;
+
+  private Object mNode_135Instance;
+
+  private Object mNode_192Instance;
+
+  private Object mNode_284Instance;
+
+  private Object mNode_361Instance;
+
+  private Object mNode_340Instance;
+
+  private Object mNode_360Instance;
+
+  private Object mNode_288Instance;
+
+  private Object mNode_433Instance;
+
+  private Object mNode_485Instance;
+
+  private Object mNode_416Instance;
+
+  private Object mNode_146Instance;
+
+  private Object mNode_122Instance;
+
+  private Object mNode_551Instance;
+
+  private Object mNode_310Instance;
+
+  private Object mNode_233Instance;
+
+  private Object mNode_354Instance;
+
+  private Object mNode_406Instance;
+
+  private Object mNode_83Instance;
+
+  private Object mNode_598Instance;
+
+  private Object mNode_160Instance;
+
+  private Object mNode_162Instance;
+
+  private Object mNode_207Instance;
+
+  private Object mNode_29Instance;
+
+  private Object mNode_372Instance;
+
+  private Object mNode_26Instance;
+
+  private Object mNode_50Instance;
+
+  private Object mNode_33Instance;
+
+  private Object mNode_66Instance;
+
+  private Object mNode_289Instance;
+
+  private Object mNode_223Instance;
+
+  private Object mNode_420Instance;
+
+  private Object mNode_450Instance;
+
+  private Object mNode_11Instance;
+
+  private Object mNode_261Instance;
+
+  private Object mNode_341Instance;
+
+  private Object mNode_157Instance;
+
+  private Object mNode_304Instance;
+
+  private Object mNode_429Instance;
+
+  private Object mNode_190Instance;
+
+  private Object mNode_269Instance;
+
+  private Object mNode_521Instance;
+
+  private Object mNode_101Instance;
+
+  private Object mNode_460Instance;
+
+  private Object mNode_431Instance;
+
+  private Object mNode_128Instance;
+
+  private Object mNode_37Instance;
+
+  private Object mNode_2Instance;
+
+  private Object mNode_384Instance;
+
+  private Object mNode_84Instance;
+
+  private Object mNode_258Instance;
+
+  private Object mNode_235Instance;
+
+  private Object mNode_121Instance;
+
+  private Object mNode_249Instance;
+
+  private Object mNode_477Instance;
+
+  private Object mNode_592Instance;
+
+  private Object mNode_38Instance;
+
+  private Object mNode_245Instance;
+
+  private Object mNode_487Instance;
+
+  private Object mNode_555Instance;
+
+  private Object mNode_155Instance;
+
+  private Object mNode_25Instance;
+
+  private Object mNode_95Instance;
+
+  private Object mNode_464Instance;
+
+  private Object mNode_273Instance;
+
+  private Object mNode_461Instance;
+
+  private Object mNode_553Instance;
+
+  private Object mNode_215Instance;
+
+  private Object mNode_76Instance;
+
+  private Object mNode_168Instance;
+
+  private Object mNode_356Instance;
+
+  private Object mNode_89Instance;
+
+  private Object mNode_60Instance;
+
+  private Object mNode_334Instance;
+
+  private Object mNode_475Instance;
+
+  private Object mNode_180Instance;
+
+  private Object mNode_218Instance;
+
+  private Object mNode_80Instance;
+
+  private Object mNode_100Instance;
+
+  private Object mNode_531Instance;
+
+  private Object mNode_238Instance;
+
+  private Object mNode_58Instance;
+
+  private Object mNode_575Instance;
+
+  private Object mNode_114Instance;
+
+  private Object mNode_413Instance;
+
+  private Object mNode_520Instance;
+
+  private Object mNode_404Instance;
+
+  private Object mNode_40Instance;
+
+  private Object mNode_156Instance;
+
+  private Object mNode_391Instance;
+
+  private Object mNode_104Instance;
+
+  private Object mNode_120Instance;
+
+  private Object mNode_123Instance;
+
+  private Object mNode_13Instance;
+
+  private Object mNode_131Instance;
+
+  private Object mNode_138Instance;
+
+  private Object mNode_141Instance;
+
+  private Object mNode_143Instance;
+
+  private Object mNode_147Instance;
+
+  private Object mNode_15Instance;
+
+  private Object mNode_151Instance;
+
+  private Object mNode_176Instance;
+
+  private Object mNode_198Instance;
+
+  private Object mNode_20Instance;
+
+  private Object mNode_202Instance;
+
+  private Object mNode_206Instance;
+
+  private Object mNode_212Instance;
+
+  private Object mNode_224Instance;
+
+  private Object mNode_226Instance;
+
+  private Object mNode_229Instance;
+
+  private Object mNode_230Instance;
+
+  private Object mNode_231Instance;
+
+  private Object mNode_234Instance;
+
+  private Object mNode_241Instance;
+
+  private Object mNode_243Instance;
+
+  private Object mNode_244Instance;
+
+  private Object mNode_250Instance;
+
+  private Object mNode_253Instance;
+
+  private Object mNode_260Instance;
+
+  private Object mNode_267Instance;
+
+  private Object mNode_271Instance;
+
+  private Object mNode_281Instance;
+
+  private Object mNode_285Instance;
+
+  private Object mNode_286Instance;
+
+  private Object mNode_31Instance;
+
+  private Object mNode_316Instance;
+
+  private Object mNode_318Instance;
+
+  private Object mNode_319Instance;
+
+  private Object mNode_322Instance;
+
+  private Object mNode_325Instance;
+
+  private Object mNode_328Instance;
+
+  private Object mNode_347Instance;
+
+  private Object mNode_349Instance;
+
+  private Object mNode_352Instance;
+
+  private Object mNode_353Instance;
+
+  private Object mNode_359Instance;
+
+  private Object mNode_366Instance;
+
+  private Object mNode_407Instance;
+
+  private Object mNode_415Instance;
+
+  private Object mNode_417Instance;
+
+  private Object mNode_426Instance;
+
+  private Object mNode_441Instance;
+
+  private Object mNode_457Instance;
+
+  private Object mNode_459Instance;
+
+  private Object mNode_468Instance;
+
+  private Object mNode_469Instance;
+
+  private Object mNode_479Instance;
+
+  private Object mNode_488Instance;
+
+  private Object mNode_49Instance;
+
+  private Object mNode_490Instance;
+
+  private Object mNode_498Instance;
+
+  private Object mNode_500Instance;
+
+  private Object mNode_506Instance;
+
+  private Object mNode_511Instance;
+
+  private Object mNode_513Instance;
+
+  private Object mNode_519Instance;
+
+  private Object mNode_527Instance;
+
+  private Object mNode_528Instance;
+
+  private Object mNode_53Instance;
+
+  private Object mNode_530Instance;
+
+  private Object mNode_537Instance;
+
+  private Object mNode_539Instance;
+
+  private Object mNode_547Instance;
+
+  private Object mNode_550Instance;
+
+  private Object mNode_556Instance;
+
+  private Object mNode_559Instance;
+
+  private Object mNode_560Instance;
+
+  private Object mNode_562Instance;
+
+  private Object mNode_565Instance;
+
+  private Object mNode_567Instance;
+
+  private Object mNode_570Instance;
+
+  private Object mNode_572Instance;
+
+  private Object mNode_578Instance;
+
+  private Object mNode_581Instance;
+
+  private Object mNode_584Instance;
+
+  private Object mNode_586Instance;
+
+  private Object mNode_588Instance;
+
+  private Object mNode_589Instance;
+
+  private Object mNode_593Instance;
+
+  private Object mNode_6Instance;
+
+  private Object mNode_67Instance;
+
+  private Object mNode_7Instance;
+
+  private Object mNode_72Instance;
+
+  private Object mNode_77Instance;
+
+  private Object mNode_79Instance;
+
+  private Object mNode_81Instance;
+
+  private Object mNode_98Instance;
+
+  private Object mNode_99Instance;
+
+  final Node_88 mSet_0;
+
+  final Node_278 mSet_1;
+
+  final Node_545 mSet_10;
+
+  final Node_471 mSet_11;
+
+  final Node_170 mSet_12;
+
+  final Node_412 mSet_13;
+
+  final Node_52 mSet_14;
+
+  final Node_442 mSet_15;
+
+  final Node_370 mSet_16;
+
+  final Node_259 mSet_17;
+
+  final Node_382 mSet_18;
+
+  final Node_276 mSet_19;
+
+  final Node_9 mSet_2;
+
+  final Node_357 mSet_20;
+
+  final Node_326 mSet_21;
+
+  final Node_94 mSet_22;
+
+  final Node_493 mSet_23;
+
+  final Node_321 mSet_24;
+
+  final Node_378 mSet_25;
+
+  final Node_369 mSet_26;
+
+  final Node_255 mSet_27;
+
+  final Node_516 mSet_28;
+
+  final Node_24 mSet_29;
+
+  final Node_277 mSet_3;
+
+  final Node_392 mSet_30;
+
+  final Node_452 mSet_31;
+
+  final Node_287 mSet_32;
+
+  final Node_110 mSet_33;
+
+  final Node_526 mSet_34;
+
+  final Node_525 mSet_35;
+
+  final Node_204 mSet_36;
+
+  final Node_129 mSet_37;
+
+  final Node_68 mSet_38;
+
+  final Node_400 mSet_39;
+
+  final Node_145 mSet_4;
+
+  final Node_237 mSet_40;
+
+  final Node_35 mSet_41;
+
+  final Node_272 mSet_42;
+
+  final Node_554 mSet_43;
+
+  final Node_39 mSet_44;
+
+  final Node_183 mSet_45;
+
+  final Node_523 mSet_46;
+
+  final Node_17 mSet_47;
+
+  final Node_294 mSet_48;
+
+  final Node_196 mSet_49;
+
+  final Node_522 mSet_5;
+
+  final Node_75 mSet_50;
+
+  final Node_117 mSet_51;
+
+  final Node_125 mSet_6;
+
+  final Node_486 mSet_7;
+
+  final Node_283 mSet_8;
+
+  final Node_335 mSet_9;
+
+  final Dependency_601 mDependency_601;
+
+  Yatagan$Component_602(Dependency_601 pSetDep_0, Node_88 pSet_0, Node_278 pSet_1, Node_545 pSet_10,
+      Node_471 pSet_11, Node_170 pSet_12, Node_412 pSet_13, Node_52 pSet_14, Node_442 pSet_15,
+      Node_370 pSet_16, Node_259 pSet_17, Node_382 pSet_18, Node_276 pSet_19, Node_9 pSet_2,
+      Node_357 pSet_20, Node_326 pSet_21, Node_94 pSet_22, Node_493 pSet_23, Node_321 pSet_24,
+      Node_378 pSet_25, Node_369 pSet_26, Node_255 pSet_27, Node_516 pSet_28, Node_24 pSet_29,
+      Node_277 pSet_3, Node_392 pSet_30, Node_452 pSet_31, Node_287 pSet_32, Node_110 pSet_33,
+      Node_526 pSet_34, Node_525 pSet_35, Node_204 pSet_36, Node_129 pSet_37, Node_68 pSet_38,
+      Node_400 pSet_39, Node_145 pSet_4, Node_237 pSet_40, Node_35 pSet_41, Node_272 pSet_42,
+      Node_554 pSet_43, Node_39 pSet_44, Node_183 pSet_45, Node_523 pSet_46, Node_17 pSet_47,
+      Node_294 pSet_48, Node_196 pSet_49, Node_522 pSet_5, Node_75 pSet_50, Node_117 pSet_51,
+      Node_125 pSet_6, Node_486 pSet_7, Node_283 pSet_8, Node_335 pSet_9) {
+    this.mDependency_601 = Checks.checkInputNotNull(pSetDep_0);
+    this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+    this.mSet_10 = Checks.checkInputNotNull(pSet_10);
+    this.mSet_11 = Checks.checkInputNotNull(pSet_11);
+    this.mSet_12 = Checks.checkInputNotNull(pSet_12);
+    this.mSet_13 = Checks.checkInputNotNull(pSet_13);
+    this.mSet_14 = Checks.checkInputNotNull(pSet_14);
+    this.mSet_15 = Checks.checkInputNotNull(pSet_15);
+    this.mSet_16 = Checks.checkInputNotNull(pSet_16);
+    this.mSet_17 = Checks.checkInputNotNull(pSet_17);
+    this.mSet_18 = Checks.checkInputNotNull(pSet_18);
+    this.mSet_19 = Checks.checkInputNotNull(pSet_19);
+    this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+    this.mSet_20 = Checks.checkInputNotNull(pSet_20);
+    this.mSet_21 = Checks.checkInputNotNull(pSet_21);
+    this.mSet_22 = Checks.checkInputNotNull(pSet_22);
+    this.mSet_23 = Checks.checkInputNotNull(pSet_23);
+    this.mSet_24 = Checks.checkInputNotNull(pSet_24);
+    this.mSet_25 = Checks.checkInputNotNull(pSet_25);
+    this.mSet_26 = Checks.checkInputNotNull(pSet_26);
+    this.mSet_27 = Checks.checkInputNotNull(pSet_27);
+    this.mSet_28 = Checks.checkInputNotNull(pSet_28);
+    this.mSet_29 = Checks.checkInputNotNull(pSet_29);
+    this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+    this.mSet_30 = Checks.checkInputNotNull(pSet_30);
+    this.mSet_31 = Checks.checkInputNotNull(pSet_31);
+    this.mSet_32 = Checks.checkInputNotNull(pSet_32);
+    this.mSet_33 = Checks.checkInputNotNull(pSet_33);
+    this.mSet_34 = Checks.checkInputNotNull(pSet_34);
+    this.mSet_35 = Checks.checkInputNotNull(pSet_35);
+    this.mSet_36 = Checks.checkInputNotNull(pSet_36);
+    this.mSet_37 = Checks.checkInputNotNull(pSet_37);
+    this.mSet_38 = Checks.checkInputNotNull(pSet_38);
+    this.mSet_39 = Checks.checkInputNotNull(pSet_39);
+    this.mSet_4 = Checks.checkInputNotNull(pSet_4);
+    this.mSet_40 = Checks.checkInputNotNull(pSet_40);
+    this.mSet_41 = Checks.checkInputNotNull(pSet_41);
+    this.mSet_42 = Checks.checkInputNotNull(pSet_42);
+    this.mSet_43 = Checks.checkInputNotNull(pSet_43);
+    this.mSet_44 = Checks.checkInputNotNull(pSet_44);
+    this.mSet_45 = Checks.checkInputNotNull(pSet_45);
+    this.mSet_46 = Checks.checkInputNotNull(pSet_46);
+    this.mSet_47 = Checks.checkInputNotNull(pSet_47);
+    this.mSet_48 = Checks.checkInputNotNull(pSet_48);
+    this.mSet_49 = Checks.checkInputNotNull(pSet_49);
+    this.mSet_5 = Checks.checkInputNotNull(pSet_5);
+    this.mSet_50 = Checks.checkInputNotNull(pSet_50);
+    this.mSet_51 = Checks.checkInputNotNull(pSet_51);
+    this.mSet_6 = Checks.checkInputNotNull(pSet_6);
+    this.mSet_7 = Checks.checkInputNotNull(pSet_7);
+    this.mSet_8 = Checks.checkInputNotNull(pSet_8);
+    this.mSet_9 = Checks.checkInputNotNull(pSet_9);
+  }
+
+  @Override
+  public Node_260 getGet_0() {
+    return this.cacheNode_260();
+  }
+
+  @Override
+  public Lazy<Node_306> getGet_1() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Node_411 getGet_10() {
+    return this.mDependency_601.ep_37();
+  }
+
+  @Override
+  public Node_307 getGet_11() {
+    return this.accessNode_307();
+  }
+
+  @Override
+  public Node_300 getGet_12() {
+    return this.accessNode_300();
+  }
+
+  @Override
+  public Provider<Node_502> getGet_13() {
+    return new ProviderImpl(this, 12);
+  }
+
+  @Override
+  public Node_419 getGet_14() {
+    return this.accessNode_419();
+  }
+
+  @Override
+  public Node_210 getGet_15() {
+    return this.cacheNode_160();
+  }
+
+  @Override
+  public Node_432 getGet_16() {
+    return this.accessNode_432();
+  }
+
+  @Override
+  public Provider<Node_422> getGet_17() {
+    return new ProviderImpl(this, 15);
+  }
+
+  @Override
+  public Node_71 getGet_18() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_655());
+  }
+
+  @Override
+  public Node_337 getGet_19() {
+    return this.accessNode_337();
+  }
+
+  @Override
+  public Node_139 getGet_2() {
+    return this.cacheNode_139();
+  }
+
+  @Override
+  public Node_242 getGet_20() {
+    return this.cacheNode_242();
+  }
+
+  @Override
+  public Node_397 getGet_21() {
+    return this.accessNode_397();
+  }
+
+  @Override
+  public Lazy<Node_458> getGet_22() {
+    return new CachingProviderImpl(this, 20);
+  }
+
+  @Override
+  public Node_154 getGet_23() {
+    return this.accessNode_154();
+  }
+
+  @Override
+  public Node_290 getGet_24() {
+    return this.cacheNode_290();
+  }
+
+  @Override
+  public Lazy<Node_303> getGet_25() {
+    return new CachingProviderImpl(this, 23);
+  }
+
+  @Override
+  public Lazy<Node_539> getGet_26() {
+    return new ProviderImpl(this, 24);
+  }
+
+  @Override
+  public Node_491 getGet_27() {
+    return this.mDependency_601.ep_46();
+  }
+
+  @Override
+  public Lazy<Node_169> getGet_28() {
+    return new CachingProviderImpl(this, 25);
+  }
+
+  @Override
+  public Node_124 getGet_29() {
+    return this.mDependency_601.ep_11();
+  }
+
+  @Override
+  public Node_88 getGet_3() {
+    return this.mSet_0;
+  }
+
+  @Override
+  public Node_193 getGet_30() {
+    return this.cacheNode_193();
+  }
+
+  @Override
+  public Node_402 getGet_4() {
+    return this.mDependency_601.ep_35();
+  }
+
+  @Override
+  public Node_278 getGet_5() {
+    return this.mSet_1;
+  }
+
+  @Override
+  public Node_9 getGet_6() {
+    return this.mSet_2;
+  }
+
+  @Override
+  public Node_366 getGet_7() {
+    return this.cacheNode_366();
+  }
+
+  @Override
+  public Node_163 getGet_8() {
+    return this.accessNode_163();
+  }
+
+  @Override
+  public Node_191 getGet_9() {
+    return this.accessNode_191();
+  }
+
+  @Override
+  public void inject_0(Injectee_604 i) {
+    i.setMember_0(this.cacheNode_580());
+    i.setMember_1(this.mDependency_601.ep_8());
+  }
+
+  @Override
+  public void inject_1(Injectee_605 i) {
+    i.setMember_0(this.accessNode_367());
+  }
+
+  @Override
+  public void inject_2(Injectee_606 i) {
+    i.setMember_0(this.mSet_3);
+    i.setMember_1(this.accessNode_142());
+    i.setMember_2(this.accessNode_132());
+    i.setMember_3(this.cacheNode_401());
+    i.setMember_4(this.accessNode_552());
+    i.setMember_5(this.accessNode_576());
+    i.setMember_6(this.mDependency_601.ep_35());
+    i.setMember_7(this.cacheNode_588());
+    i.setMember_8(this.cacheNode_72());
+    i.setMember_9(this.cacheNode_194());
+  }
+
+  private Object switch$$access$0(int slot) {
+    switch(slot) {
+      case 0: return this.cacheNode_260();
+      case 1: return this.cacheNode_306();
+      case 2: return this.cacheNode_139();
+      case 3: return this.mSet_0;
+      case 4: return this.mDependency_601.ep_35();
+      case 5: return this.mSet_2;
+      case 6: return this.cacheNode_366();
+      case 7: return this.accessNode_163();
+      case 8: return this.accessNode_191();
+      case 9: return this.mDependency_601.ep_37();
+      case 10: return this.accessNode_307();
+      case 11: return this.accessNode_300();
+      case 12: return this.cacheNode_502();
+      case 13: return this.cacheNode_160();
+      case 14: return this.accessNode_432();
+      case 15: return this.cacheNode_422();
+      case 16: return Checks.checkProvisionNotNull(Module_608.Companion.provides_655());
+      case 17: return this.accessNode_337();
+      case 18: return this.cacheNode_242();
+      case 19: return this.accessNode_397();
+      case 20: return this.accessNode_458();
+      case 21: return this.accessNode_154();
+      case 22: return this.cacheNode_290();
+      case 23: return this.accessNode_303();
+      case 24: return this.cacheNode_539();
+      case 25: return this.accessNode_44();
+      case 26: return this.mDependency_601.ep_11();
+      case 27: return this.cacheNode_193();
+      case 28: return this.cacheNode_580();
+      case 29: return this.mDependency_601.ep_8();
+      case 30: return this.accessNode_367();
+      case 31: return this.accessNode_142();
+      case 32: return this.accessNode_132();
+      case 33: return this.cacheNode_401();
+      case 34: return this.accessNode_552();
+      case 35: return this.accessNode_576();
+      case 36: return this.cacheNode_588();
+      case 37: return this.cacheNode_72();
+      case 38: return this.cacheNode_194();
+      case 39: return this.accessNode_201();
+      case 40: return this.accessNode_107();
+      case 41: return this.cacheNode_53();
+      case 42: return this.accessNode_296();
+      case 43: return this.accessNode_558();
+      case 44: return this.accessNode_453();
+      case 45: return Checks.checkProvisionNotNull(Module_608.Companion.provides_668());
+      case 46: return this.cacheNode_375();
+      case 47: return this.accessNode_126();
+      case 48: return this.mSet_4;
+      case 49: return this.accessNode_313();
+      case 50: return this.cacheNode_445();
+      case 51: return this.mSet_5;
+      case 52: return this.accessNode_274();
+      case 53: return this.cacheNode_547();
+      case 54: return this.accessNode_134();
+      case 55: return this.accessNode_137();
+      case 56: return this.mSet_7;
+      case 57: return this.accessNode_470();
+      case 58: return this.accessNode_111();
+      case 59: return this.accessNode_61();
+      case 60: return this.accessNode_27();
+      case 61: return this.accessNode_166();
+      case 62: return this.accessNode_282();
+      case 63: return this.cacheNode_463();
+      case 64: return this.accessNode_232();
+      case 65: return this.cacheNode_469();
+      case 66: return this.mSet_8;
+      case 67: return this.cacheNode_499();
+      case 68: return this.accessNode_535();
+      case 69: return this.accessNode_394();
+      case 70: return this.cacheNode_424();
+      case 71: return this.mSet_9;
+      case 72: return this.cacheNode_64();
+      case 73: return this.accessNode_599();
+      case 74: return this.cacheNode_500();
+      case 75: return this.cacheNode_379();
+      case 76: return this.mSet_10;
+      case 77: return this.mDependency_601.ep_47();
+      case 78: return this.accessNode_320();
+      case 79: return this.accessNode_332();
+      case 80: return this.mDependency_601.ep_42();
+      case 81: return this.mDependency_601.ep_49();
+      case 82: return this.accessNode_358();
+      case 83: return this.accessNode_106();
+      case 84: return this.accessNode_165();
+      case 85: return this.accessNode_482();
+      case 86: return this.cacheNode_6();
+      case 87: return this.mSet_11;
+      case 88: return this.cacheNode_250();
+      case 89: return this.accessNode_377();
+      case 90: return this.cacheNode_511();
+      case 91: return this.accessNode_434();
+      case 92: return this.cacheNode_488();
+      case 93: return this.accessNode_248();
+      case 94: return this.mDependency_601.ep_13();
+      case 95: return this.accessNode_497();
+      case 96: return this.cacheNode_285();
+      case 97: return this.mSet_12;
+      case 98: return this.accessNode_569();
+      case 99: return this.cacheNode_572();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$1(int slot) {
+    switch(slot) {
+      case 0: return this.accessNode_447();
+      case 1: return this.cacheNode_457();
+      case 2: return this.accessNode_494();
+      case 3: return this.accessNode_171();
+      case 4: return this.accessNode_446();
+      case 5: return this.accessNode_148();
+      case 6: return this.accessNode_133();
+      case 7: return this.cacheNode_241();
+      case 8: return this.cacheNode_537();
+      case 9: return this.accessNode_548();
+      case 10: return this.cacheNode_586();
+      case 11: return this.accessNode_179();
+      case 12: return this.cacheNode_570();
+      case 13: return this.cacheNode_581();
+      case 14: return this.cacheNode_135();
+      case 15: return this.cacheNode_352();
+      case 16: return this.cacheNode_192();
+      case 17: return this.cacheNode_284();
+      case 18: return this.mDependency_601.ep_2();
+      case 19: return this.accessNode_140();
+      case 20: return this.accessNode_495();
+      case 21: return this.accessNode_136();
+      case 22: return this.mSet_13;
+      case 23: return this.accessNode_280();
+      case 24: return new Node_181();
+      case 25: return this.cacheNode_361();
+      case 26: return this.accessNode_338();
+      case 27: return this.cacheNode_340();
+      case 28: return this.mDependency_601.ep_26();
+      case 29: return this.accessNode_385();
+      case 30: return this.accessNode_480();
+      case 31: return Checks.checkProvisionNotNull(Module_608.Companion.provides_699());
+      case 32: return this.cacheNode_206();
+      case 33: return this.cacheNode_360();
+      case 34: return this.cacheNode_288();
+      case 35: return this.mDependency_601.ep_36();
+      case 36: return this.accessNode_268();
+      case 37: return this.cacheNode_359();
+      case 38: return this.mSet_14;
+      case 39: return this.accessNode_178();
+      case 40: return this.mSet_15;
+      case 41: return this.cacheNode_485();
+      case 42: return this.cacheNode_441();
+      case 43: return this.cacheNode_7();
+      case 44: return this.accessNode_577();
+      case 45: return this.cacheNode_506();
+      case 46: return this.mDependency_601.ep_52();
+      case 47: return this.accessNode_23();
+      case 48: return this.cacheNode_231();
+      case 49: return this.accessNode_298();
+      case 50: return this.cacheNode_479();
+      case 51: return this.cacheNode_416();
+      case 52: return this.accessNode_22();
+      case 53: return this.cacheNode_146();
+      case 54: return this.cacheNode_122();
+      case 55: return this.mDependency_601.ep_30();
+      case 56: return this.cacheNode_123();
+      case 57: return this.mDependency_601.ep_10();
+      case 58: return this.mSet_17;
+      case 59: return this.accessNode_209();
+      case 60: return this.accessNode_573();
+      case 61: return this.accessNode_127();
+      case 62: return this.cacheNode_551();
+      case 63: return this.cacheNode_353();
+      case 64: return this.cacheNode_77();
+      case 65: return this.accessNode_185();
+      case 66: return this.mSet_18;
+      case 67: return this.accessNode_115();
+      case 68: return Checks.checkProvisionNotNull(Module_608.Companion.provides_715());
+      case 69: return this.cacheNode_310();
+      case 70: return this.accessNode_436();
+      case 71: return this.accessNode_438();
+      case 72: return this.mDependency_601.ep_22();
+      case 73: return Checks.checkProvisionNotNull(Module_608.Companion.provides_718());
+      case 74: return this.mDependency_601.ep_43();
+      case 75: return this.accessNode_393();
+      case 76: return this.cacheNode_527();
+      case 77: return this.cacheNode_234();
+      case 78: return this.cacheNode_498();
+      case 79: return this.cacheNode_233();
+      case 80: return this.cacheNode_354();
+      case 81: return this.cacheNode_49();
+      case 82: return this.accessNode_510();
+      case 83: return this.cacheNode_406();
+      case 84: return this.accessNode_492();
+      case 85: return this.cacheNode_83();
+      case 86: return this.accessNode_427();
+      case 87: return this.cacheNode_598();
+      case 88: return this.accessNode_350();
+      case 89: return this.accessNode_93();
+      case 90: return this.mSet_31;
+      case 91: return this.mDependency_601.ep_48();
+      case 92: return this.accessNode_564();
+      case 93: return this.mDependency_601.ep_55();
+      case 94: return this.accessNode_164();
+      case 95: return this.cacheNode_162();
+      case 96: return this.accessNode_329();
+      case 97: return this.accessNode_116();
+      case 98: return this.cacheNode_207();
+      case 99: return this.mSet_19;
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$2(int slot) {
+    switch(slot) {
+      case 0: return this.cacheNode_29();
+      case 1: return this.accessNode_301();
+      case 2: return this.mDependency_601.ep_9();
+      case 3: return this.mSet_20;
+      case 4: return this.mSet_21;
+      case 5: return this.accessNode_439();
+      case 6: return this.accessNode_440();
+      case 7: return this.cacheNode_372();
+      case 8: return this.cacheNode_26();
+      case 9: return this.accessNode_362();
+      case 10: return this.cacheNode_404();
+      case 11: return this.mDependency_601.ep_51();
+      case 12: return this.cacheNode_347();
+      case 13: return this.cacheNode_198();
+      case 14: return this.mDependency_601.ep_16();
+      case 15: return this.accessNode_585();
+      case 16: return this.accessNode_97();
+      case 17: return this.accessNode_512();
+      case 18: return this.cacheNode_84();
+      case 19: return this.accessNode_292();
+      case 20: return this.cacheNode_50();
+      case 21: return this.cacheNode_567();
+      case 22: return this.accessNode_405();
+      case 23: return this.accessNode_566();
+      case 24: return this.accessNode_596();
+      case 25: return this.accessNode_595();
+      case 26: return this.accessNode_410();
+      case 27: return this.mDependency_601.ep_12();
+      case 28: return this.cacheNode_33();
+      case 29: return this.cacheNode_104();
+      case 30: return this.cacheNode_589();
+      case 31: return this.accessNode_85();
+      case 32: return this.cacheNode_66();
+      case 33: return this.accessNode_425();
+      case 34: return this.accessNode_454();
+      case 35: return this.cacheNode_322();
+      case 36: return this.accessNode_5();
+      case 37: return this.accessNode_515();
+      case 38: return this.cacheNode_289();
+      case 39: return this.mSet_22;
+      case 40: return this.cacheNode_212();
+      case 41: return this.mSet_23;
+      case 42: return this.mSet_24;
+      case 43: return this.mDependency_601.ep_17();
+      case 44: return this.accessNode_150();
+      case 45: return this.cacheNode_223();
+      case 46: return this.accessNode_56();
+      case 47: return this.accessNode_12();
+      case 48: return this.accessNode_449();
+      case 49: return this.cacheNode_420();
+      case 50: return this.accessNode_351();
+      case 51: return this.mDependency_601.ep_34();
+      case 52: return Checks.checkProvisionNotNull(Module_608.Companion.provides_748());
+      case 53: return this.accessNode_568();
+      case 54: return this.mDependency_601.ep_57();
+      case 55: return this.cacheNode_407();
+      case 56: return this.accessNode_518();
+      case 57: return this.mSet_25;
+      case 58: return this.cacheNode_267();
+      case 59: return this.mSet_26;
+      case 60: return this.accessNode_517();
+      case 61: return this.accessNode_118();
+      case 62: return this.accessNode_63();
+      case 63: return this.mSet_27;
+      case 64: return this.accessNode_18();
+      case 65: return this.accessNode_514();
+      case 66: return this.accessNode_21();
+      case 67: return this.cacheNode_38();
+      case 68: return this.cacheNode_553();
+      case 69: return this.accessNode_309();
+      case 70: return this.cacheNode_81();
+      case 71: return this.mSet_28;
+      case 72: return this.accessNode_45();
+      case 73: return this.mSet_29;
+      case 74: return this.cacheNode_450();
+      case 75: return this.accessNode_409();
+      case 76: return this.accessNode_225();
+      case 77: return this.mDependency_601.ep_45();
+      case 78: return this.accessNode_390();
+      case 79: return this.cacheNode_11();
+      case 80: return this.cacheNode_261();
+      case 81: return this.accessNode_529();
+      case 82: return this.cacheNode_341();
+      case 83: return this.mDependency_601.ep_20();
+      case 84: return this.cacheNode_157();
+      case 85: return this.cacheNode_304();
+      case 86: return this.accessNode_582();
+      case 87: return this.cacheNode_429();
+      case 88: return this.accessNode_389();
+      case 89: return this.accessNode_508();
+      case 90: return this.accessNode_466();
+      case 91: return this.mSet_30;
+      case 92: return this.accessNode_348();
+      case 93: return this.accessNode_600();
+      case 94: return this.accessNode_293();
+      case 95: return this.cacheNode_190();
+      case 96: return this.cacheNode_269();
+      case 97: return this.accessNode_103();
+      case 98: return this.cacheNode_415();
+      case 99: return this.cacheNode_325();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$3(int slot) {
+    switch(slot) {
+      case 0: return this.cacheNode_521();
+      case 1: return this.cacheNode_101();
+      case 2: return this.cacheNode_460();
+      case 3: return this.accessNode_153();
+      case 4: return this.accessNode_189();
+      case 5: return this.accessNode_333();
+      case 6: return this.mDependency_601.ep_3();
+      case 7: return this.mSet_40;
+      case 8: return this.cacheNode_281();
+      case 9: return this.mSet_32;
+      case 10: return this.accessNode_388();
+      case 11: return this.cacheNode_431();
+      case 12: return this.cacheNode_562();
+      case 13: return this.accessNode_574();
+      case 14: return this.mDependency_601.ep_39();
+      case 15: return this.accessNode_507();
+      case 16: return this.cacheNode_128();
+      case 17: return this.accessNode_456();
+      case 18: return this.cacheNode_37();
+      case 19: return this.cacheNode_2();
+      case 20: return this.accessNode_343();
+      case 21: return this.accessNode_339();
+      case 22: return this.accessNode_344();
+      case 23: return this.cacheNode_20();
+      case 24: return this.accessNode_597();
+      case 25: return this.cacheNode_384();
+      case 26: return this.accessNode_421();
+      case 27: return this.accessNode_149();
+      case 28: return this.accessNode_211();
+      case 29: return this.accessNode_336();
+      case 30: return this.cacheNode_253();
+      case 31: return this.cacheNode_15();
+      case 32: return this.mDependency_601.ep_32();
+      case 33: return Checks.checkProvisionNotNull(Module_608.Companion.provides_810());
+      case 34: return this.accessNode_541();
+      case 35: return this.cacheNode_258();
+      case 36: return this.cacheNode_235();
+      case 37: return this.cacheNode_121();
+      case 38: return this.cacheNode_79();
+      case 39: return this.accessNode_524();
+      case 40: return this.accessNode_501();
+      case 41: return this.cacheNode_249();
+      case 42: return this.cacheNode_243();
+      case 43: return this.accessNode_186();
+      case 44: return this.cacheNode_477();
+      case 45: return this.mSet_33;
+      case 46: return this.cacheNode_31();
+      case 47: return this.accessNode_263();
+      case 48: return this.cacheNode_176();
+      case 49: return Checks.checkProvisionNotNull(Module_608.Companion.provides_791());
+      case 50: return this.cacheNode_559();
+      case 51: return this.accessNode_418();
+      case 52: return this.cacheNode_592();
+      case 53: return this.mSet_34;
+      case 54: return this.mSet_35;
+      case 55: return this.accessNode_54();
+      case 56: return this.cacheNode_229();
+      case 57: return this.accessNode_443();
+      case 58: return this.accessNode_82();
+      case 59: return this.cacheNode_245();
+      case 60: return this.mDependency_601.ep_28();
+      case 61: return this.accessNode_48();
+      case 62: return this.mDependency_601.ep_15();
+      case 63: return this.mDependency_601.ep_4();
+      case 64: return this.mDependency_601.ep_21();
+      case 65: return this.accessNode_239();
+      case 66: return this.cacheNode_487();
+      case 67: return this.accessNode_152();
+      case 68: return this.mSet_36;
+      case 69: return this.cacheNode_490();
+      case 70: return this.cacheNode_556();
+      case 71: return this.accessNode_331();
+      case 72: return this.accessNode_414();
+      case 73: return this.cacheNode_555();
+      case 74: return this.cacheNode_13();
+      case 75: return this.cacheNode_155();
+      case 76: return this.cacheNode_25();
+      case 77: return this.mDependency_601.ep_40();
+      case 78: return this.accessNode_28();
+      case 79: return this.mSet_37;
+      case 80: return this.cacheNode_141();
+      case 81: return this.accessNode_213();
+      case 82: return this.accessNode_42();
+      case 83: return this.cacheNode_464();
+      case 84: return this.accessNode_399();
+      case 85: return this.cacheNode_224();
+      case 86: return this.accessNode_265();
+      case 87: return this.mSet_38;
+      case 88: return this.mDependency_601.ep_53();
+      case 89: return this.cacheNode_76();
+      case 90: return this.cacheNode_180();
+      case 91: return this.cacheNode_356();
+      case 92: return this.cacheNode_459();
+      case 93: return this.mSet_50;
+      case 94: return this.mDependency_601.ep_24();
+      case 95: return this.cacheNode_286();
+      case 96: return this.accessNode_312();
+      case 97: return this.cacheNode_138();
+      case 98: return this.accessNode_119();
+      case 99: return this.cacheNode_468();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$4(int slot) {
+    switch(slot) {
+      case 0: return this.mSet_39;
+      case 1: return this.accessNode_387();
+      case 2: return this.accessNode_105();
+      case 3: return this.cacheNode_318();
+      case 4: return this.cacheNode_273();
+      case 5: return this.accessNode_473();
+      case 6: return this.accessNode_311();
+      case 7: return this.mDependency_601.ep_23();
+      case 8: return this.cacheNode_560();
+      case 9: return this.mDependency_601.ep_31();
+      case 10: return this.mDependency_601.ep_54();
+      case 11: return this.accessNode_314();
+      case 12: return this.accessNode_534();
+      case 13: return this.mDependency_601.ep_25();
+      case 14: return this.cacheNode_349();
+      case 15: return this.cacheNode_316();
+      case 16: return this.mDependency_601.ep_0();
+      case 17: return this.accessNode_395();
+      case 18: return this.accessNode_16();
+      case 19: return this.cacheNode_461();
+      case 20: return this.mDependency_601.ep_29();
+      case 21: return this.accessNode_483();
+      case 22: return this.mSet_48;
+      case 23: return this.mSet_41;
+      case 24: return this.cacheNode_202();
+      case 25: return this.accessNode_324();
+      case 26: return this.cacheNode_67();
+      case 27: return this.cacheNode_417();
+      case 28: return this.mDependency_601.ep_6();
+      case 29: return this.accessNode_342();
+      case 30: return Checks.checkProvisionNotNull(Module_608.Companion.provides_823());
+      case 31: return this.cacheNode_215();
+      case 32: return this.mSet_42;
+      case 33: return this.cacheNode_230();
+      case 34: return this.accessNode_240();
+      case 35: return this.cacheNode_426();
+      case 36: return this.mSet_43;
+      case 37: return this.accessNode_381();
+      case 38: return this.accessNode_275();
+      case 39: return this.mDependency_601.ep_38();
+      case 40: return this.accessNode_365();
+      case 41: return this.mSet_44;
+      case 42: return this.mDependency_601.ep_14();
+      case 43: return this.mDependency_601.ep_41();
+      case 44: return this.mDependency_601.ep_33();
+      case 45: return this.mDependency_601.ep_1();
+      case 46: return this.accessNode_222();
+      case 47: return this.cacheNode_328();
+      case 48: return this.accessNode_175();
+      case 49: return this.cacheNode_578();
+      case 50: return this.accessNode_214();
+      case 51: return this.accessNode_455();
+      case 52: return this.mSet_45;
+      case 53: return this.cacheNode_319();
+      case 54: return this.accessNode_182();
+      case 55: return this.accessNode_496();
+      case 56: return this.cacheNode_131();
+      case 57: return this.mDependency_601.ep_18();
+      case 58: return this.accessNode_317();
+      case 59: return this.accessNode_92();
+      case 60: return this.mSet_46;
+      case 61: return this.accessNode_543();
+      case 62: return this.cacheNode_244();
+      case 63: return this.accessNode_386();
+      case 64: return Checks.checkProvisionNotNull(Module_608.Companion.provides_832());
+      case 65: return this.cacheNode_168();
+      case 66: return this.cacheNode_391();
+      case 67: return this.cacheNode_226();
+      case 68: return this.accessNode_396();
+      case 69: return this.accessNode_364();
+      case 70: return this.accessNode_363();
+      case 71: return this.accessNode_199();
+      case 72: return this.cacheNode_89();
+      case 73: return this.cacheNode_60();
+      case 74: return this.accessNode_299();
+      case 75: return this.cacheNode_334();
+      case 76: return this.cacheNode_475();
+      case 77: return this.cacheNode_120();
+      case 78: return this.cacheNode_528();
+      case 79: return this.cacheNode_143();
+      case 80: return this.accessNode_561();
+      case 81: return this.accessNode_264();
+      case 82: return this.accessNode_74();
+      case 83: return this.accessNode_197();
+      case 84: return this.cacheNode_530();
+      case 85: return this.accessNode_504();
+      case 86: return this.cacheNode_80();
+      case 87: return this.accessNode_172();
+      case 88: return this.cacheNode_550();
+      case 89: return this.cacheNode_100();
+      case 90: return this.cacheNode_531();
+      case 91: return this.cacheNode_565();
+      case 92: return this.accessNode_533();
+      case 93: return this.cacheNode_271();
+      case 94: return this.accessNode_109();
+      case 95: return this.cacheNode_238();
+      case 96: return this.cacheNode_98();
+      case 97: return this.accessNode_184();
+      case 98: return this.accessNode_96();
+      case 99: return this.cacheNode_58();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$5(int slot) {
+    switch(slot) {
+      case 0: return Checks.checkProvisionNotNull(Module_608.Companion.provides_856());
+      case 1: return this.accessNode_330();
+      case 2: return this.accessNode_590();
+      case 3: return this.cacheNode_593();
+      case 4: return this.accessNode_43();
+      case 5: return this.accessNode_536();
+      case 6: return this.cacheNode_575();
+      case 7: return this.accessNode_113();
+      case 8: return this.cacheNode_99();
+      case 9: return this.mSet_49;
+      case 10: return this.cacheNode_114();
+      case 11: return this.accessNode_219();
+      case 12: return this.mDependency_601.ep_44();
+      case 13: return this.accessNode_257();
+      case 14: return this.accessNode_102();
+      case 15: return this.accessNode_46();
+      case 16: return this.cacheNode_156();
+      case 17: return this.cacheNode_520();
+      case 18: return this.accessNode_8();
+      case 19: return this.cacheNode_584();
+      case 20: return this.accessNode_4();
+      case 21: return this.cacheNode_40();
+      case 22: return this.accessNode_86();
+      case 23: return this.mSet_51;
+      case 24: return this.accessNode_374();
+      case 25: return this.accessNode_78();
+      case 26: return this.cacheNode_513();
+      case 27: return this.accessNode_571();
+      default: throw new AssertionError();
+    }
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot / 100) {
+      case 0: return switch$$access$0(slot % 100);
+      case 1: return switch$$access$1(slot % 100);
+      case 2: return switch$$access$2(slot % 100);
+      case 3: return switch$$access$3(slot % 100);
+      case 4: return switch$$access$4(slot % 100);
+      case 5: return switch$$access$5(slot % 100);
+      default: throw new AssertionError();
+    }
+  }
+
+  Node_306 cacheNode_306() {
+    Object local = this.mNode_306Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_649(new CachingProviderImpl(this, 57), new CachingProviderImpl(this, 58), new CachingProviderImpl(this, 59), new CachingProviderImpl(this, 60), this.cacheNode_242(), new CachingProviderImpl(this, 61)));
+      this.mNode_306Instance = local;
+    }
+    return (Node_306) local;
+  }
+
+  Node_139 cacheNode_139() {
+    Object local = this.mNode_139Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_650(new CachingProviderImpl(this, 62), new ProviderImpl(this, 63), this.accessNode_232(), new ProviderImpl(this, 65), new CachingProviderImpl(this, 66), new ProviderImpl(this, 33), new ProviderImpl(this, 67), this.accessNode_535(), new CachingProviderImpl(this, 69), this.cacheNode_366(), new ProviderImpl(this, 70), this.mSet_9, new ProviderImpl(this, 72), this.accessNode_599(), new ProviderImpl(this, 74), new ProviderImpl(this, 75), new ProviderImpl(this, 76), new ProviderImpl(this, 77), new CachingProviderImpl(this, 78), new ProviderImpl(this, 79), new ProviderImpl(this, 80), this.mDependency_601.ep_49(), this.accessNode_358()));
+      this.mNode_139Instance = local;
+    }
+    return (Node_139) local;
+  }
+
+  Node_307 accessNode_307() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_651(new CachingProviderImpl(this, 139), this.mSet_15, new ProviderImpl(this, 28), this.cacheNode_433(), new ProviderImpl(this, 141), this.cacheNode_441(), new ProviderImpl(this, 143), new ProviderImpl(this, 46), new CachingProviderImpl(this, 144), this.cacheNode_506(), new ProviderImpl(this, 74), new CachingProviderImpl(this, 14), this.accessNode_134(), this.mDependency_601.ep_52(), new ProviderImpl(this, 65), this.accessNode_383(), new CachingProviderImpl(this, 147), this.cacheNode_72(), new ProviderImpl(this, 148), this.accessNode_298(), new ProviderImpl(this, 150), new ProviderImpl(this, 151), this.accessNode_22(), this.cacheNode_146(), this.cacheNode_122()));
+  }
+
+  Node_300 accessNode_300() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_652(this.mDependency_601.ep_30(), new CachingProviderImpl(this, 14), this.mSet_16, this.accessNode_305(), new ProviderImpl(this, 156), this.mDependency_601.ep_10(), this.mSet_17, this.accessNode_209(), new CachingProviderImpl(this, 160), new ProviderImpl(this, 161), this.cacheNode_551()));
+  }
+
+  Node_502 cacheNode_502() {
+    Object local = this.mNode_502Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_653(new ProviderImpl(this, 163), new ProviderImpl(this, 164), this.accessNode_185(), new CachingProviderImpl(this, 166), this.accessNode_115(), this.mDependency_601.ep_26(), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new ProviderImpl(this, 154), this.cacheNode_310()));
+      this.mNode_502Instance = local;
+    }
+    return (Node_502) local;
+  }
+
+  Node_422 cacheNode_422() {
+    Object local = this.mNode_422Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_654(this.cacheNode_193(), this.cacheNode_162(), new CachingProviderImpl(this, 126), this.mDependency_601.ep_2(), this.mDependency_601.ep_26(), new ProviderImpl(this, 196), this.cacheNode_206(), this.accessNode_116(), this.cacheNode_207(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 52), new ProviderImpl(this, 74), this.mSet_19, this.accessNode_447(), new ProviderImpl(this, 200), new CachingProviderImpl(this, 201), this.mDependency_601.ep_9(), this.mSet_20, new ProviderImpl(this, 92), this.mSet_21, this.cacheNode_192(), new CachingProviderImpl(this, 205), new CachingProviderImpl(this, 206), this.accessNode_126()));
+      this.mNode_422Instance = local;
+    }
+    return (Node_422) local;
+  }
+
+  Node_242 cacheNode_242() {
+    Object local = this.mNode_242Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_656(this.mDependency_601.ep_51(), new CachingProviderImpl(this, 62), new ProviderImpl(this, 212), new ProviderImpl(this, 213), new CachingProviderImpl(this, 214), new CachingProviderImpl(this, 209), new ProviderImpl(this, 215), this.accessNode_154(), this.accessNode_97(), new CachingProviderImpl(this, 217), new ProviderImpl(this, 218), this.accessNode_292(), new ProviderImpl(this, 220), new CachingProviderImpl(this, 82), this.cacheNode_567(), new ProviderImpl(this, 222), this.mDependency_601.ep_42(), new CachingProviderImpl(this, 223)));
+      this.mNode_242Instance = local;
+    }
+    return (Node_242) local;
+  }
+
+  Node_397 accessNode_397() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_657(this.accessNode_596(), new ProviderImpl(this, 32), new ProviderImpl(this, 198), this.accessNode_595(), this.accessNode_410(), this.mSet_7, this.mDependency_601.ep_12(), new ProviderImpl(this, 228), this.mDependency_601.ep_9(), this.mDependency_601.ep_10(), new ProviderImpl(this, 229)));
+  }
+
+  Node_154 accessNode_154() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_658(this.cacheNode_192(), new CachingProviderImpl(this, 222), this.mDependency_601.ep_17(), new ProviderImpl(this, 182), new CachingProviderImpl(this, 244)));
+  }
+
+  Node_290 cacheNode_290() {
+    Object local = this.mNode_290Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_659(this.cacheNode_212(), this.accessNode_93(), new ProviderImpl(this, 75), new ProviderImpl(this, 151), new ProviderImpl(this, 245), new CachingProviderImpl(this, 246), new ProviderImpl(this, 229), new CachingProviderImpl(this, 247), new CachingProviderImpl(this, 248), new ProviderImpl(this, 249), this.accessNode_351(), new ProviderImpl(this, 251), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), new CachingProviderImpl(this, 253), new CachingProviderImpl(this, 31), this.accessNode_97(), this.cacheNode_500()));
+      this.mNode_290Instance = local;
+    }
+    return (Node_290) local;
+  }
+
+  Node_303 accessNode_303() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_660(new ProviderImpl(this, 107), new ProviderImpl(this, 22), new ProviderImpl(this, 50), new CachingProviderImpl(this, 35), new ProviderImpl(this, 36), new ProviderImpl(this, 254)));
+  }
+
+  Node_193 cacheNode_193() {
+    Object local = this.mNode_193Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_661(new CachingProviderImpl(this, 82), this.mSet_28, this.accessNode_150()));
+      this.mNode_193Instance = local;
+    }
+    return (Node_193) local;
+  }
+
+  Node_580 cacheNode_580() {
+    Object local = this.mNode_580Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_662(this.accessNode_45(), this.mSet_29, this.accessNode_136(), this.cacheNode_450(), new ProviderImpl(this, 275), new CachingProviderImpl(this, 106), new ProviderImpl(this, 72), this.accessNode_427(), this.cacheNode_422(), new CachingProviderImpl(this, 276), this.mDependency_601.ep_45(), this.accessNode_303(), new ProviderImpl(this, 278), new CachingProviderImpl(this, 47), new ProviderImpl(this, 107), this.cacheNode_527(), new ProviderImpl(this, 279), new ProviderImpl(this, 280), this.cacheNode_404(), this.accessNode_529(), this.accessNode_599(), new CachingProviderImpl(this, 241), new ProviderImpl(this, 282), this.mDependency_601.ep_20(), new ProviderImpl(this, 207), this.cacheNode_157(), new ProviderImpl(this, 285), this.accessNode_582()));
+      this.mNode_580Instance = local;
+    }
+    return (Node_580) local;
+  }
+
+  Node_401 cacheNode_401() {
+    Object local = this.mNode_401Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_663(new ProviderImpl(this, 325), this.accessNode_282(), Checks.checkProvisionNotNull(Module_608.Companion.provides_699()), new CachingProviderImpl(this, 52), new ProviderImpl(this, 83), this.accessNode_103(), this.cacheNode_570(), this.mSet_23, this.accessNode_577(), this.mSet_1, new CachingProviderImpl(this, 4), new ProviderImpl(this, 218), new ProviderImpl(this, 218), this.mSet_7, new CachingProviderImpl(this, 222)));
+      this.mNode_401Instance = local;
+    }
+    return (Node_401) local;
+  }
+
+  Node_576 accessNode_576() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_664(new CachingProviderImpl(this, 334), new CachingProviderImpl(this, 82), this.cacheNode_258(), new ProviderImpl(this, 92), new CachingProviderImpl(this, 104), new ProviderImpl(this, 336), new CachingProviderImpl(this, 69), new CachingProviderImpl(this, 250)));
+  }
+
+  Node_194 cacheNode_194() {
+    Object local = this.mNode_194Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_665(this.cacheNode_354(), this.accessNode_394(), this.accessNode_115(), this.cacheNode_243()));
+      this.mNode_194Instance = local;
+    }
+    return (Node_194) local;
+  }
+
+  Node_201 accessNode_201() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_666(new CachingProviderImpl(this, 343), new CachingProviderImpl(this, 315), new ProviderImpl(this, 344), new ProviderImpl(this, 75), new ProviderImpl(this, 345), this.mDependency_601.ep_50(), new ProviderImpl(this, 168), new CachingProviderImpl(this, 265)));
+  }
+
+  Node_107 accessNode_107() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_667(new ProviderImpl(this, 13), new ProviderImpl(this, 346), new CachingProviderImpl(this, 147), new CachingProviderImpl(this, 79), new CachingProviderImpl(this, 347), new CachingProviderImpl(this, 222), new ProviderImpl(this, 162), new ProviderImpl(this, 348), this.cacheNode_306(), new ProviderImpl(this, 137), this.accessNode_510(), new CachingProviderImpl(this, 129), Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 289), new CachingProviderImpl(this, 89), new ProviderImpl(this, 72), this.accessNode_336()));
+  }
+
+  Node_375 cacheNode_375() {
+    Object local = this.mNode_375Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_669(new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 278), new CachingProviderImpl(this, 347), this.mDependency_601.ep_21(), this.mSet_14, this.accessNode_211(), new ProviderImpl(this, 295), this.accessNode_239(), new ProviderImpl(this, 13), this.accessNode_106(), this.mSet_34, new ProviderImpl(this, 113), this.mDependency_601.ep_32(), new ProviderImpl(this, 136), new ProviderImpl(this, 207), new CachingProviderImpl(this, 190), this.cacheNode_487(), this.accessNode_152()));
+      this.mNode_375Instance = local;
+    }
+    return (Node_375) local;
+  }
+
+  Node_126 accessNode_126() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_670(new CachingProviderImpl(this, 351), new CachingProviderImpl(this, 10), new CachingProviderImpl(this, 119), this.mSet_36, this.cacheNode_490(), this.mSet_40, new ProviderImpl(this, 67), this.mSet_32, new ProviderImpl(this, 325), new CachingProviderImpl(this, 85), this.cacheNode_556(), this.accessNode_331(), new ProviderImpl(this, 302), this.mDependency_601.ep_57(), this.mDependency_601.ep_13(), this.accessNode_185(), new CachingProviderImpl(this, 372), new ProviderImpl(this, 373), this.mDependency_601.ep_35(), this.accessNode_458(), new ProviderImpl(this, 148)));
+  }
+
+  Node_445 cacheNode_445() {
+    Object local = this.mNode_445Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_671(this.cacheNode_25(), this.cacheNode_2(), this.accessNode_282(), this.mDependency_601.ep_40(), this.cacheNode_360(), new CachingProviderImpl(this, 378), new ProviderImpl(this, 4), new ProviderImpl(this, 96), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), this.mDependency_601.ep_8(), this.accessNode_179(), this.mSet_37, new CachingProviderImpl(this, 79), this.cacheNode_141(), this.accessNode_213(), this.cacheNode_95(), this.mSet_20, this.cacheNode_420(), this.accessNode_573()));
+      this.mNode_445Instance = local;
+    }
+    return (Node_445) local;
+  }
+
+  Node_274 accessNode_274() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_672(this.accessNode_42(), this.mSet_11, new ProviderImpl(this, 316), new ProviderImpl(this, 61), this.mSet_20, new ProviderImpl(this, 383), this.accessNode_399(), this.cacheNode_306(), this.accessNode_178(), this.mDependency_601.ep_3(), this.cacheNode_304(), this.cacheNode_38(), new CachingProviderImpl(this, 269), this.cacheNode_224(), this.cacheNode_84(), this.mSet_2));
+  }
+
+  Node_137 accessNode_137() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_673(Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), this.mDependency_601.ep_24(), new ProviderImpl(this, 1), this.cacheNode_176(), this.mDependency_601.ep_7(), new ProviderImpl(this, 395), new ProviderImpl(this, 143), this.mDependency_601.ep_39(), new CachingProviderImpl(this, 396), this.cacheNode_519(), this.cacheNode_138(), new CachingProviderImpl(this, 120), this.cacheNode_354(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), this.accessNode_85(), new ProviderImpl(this, 247), this.accessNode_282(), new ProviderImpl(this, 212), this.accessNode_97(), new ProviderImpl(this, 164), this.accessNode_367(), new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 52), this.accessNode_482(), new CachingProviderImpl(this, 139)));
+  }
+
+  Node_111 accessNode_111() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_674(new CachingProviderImpl(this, 402), new ProviderImpl(this, 92), new ProviderImpl(this, 403), this.mSet_40, this.cacheNode_260(), this.mDependency_601.ep_10(), new CachingProviderImpl(this, 222), new ProviderImpl(this, 350), new CachingProviderImpl(this, 398), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 126), new ProviderImpl(this, 235)));
+  }
+
+  Node_61 accessNode_61() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_675(Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), new ProviderImpl(this, 208), this.cacheNode_288(), new CachingProviderImpl(this, 139), new ProviderImpl(this, 404), new ProviderImpl(this, 200), new CachingProviderImpl(this, 405), new CachingProviderImpl(this, 31), new ProviderImpl(this, 370), new ProviderImpl(this, 70), new ProviderImpl(this, 235), this.accessNode_311(), this.mDependency_601.ep_23()));
+  }
+
+  Node_27 accessNode_27() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_676(this.mSet_31, this.accessNode_179(), new ProviderImpl(this, 408), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new CachingProviderImpl(this, 79), this.accessNode_201(), new ProviderImpl(this, 70), new CachingProviderImpl(this, 234), this.mSet_6, this.mDependency_601.ep_31(), new ProviderImpl(this, 113), this.mSet_40));
+  }
+
+  Node_166 accessNode_166() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_677(new ProviderImpl(this, 296), new CachingProviderImpl(this, 79), this.accessNode_564(), this.mDependency_601.ep_52(), this.accessNode_103(), this.mDependency_601.ep_54(), new ProviderImpl(this, 156), new CachingProviderImpl(this, 247), this.accessNode_314(), this.accessNode_534(), this.cacheNode_589(), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 85), this.cacheNode_349()));
+  }
+
+  Node_282 accessNode_282() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_678(this.mDependency_601.ep_31(), this.cacheNode_316()));
+  }
+
+  Node_463 cacheNode_463() {
+    Object local = this.mNode_463Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_679(this.mDependency_601.ep_39(), this.accessNode_329(), this.accessNode_350(), new CachingProviderImpl(this, 387)));
+      this.mNode_463Instance = local;
+    }
+    return (Node_463) local;
+  }
+
+  Node_499 cacheNode_499() {
+    Object local = this.mNode_499Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_680(new ProviderImpl(this, 15), this.cacheNode_273(), new CachingProviderImpl(this, 412), new CachingProviderImpl(this, 105), this.accessNode_385(), new ProviderImpl(this, 117)));
+      this.mNode_499Instance = local;
+    }
+    return (Node_499) local;
+  }
+
+  Node_535 accessNode_535() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_681(this.mDependency_601.ep_29(), new ProviderImpl(this, 282), new CachingProviderImpl(this, 421), new ProviderImpl(this, 153), new ProviderImpl(this, 112), this.mSet_30));
+  }
+
+  Node_424 cacheNode_424() {
+    Object local = this.mNode_424Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_682(new CachingProviderImpl(this, 152), this.cacheNode_207(), new ProviderImpl(this, 268), this.accessNode_239()));
+      this.mNode_424Instance = local;
+    }
+    return (Node_424) local;
+  }
+
+  Node_64 cacheNode_64() {
+    Object local = this.mNode_64Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_683(new ProviderImpl(this, 399), this.cacheNode_121(), this.accessNode_216(), new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 237), new ProviderImpl(this, 209), new CachingProviderImpl(this, 139), new ProviderImpl(this, 2), this.accessNode_342(), this.mSet_14, new ProviderImpl(this, 96), new ProviderImpl(this, 280), this.accessNode_187(), new CachingProviderImpl(this, 11), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), this.cacheNode_215(), this.mSet_42, this.accessNode_148()));
+      this.mNode_64Instance = local;
+    }
+    return (Node_64) local;
+  }
+
+  Node_379 cacheNode_379() {
+    Object local = this.mNode_379Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_684(this.accessNode_348(), this.mSet_8, this.cacheNode_375(), this.accessNode_275(), this.mDependency_601.ep_38(), new ProviderImpl(this, 156), new CachingProviderImpl(this, 440), this.cacheNode_347(), this.mSet_44, this.accessNode_54(), this.cacheNode_457(), new CachingProviderImpl(this, 168), this.mDependency_601.ep_14(), this.accessNode_21(), this.accessNode_447(), this.accessNode_362(), new ProviderImpl(this, 311), this.cacheNode_146(), this.mDependency_601.ep_55(), this.mDependency_601.ep_41(), this.cacheNode_354(), this.accessNode_566(), this.mDependency_601.ep_33(), new ProviderImpl(this, 8), this.mSet_20, this.mDependency_601.ep_1()));
+      this.mNode_379Instance = local;
+    }
+    return (Node_379) local;
+  }
+
+  Node_332 accessNode_332() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_685(Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.accessNode_515(), this.cacheNode_416()));
+  }
+
+  Node_358 accessNode_358() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_686(new ProviderImpl(this, 251), this.accessNode_507(), new CachingProviderImpl(this, 446), new ProviderImpl(this, 91)));
+  }
+
+  Node_482 accessNode_482() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_687(new ProviderImpl(this, 339), this.accessNode_492(), new CachingProviderImpl(this, 52), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 454), this.accessNode_458(), new CachingProviderImpl(this, 66), this.accessNode_439(), this.cacheNode_269(), this.accessNode_105(), new CachingProviderImpl(this, 405), new ProviderImpl(this, 126), new CachingProviderImpl(this, 347), this.accessNode_140(), this.cacheNode_231(), this.mSet_40));
+  }
+
+  Node_569 accessNode_569() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_688(new CachingProviderImpl(this, 413), new ProviderImpl(this, 318), this.accessNode_458(), this.accessNode_524(), new CachingProviderImpl(this, 61), this.cacheNode_304(), new ProviderImpl(this, 459)));
+  }
+
+  Node_494 accessNode_494() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_689(new CachingProviderImpl(this, 227), this.cacheNode_38(), new ProviderImpl(this, 301), this.cacheNode_162(), new CachingProviderImpl(this, 378), new CachingProviderImpl(this, 381), new ProviderImpl(this, 180), new CachingProviderImpl(this, 171), new ProviderImpl(this, 228), new ProviderImpl(this, 397), new ProviderImpl(this, 96), new ProviderImpl(this, 21), new CachingProviderImpl(this, 147)));
+  }
+
+  Node_171 accessNode_171() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_690(this.cacheNode_76(), this.mSet_10, this.accessNode_232(), new CachingProviderImpl(this, 448), new ProviderImpl(this, 473), this.mSet_35, new ProviderImpl(this, 92), new ProviderImpl(this, 162), this.accessNode_385(), new ProviderImpl(this, 474), this.cacheNode_267(), this.cacheNode_406(), this.mDependency_601.ep_35(), this.accessNode_548(), this.accessNode_480(), this.accessNode_185(), this.mDependency_601.ep_56(), this.cacheNode_502()));
+  }
+
+  Node_135 cacheNode_135() {
+    Object local = this.mNode_135Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_691(new CachingProviderImpl(this, 104), this.mDependency_601.ep_10(), new ProviderImpl(this, 488), this.accessNode_529(), this.accessNode_214(), new ProviderImpl(this, 473), this.cacheNode_76(), this.mSet_0, new CachingProviderImpl(this, 439), new ProviderImpl(this, 377), new CachingProviderImpl(this, 480), new ProviderImpl(this, 77), this.cacheNode_207(), new ProviderImpl(this, 300), new CachingProviderImpl(this, 222), new ProviderImpl(this, 447), new ProviderImpl(this, 64), new ProviderImpl(this, 280), this.mSet_13, new CachingProviderImpl(this, 469), new CachingProviderImpl(this, 278), new ProviderImpl(this, 422), this.accessNode_42(), this.cacheNode_284(), this.mSet_2, new ProviderImpl(this, 63), this.accessNode_329(), new ProviderImpl(this, 489)));
+      this.mNode_135Instance = local;
+    }
+    return (Node_135) local;
+  }
+
+  Node_192 cacheNode_192() {
+    Object local = this.mNode_192Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_692(new ProviderImpl(this, 491), new ProviderImpl(this, 178), new ProviderImpl(this, 127), this.mDependency_601.ep_35(), this.accessNode_533(), this.mSet_46, new CachingProviderImpl(this, 7)));
+      this.mNode_192Instance = local;
+    }
+    return (Node_192) local;
+  }
+
+  Node_284 cacheNode_284() {
+    Object local = this.mNode_284Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_693(this.accessNode_395(), this.cacheNode_157(), new ProviderImpl(this, 493), new CachingProviderImpl(this, 79), new ProviderImpl(this, 424), new ProviderImpl(this, 403), this.accessNode_150(), this.cacheNode_519(), this.mDependency_601.ep_4(), new ProviderImpl(this, 490), new ProviderImpl(this, 280), this.accessNode_518(), this.accessNode_543(), this.accessNode_600()));
+      this.mNode_284Instance = local;
+    }
+    return (Node_284) local;
+  }
+
+  Node_140 accessNode_140() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_694(this.cacheNode_147(), this.cacheNode_72(), this.mDependency_601.ep_38(), new CachingProviderImpl(this, 289), this.cacheNode_441(), new CachingProviderImpl(this, 44), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 123), new ProviderImpl(this, 46), new CachingProviderImpl(this, 398), new ProviderImpl(this, 447), this.cacheNode_551(), this.cacheNode_527(), new CachingProviderImpl(this, 79), this.accessNode_512(), this.cacheNode_352(), this.accessNode_27(), this.accessNode_109(), this.cacheNode_334(), this.cacheNode_361(), this.accessNode_558(), new CachingProviderImpl(this, 412)));
+  }
+
+  Node_136 accessNode_136() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_695(new CachingProviderImpl(this, 14), new CachingProviderImpl(this, 25), this.mSet_19, this.accessNode_303(), this.cacheNode_341(), this.accessNode_492(), new CachingProviderImpl(this, 130), new CachingProviderImpl(this, 123), this.cacheNode_157(), this.cacheNode_426(), new CachingProviderImpl(this, 333), this.cacheNode_589(), new CachingProviderImpl(this, 281), Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), new CachingProviderImpl(this, 474), this.cacheNode_212(), new ProviderImpl(this, 472), new CachingProviderImpl(this, 384), this.mSet_3));
+  }
+
+  Node_361 cacheNode_361() {
+    Object local = this.mNode_361Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_696(new CachingProviderImpl(this, 256), this.accessNode_96(), this.cacheNode_306(), this.mDependency_601.ep_43(), new ProviderImpl(this, 163), new CachingProviderImpl(this, 266), new ProviderImpl(this, 490)));
+      this.mNode_361Instance = local;
+    }
+    return (Node_361) local;
+  }
+
+  Node_338 accessNode_338() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_697(new CachingProviderImpl(this, 271), this.accessNode_337(), this.accessNode_16(), this.accessNode_136(), this.cacheNode_139(), this.accessNode_105(), this.accessNode_275(), this.mSet_48, this.accessNode_93(), this.cacheNode_556(), this.mDependency_601.ep_31(), this.cacheNode_104(), this.cacheNode_429(), this.accessNode_56(), this.mDependency_601.ep_0(), new CachingProviderImpl(this, 52), new ProviderImpl(this, 359), new ProviderImpl(this, 22), this.cacheNode_131(), new CachingProviderImpl(this, 222), this.cacheNode_198(), this.accessNode_307(), this.mSet_1, new ProviderImpl(this, 128), this.cacheNode_284(), this.cacheNode_319(), this.mDependency_601.ep_43(), this.mSet_27, this.mSet_26));
+  }
+
+  Node_340 cacheNode_340() {
+    Object local = this.mNode_340Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_698(this.mDependency_601.ep_40(), new ProviderImpl(this, 74), this.cacheNode_450(), new CachingProviderImpl(this, 253), new ProviderImpl(this, 164), new ProviderImpl(this, 301), new CachingProviderImpl(this, 304), this.cacheNode_426(), new CachingProviderImpl(this, 139), this.accessNode_27(), new ProviderImpl(this, 484), new CachingProviderImpl(this, 120), this.mSet_30, new ProviderImpl(this, 323), new ProviderImpl(this, 75), new ProviderImpl(this, 218), this.mSet_13, new CachingProviderImpl(this, 105)));
+      this.mNode_340Instance = local;
+    }
+    return (Node_340) local;
+  }
+
+  Node_360 cacheNode_360() {
+    Object local = this.mNode_360Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_700(this.accessNode_115(), new ProviderImpl(this, 76), this.mDependency_601.ep_35(), new ProviderImpl(this, 162), this.mDependency_601.ep_22(), new ProviderImpl(this, 308), new CachingProviderImpl(this, 60), this.mDependency_601.ep_45(), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new CachingProviderImpl(this, 139), new CachingProviderImpl(this, 161), this.mSet_26, new ProviderImpl(this, 447), this.mSet_7, new ProviderImpl(this, 86), new ProviderImpl(this, 472), this.mDependency_601.ep_36(), this.mSet_3));
+      this.mNode_360Instance = local;
+    }
+    return (Node_360) local;
+  }
+
+  Node_288 cacheNode_288() {
+    Object local = this.mNode_288Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_701(this.mSet_45, new CachingProviderImpl(this, 266), new ProviderImpl(this, 153), new CachingProviderImpl(this, 250), this.cacheNode_212(), new CachingProviderImpl(this, 421), this.mSet_42, new CachingProviderImpl(this, 111), this.cacheNode_551(), this.mDependency_601.ep_39(), new CachingProviderImpl(this, 278), new CachingProviderImpl(this, 82), new CachingProviderImpl(this, 223), new ProviderImpl(this, 114), new ProviderImpl(this, 177), new CachingProviderImpl(this, 458), new CachingProviderImpl(this, 480), new ProviderImpl(this, 195), new ProviderImpl(this, 366), this.mDependency_601.ep_42(), this.mSet_6, new ProviderImpl(this, 208), new CachingProviderImpl(this, 289)));
+      this.mNode_288Instance = local;
+    }
+    return (Node_288) local;
+  }
+
+  Node_433 cacheNode_433() {
+    Object local = this.mNode_433Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_702(new ProviderImpl(this, 187)));
+      this.mNode_433Instance = local;
+    }
+    return (Node_433) local;
+  }
+
+  Node_485 cacheNode_485() {
+    Object local = this.mNode_485Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_703(this.cacheNode_556(), this.cacheNode_416(), new CachingProviderImpl(this, 394), this.accessNode_535(), new CachingProviderImpl(this, 215), new ProviderImpl(this, 318), this.mDependency_601.ep_10(), this.accessNode_524(), this.cacheNode_80(), this.accessNode_280(), this.cacheNode_143(), this.cacheNode_64(), new CachingProviderImpl(this, 201), this.accessNode_132(), this.cacheNode_475(), this.cacheNode_31(), this.mDependency_601.ep_46(), this.accessNode_248(), this.cacheNode_89(), new CachingProviderImpl(this, 504), new ProviderImpl(this, 2), this.mSet_8, this.mSet_33, this.mSet_15, new CachingProviderImpl(this, 248)));
+      this.mNode_485Instance = local;
+    }
+    return (Node_485) local;
+  }
+
+  Node_577 accessNode_577() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_704(this.mSet_21, this.cacheNode_26(), this.accessNode_216(), this.mDependency_601.ep_47(), this.accessNode_299()));
+  }
+
+  Node_383 accessNode_383() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_705(this.mSet_23, this.cacheNode_551()));
+  }
+
+  Node_298 accessNode_298() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_706(new ProviderImpl(this, 506), new ProviderImpl(this, 397), this.mDependency_601.ep_40(), new ProviderImpl(this, 298), new ProviderImpl(this, 426), new ProviderImpl(this, 395), new ProviderImpl(this, 56), this.accessNode_331(), new ProviderImpl(this, 188), new CachingProviderImpl(this, 120), this.cacheNode_143(), new ProviderImpl(this, 63), this.mDependency_601.ep_35(), this.accessNode_296(), this.accessNode_113(), new CachingProviderImpl(this, 234), new ProviderImpl(this, 258)));
+  }
+
+  Node_416 cacheNode_416() {
+    Object local = this.mNode_416Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_707(this.mDependency_601.ep_32(), this.accessNode_56(), this.accessNode_454(), new ProviderImpl(this, 508), new CachingProviderImpl(this, 310), this.accessNode_533(), this.mDependency_601.ep_29(), new ProviderImpl(this, 472), this.accessNode_339(), this.cacheNode_64(), this.cacheNode_168(), new ProviderImpl(this, 65), new ProviderImpl(this, 484), new CachingProviderImpl(this, 443), new ProviderImpl(this, 245), this.cacheNode_224(), new ProviderImpl(this, 90)));
+      this.mNode_416Instance = local;
+    }
+    return (Node_416) local;
+  }
+
+  Node_22 accessNode_22() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_708(new ProviderImpl(this, 75), new CachingProviderImpl(this, 480), new ProviderImpl(this, 280), this.mDependency_601.ep_51(), this.cacheNode_230(), this.accessNode_45(), new CachingProviderImpl(this, 263), new ProviderImpl(this, 348), this.cacheNode_20(), new ProviderImpl(this, 503), this.cacheNode_521(), new ProviderImpl(this, 492)));
+  }
+
+  Node_146 cacheNode_146() {
+    Object local = this.mNode_146Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_709(new CachingProviderImpl(this, 32), this.accessNode_590(), new CachingProviderImpl(this, 429), this.cacheNode_433(), new CachingProviderImpl(this, 205), this.accessNode_184(), new CachingProviderImpl(this, 253), new CachingProviderImpl(this, 469), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), this.cacheNode_25(), this.mDependency_601.ep_26(), new ProviderImpl(this, 352), new ProviderImpl(this, 299), new CachingProviderImpl(this, 60), new ProviderImpl(this, 499), this.mDependency_601.ep_16(), this.mDependency_601.ep_25(), new ProviderImpl(this, 375)));
+      this.mNode_146Instance = local;
+    }
+    return (Node_146) local;
+  }
+
+  Node_122 cacheNode_122() {
+    Object local = this.mNode_122Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_710(new ProviderImpl(this, 106), this.cacheNode_539(), new ProviderImpl(this, 312)));
+      this.mNode_122Instance = local;
+    }
+    return (Node_122) local;
+  }
+
+  Node_305 accessNode_305() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_711(new ProviderImpl(this, 485), this.mSet_49));
+  }
+
+  Node_551 cacheNode_551() {
+    Object local = this.mNode_551Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_712());
+      this.mNode_551Instance = local;
+    }
+    return (Node_551) local;
+  }
+
+  Node_185 accessNode_185() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_713(new CachingProviderImpl(this, 469), this.cacheNode_586(), new ProviderImpl(this, 477), this.accessNode_82(), new ProviderImpl(this, 198), new CachingProviderImpl(this, 34), new ProviderImpl(this, 385), this.cacheNode_160(), new ProviderImpl(this, 325), this.mSet_5, new ProviderImpl(this, 164), new ProviderImpl(this, 225), this.mSet_39, this.mSet_21));
+  }
+
+  Node_115 accessNode_115() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_714(new CachingProviderImpl(this, 170), this.mSet_34, this.mDependency_601.ep_14(), new CachingProviderImpl(this, 438), this.cacheNode_433(), new ProviderImpl(this, 28), new CachingProviderImpl(this, 306), new CachingProviderImpl(this, 469), new CachingProviderImpl(this, 85), this.mDependency_601.ep_19(), new ProviderImpl(this, 492), new ProviderImpl(this, 300), new CachingProviderImpl(this, 276), this.mSet_14, new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 10), this.mSet_8, this.accessNode_216(), new ProviderImpl(this, 316), new CachingProviderImpl(this, 288), new CachingProviderImpl(this, 382), new ProviderImpl(this, 220), new ProviderImpl(this, 456), this.mDependency_601.ep_12(), new CachingProviderImpl(this, 98), new CachingProviderImpl(this, 60)));
+  }
+
+  Node_310 cacheNode_310() {
+    Object local = this.mNode_310Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_716(this.accessNode_85(), this.accessNode_393(), new ProviderImpl(this, 393), this.cacheNode_360(), this.accessNode_59(), new ProviderImpl(this, 287), this.cacheNode_431(), this.cacheNode_76(), this.accessNode_395(), this.mSet_46, new CachingProviderImpl(this, 233), this.accessNode_303(), this.cacheNode_426(), this.cacheNode_580()));
+      this.mNode_310Instance = local;
+    }
+    return (Node_310) local;
+  }
+
+  Node_436 accessNode_436() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_717(this.accessNode_300(), new ProviderImpl(this, 192), this.accessNode_282(), this.cacheNode_559(), this.accessNode_597(), new ProviderImpl(this, 351), new ProviderImpl(this, 128), this.cacheNode_519(), this.accessNode_386(), this.cacheNode_506(), this.mDependency_601.ep_16(), this.accessNode_590(), this.mDependency_601.ep_44(), this.mDependency_601.ep_3(), new ProviderImpl(this, 369), this.mSet_15, new CachingProviderImpl(this, 334), new CachingProviderImpl(this, 504), new ProviderImpl(this, 383), this.mSet_32, this.accessNode_21(), this.cacheNode_527(), this.cacheNode_13(), this.cacheNode_141(), this.accessNode_257(), this.accessNode_338()));
+  }
+
+  Node_393 accessNode_393() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_719(this.accessNode_102(), this.accessNode_97(), new ProviderImpl(this, 144), new ProviderImpl(this, 435), new ProviderImpl(this, 177), this.accessNode_467(), new ProviderImpl(this, 424), new CachingProviderImpl(this, 515), new ProviderImpl(this, 51), this.accessNode_515(), this.mDependency_601.ep_3(), new ProviderImpl(this, 282), new CachingProviderImpl(this, 322), new CachingProviderImpl(this, 425), new ProviderImpl(this, 218), new ProviderImpl(this, 33), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new ProviderImpl(this, 212), new CachingProviderImpl(this, 482), new CachingProviderImpl(this, 474), this.mDependency_601.ep_27(), this.accessNode_59(), new ProviderImpl(this, 456)));
+  }
+
+  Node_233 cacheNode_233() {
+    Object local = this.mNode_233Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_720(new ProviderImpl(this, 300), new ProviderImpl(this, 108), new ProviderImpl(this, 213), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 386), new CachingProviderImpl(this, 209), this.cacheNode_38(), this.mDependency_601.ep_14(), this.accessNode_295(), this.cacheNode_250(), new ProviderImpl(this, 503), new ProviderImpl(this, 110), new CachingProviderImpl(this, 126), this.mDependency_601.ep_30()));
+      this.mNode_233Instance = local;
+    }
+    return (Node_233) local;
+  }
+
+  Node_354 cacheNode_354() {
+    Object local = this.mNode_354Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_721(this.cacheNode_537(), this.cacheNode_81(), new CachingProviderImpl(this, 79), this.mSet_50, this.cacheNode_135(), this.cacheNode_521(), new CachingProviderImpl(this, 485), new CachingProviderImpl(this, 139), new ProviderImpl(this, 195), this.accessNode_175(), new ProviderImpl(this, 51)));
+      this.mNode_354Instance = local;
+    }
+    return (Node_354) local;
+  }
+
+  Node_406 cacheNode_406() {
+    Object local = this.mNode_406Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_723());
+      this.mNode_406Instance = local;
+    }
+    return (Node_406) local;
+  }
+
+  Node_492 accessNode_492() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_724(this.accessNode_209(), this.accessNode_595(), new ProviderImpl(this, 476), new ProviderImpl(this, 249), this.mDependency_601.ep_37(), this.mSet_48, this.mDependency_601.ep_30(), new CachingProviderImpl(this, 507), new ProviderImpl(this, 486), new CachingProviderImpl(this, 504), this.accessNode_154(), new ProviderImpl(this, 18), new ProviderImpl(this, 283), this.mSet_45, this.cacheNode_258(), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 381), this.mDependency_601.ep_29(), new ProviderImpl(this, 300), this.mDependency_601.ep_32(), new CachingProviderImpl(this, 250), this.cacheNode_391(), Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), new CachingProviderImpl(this, 81), new CachingProviderImpl(this, 461), this.mSet_1, new CachingProviderImpl(this, 468), new ProviderImpl(this, 13), new ProviderImpl(this, 162), new CachingProviderImpl(this, 234)));
+  }
+
+  Node_83 cacheNode_83() {
+    Object local = this.mNode_83Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_725());
+      this.mNode_83Instance = local;
+    }
+    return (Node_83) local;
+  }
+
+  Node_598 cacheNode_598() {
+    Object local = this.mNode_598Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_726(this.accessNode_434(), new CachingProviderImpl(this, 85), this.cacheNode_271(), this.cacheNode_499(), new ProviderImpl(this, 399), this.cacheNode_401(), this.mDependency_601.ep_38()));
+      this.mNode_598Instance = local;
+    }
+    return (Node_598) local;
+  }
+
+  Node_350 accessNode_350() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_727(this.mSet_33, this.cacheNode_349(), this.mSet_30, new CachingProviderImpl(this, 217), this.accessNode_307(), this.cacheNode_530(), this.accessNode_296(), this.mDependency_601.ep_38(), this.mSet_31, this.mSet_7, this.cacheNode_415(), new ProviderImpl(this, 296), new CachingProviderImpl(this, 276)));
+  }
+
+  Node_160 cacheNode_160() {
+    Object local = this.mNode_160Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_728(this.mSet_31, this.mDependency_601.ep_48(), new CachingProviderImpl(this, 192), this.mDependency_601.ep_55(), new CachingProviderImpl(this, 68), this.mDependency_601.ep_7()));
+      this.mNode_160Instance = local;
+    }
+    return (Node_160) local;
+  }
+
+  Node_162 cacheNode_162() {
+    Object local = this.mNode_162Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_729(new CachingProviderImpl(this, 289), new CachingProviderImpl(this, 25), new ProviderImpl(this, 462), new ProviderImpl(this, 507), new CachingProviderImpl(this, 227), new CachingProviderImpl(this, 297), Checks.checkProvisionNotNull(Module_608.Companion.provides_699()), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), new CachingProviderImpl(this, 481), this.accessNode_18(), this.cacheNode_570(), new ProviderImpl(this, 285), new ProviderImpl(this, 350), this.mDependency_601.ep_33(), this.mDependency_601.ep_48()));
+      this.mNode_162Instance = local;
+    }
+    return (Node_162) local;
+  }
+
+  Node_207 cacheNode_207() {
+    Object local = this.mNode_207Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_730(new ProviderImpl(this, 266), new CachingProviderImpl(this, 272), new ProviderImpl(this, 2), new CachingProviderImpl(this, 361), new ProviderImpl(this, 99), new ProviderImpl(this, 508), new CachingProviderImpl(this, 44), new ProviderImpl(this, 414), new ProviderImpl(this, 114), this.accessNode_185()));
+      this.mNode_207Instance = local;
+    }
+    return (Node_207) local;
+  }
+
+  Node_44 accessNode_44() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_731(this.accessNode_518(), this.accessNode_514(), this.accessNode_21(), new ProviderImpl(this, 267), this.cacheNode_553(), new CachingProviderImpl(this, 31), this.cacheNode_416(), this.accessNode_309(), new ProviderImpl(this, 270), this.mSet_47));
+  }
+
+  Node_29 cacheNode_29() {
+    Object local = this.mNode_29Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_732(new ProviderImpl(this, 249), new CachingProviderImpl(this, 378), new ProviderImpl(this, 449), this.accessNode_410(), new CachingProviderImpl(this, 25), new ProviderImpl(this, 101), this.cacheNode_100(), new CachingProviderImpl(this, 396)));
+      this.mNode_29Instance = local;
+    }
+    return (Node_29) local;
+  }
+
+  Node_439 accessNode_439() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_733(new CachingProviderImpl(this, 303), new ProviderImpl(this, 132), this.cacheNode_245(), this.cacheNode_520(), new CachingProviderImpl(this, 448), new ProviderImpl(this, 336), this.mDependency_601.ep_8(), new CachingProviderImpl(this, 222), this.cacheNode_162(), this.accessNode_367(), new CachingProviderImpl(this, 186), this.accessNode_203(), new CachingProviderImpl(this, 412), this.cacheNode_325(), new CachingProviderImpl(this, 171), this.cacheNode_104(), new CachingProviderImpl(this, 275)));
+  }
+
+  Node_440 accessNode_440() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_734(new ProviderImpl(this, 156), new ProviderImpl(this, 96), this.accessNode_5(), new ProviderImpl(this, 39), new ProviderImpl(this, 274), new CachingProviderImpl(this, 512), this.cacheNode_231(), this.cacheNode_135(), this.accessNode_133(), this.cacheNode_50(), new CachingProviderImpl(this, 205)));
+  }
+
+  Node_372 cacheNode_372() {
+    Object local = this.mNode_372Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_735(this.accessNode_296(), this.accessNode_103(), this.mDependency_601.ep_21(), this.accessNode_515(), this.accessNode_8(), this.accessNode_333(), this.cacheNode_11(), this.accessNode_576(), new CachingProviderImpl(this, 140), this.cacheNode_325(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 266), this.cacheNode_160(), this.cacheNode_450(), this.cacheNode_234(), this.cacheNode_215(), new ProviderImpl(this, 62), this.mDependency_601.ep_16(), new CachingProviderImpl(this, 451), new CachingProviderImpl(this, 34), this.mSet_39, this.accessNode_54(), this.mDependency_601.ep_27()));
+      this.mNode_372Instance = local;
+    }
+    return (Node_372) local;
+  }
+
+  Node_26 cacheNode_26() {
+    Object local = this.mNode_26Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_736(new ProviderImpl(this, 235), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 25), new ProviderImpl(this, 166), new ProviderImpl(this, 229), this.accessNode_535(), new ProviderImpl(this, 187), new CachingProviderImpl(this, 79), this.cacheNode_121(), new ProviderImpl(this, 255), new ProviderImpl(this, 12), new ProviderImpl(this, 211), new CachingProviderImpl(this, 126), new CachingProviderImpl(this, 367), new ProviderImpl(this, 221), new ProviderImpl(this, 125), new ProviderImpl(this, 344), new ProviderImpl(this, 232), new CachingProviderImpl(this, 61), new CachingProviderImpl(this, 265), new CachingProviderImpl(this, 371), this.accessNode_136()));
+      this.mNode_26Instance = local;
+    }
+    return (Node_26) local;
+  }
+
+  Node_50 cacheNode_50() {
+    Object local = this.mNode_50Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_737(this.accessNode_569(), this.cacheNode_229(), this.cacheNode_556(), this.cacheNode_551(), new ProviderImpl(this, 376), this.accessNode_179(), this.accessNode_425(), this.mSet_20, new CachingProviderImpl(this, 520), new ProviderImpl(this, 163), this.accessNode_165(), new CachingProviderImpl(this, 25), this.cacheNode_431(), this.cacheNode_562(), this.mSet_17, new CachingProviderImpl(this, 360), new ProviderImpl(this, 475), this.cacheNode_463(), new ProviderImpl(this, 35), this.accessNode_118(), this.cacheNode_242(), new ProviderImpl(this, 60), new CachingProviderImpl(this, 262), this.mDependency_601.ep_14(), this.accessNode_56(), new CachingProviderImpl(this, 482), this.cacheNode_379(), this.cacheNode_120()));
+      this.mNode_50Instance = local;
+    }
+    return (Node_50) local;
+  }
+
+  Node_566 accessNode_566() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_738(this.accessNode_164(), this.cacheNode_589(), new CachingProviderImpl(this, 155), new CachingProviderImpl(this, 307), this.cacheNode_13()));
+  }
+
+  Node_410 accessNode_410() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_739(new ProviderImpl(this, 376), new ProviderImpl(this, 58), this.accessNode_92(), new CachingProviderImpl(this, 79), new ProviderImpl(this, 207), new CachingProviderImpl(this, 17), new ProviderImpl(this, 374), this.cacheNode_83(), this.accessNode_393(), this.accessNode_533(), new ProviderImpl(this, 232), new CachingProviderImpl(this, 121), new CachingProviderImpl(this, 386), new CachingProviderImpl(this, 406), new ProviderImpl(this, 38), this.accessNode_97(), new ProviderImpl(this, 176), new CachingProviderImpl(this, 440), this.cacheNode_206()));
+  }
+
+  Node_33 cacheNode_33() {
+    Object local = this.mNode_33Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_740(this.cacheNode_81(), this.cacheNode_391(), this.cacheNode_589(), this.accessNode_454(), this.accessNode_507(), this.mDependency_601.ep_15(), new CachingProviderImpl(this, 355), new ProviderImpl(this, 83), this.cacheNode_198(), new ProviderImpl(this, 249), new CachingProviderImpl(this, 155), this.accessNode_569()));
+      this.mNode_33Instance = local;
+    }
+    return (Node_33) local;
+  }
+
+  Node_85 accessNode_85() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_741(new CachingProviderImpl(this, 412), this.mSet_14, new CachingProviderImpl(this, 393), new CachingProviderImpl(this, 20), new CachingProviderImpl(this, 343), this.cacheNode_406(), new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 205), new ProviderImpl(this, 477), new CachingProviderImpl(this, 209), this.mSet_1, new ProviderImpl(this, 212), new ProviderImpl(this, 98), new CachingProviderImpl(this, 276), this.cacheNode_459(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), new CachingProviderImpl(this, 209), new CachingProviderImpl(this, 152), this.accessNode_533(), new CachingProviderImpl(this, 171), new CachingProviderImpl(this, 47)));
+  }
+
+  Node_66 cacheNode_66() {
+    Object local = this.mNode_66Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_742(this.accessNode_543(), this.mDependency_601.ep_40(), new ProviderImpl(this, 156), this.cacheNode_226(), new ProviderImpl(this, 205)));
+      this.mNode_66Instance = local;
+    }
+    return (Node_66) local;
+  }
+
+  Node_289 cacheNode_289() {
+    Object local = this.mNode_289Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_743(this.mSet_51, new CachingProviderImpl(this, 25), this.mDependency_601.ep_56(), this.cacheNode_233(), this.mDependency_601.ep_48(), this.mDependency_601.ep_18(), new ProviderImpl(this, 210), this.accessNode_134(), this.mSet_19, this.cacheNode_375(), new CachingProviderImpl(this, 243), this.accessNode_508(), this.mSet_45, this.accessNode_51(), this.accessNode_132()));
+      this.mNode_289Instance = local;
+    }
+    return (Node_289) local;
+  }
+
+  Node_150 accessNode_150() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_744(new CachingProviderImpl(this, 95), new ProviderImpl(this, 229), new ProviderImpl(this, 348), this.accessNode_329(), new CachingProviderImpl(this, 501), new CachingProviderImpl(this, 520), new ProviderImpl(this, 109), new CachingProviderImpl(this, 206), this.cacheNode_565()));
+  }
+
+  Node_223 cacheNode_223() {
+    Object local = this.mNode_223Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_745(this.cacheNode_99(), this.accessNode_163(), new ProviderImpl(this, 340), this.accessNode_389(), this.accessNode_296(), this.mDependency_601.ep_13(), this.accessNode_541(), this.mDependency_601.ep_6(), this.mDependency_601.ep_11()));
+      this.mNode_223Instance = local;
+    }
+    return (Node_223) local;
+  }
+
+  Node_420 cacheNode_420() {
+    Object local = this.mNode_420Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_746(this.mDependency_601.ep_53(), new ProviderImpl(this, 29), this.accessNode_339(), new ProviderImpl(this, 331), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), this.accessNode_51(), this.accessNode_529(), this.mDependency_601.ep_4(), this.accessNode_405(), new ProviderImpl(this, 489), this.accessNode_182()));
+      this.mNode_420Instance = local;
+    }
+    return (Node_420) local;
+  }
+
+  Node_351 accessNode_351() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_747(this.mDependency_601.ep_33(), new ProviderImpl(this, 350), new CachingProviderImpl(this, 7), new ProviderImpl(this, 335), this.mSet_29, new ProviderImpl(this, 229), new ProviderImpl(this, 141), new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 47), this.cacheNode_286()));
+  }
+
+  Node_568 accessNode_568() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_749(this.accessNode_333(), this.mDependency_601.ep_54(), this.mSet_50, this.accessNode_397(), this.mSet_22, this.mSet_8, new CachingProviderImpl(this, 209), this.cacheNode_319(), this.cacheNode_340(), new CachingProviderImpl(this, 480), this.cacheNode_429(), new ProviderImpl(this, 58), this.cacheNode_457(), this.mDependency_601.ep_45(), this.cacheNode_269(), this.accessNode_436(), this.mSet_30, new ProviderImpl(this, 61)));
+  }
+
+  Node_518 accessNode_518() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_750(new CachingProviderImpl(this, 440), this.mSet_40, new CachingProviderImpl(this, 93), this.accessNode_5(), new CachingProviderImpl(this, 144), this.accessNode_97(), this.cacheNode_479(), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 189)));
+  }
+
+  Node_517 accessNode_517() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_751(new CachingProviderImpl(this, 8), new ProviderImpl(this, 87), this.cacheNode_212(), new CachingProviderImpl(this, 105), this.cacheNode_498(), new CachingProviderImpl(this, 139), this.cacheNode_151()));
+  }
+
+  Node_18 accessNode_18() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_752(this.mSet_2));
+  }
+
+  Node_450 cacheNode_450() {
+    Object local = this.mNode_450Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_753(new ProviderImpl(this, 420)));
+      this.mNode_450Instance = local;
+    }
+    return (Node_450) local;
+  }
+
+  Node_11 cacheNode_11() {
+    Object local = this.mNode_11Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_754(this.mDependency_601.ep_57()));
+      this.mNode_11Instance = local;
+    }
+    return (Node_11) local;
+  }
+
+  Node_261 cacheNode_261() {
+    Object local = this.mNode_261Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_755(this.cacheNode_547(), new CachingProviderImpl(this, 158), this.mSet_50, this.accessNode_96(), this.cacheNode_384(), new ProviderImpl(this, 514)));
+      this.mNode_261Instance = local;
+    }
+    return (Node_261) local;
+  }
+
+  Node_599 accessNode_599() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_756(this.accessNode_596(), new ProviderImpl(this, 149), new ProviderImpl(this, 181), this.mDependency_601.ep_30(), new CachingProviderImpl(this, 139), this.mSet_34, this.cacheNode_249(), new CachingProviderImpl(this, 121), this.accessNode_154(), new CachingProviderImpl(this, 367), this.cacheNode_190(), new ProviderImpl(this, 278), new CachingProviderImpl(this, 91), new ProviderImpl(this, 433), new ProviderImpl(this, 163), new CachingProviderImpl(this, 289), new ProviderImpl(this, 228), new ProviderImpl(this, 79), new CachingProviderImpl(this, 434)));
+  }
+
+  Node_341 cacheNode_341() {
+    Object local = this.mNode_341Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_757(this.mSet_36, this.cacheNode_160(), new CachingProviderImpl(this, 398), new ProviderImpl(this, 495), new ProviderImpl(this, 350), this.accessNode_351(), this.cacheNode_457(), this.accessNode_333(), this.cacheNode_551()));
+      this.mNode_341Instance = local;
+    }
+    return (Node_341) local;
+  }
+
+  Node_157 cacheNode_157() {
+    Object local = this.mNode_157Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_758(new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 54)));
+      this.mNode_157Instance = local;
+    }
+    return (Node_157) local;
+  }
+
+  Node_304 cacheNode_304() {
+    Object local = this.mNode_304Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_759(new ProviderImpl(this, 302), this.accessNode_358(), this.mSet_37, this.accessNode_517(), this.cacheNode_37(), this.mSet_7, new CachingProviderImpl(this, 275), this.accessNode_239(), this.accessNode_596(), this.mSet_51, new ProviderImpl(this, 454), new CachingProviderImpl(this, 442), this.accessNode_558(), new ProviderImpl(this, 75), this.cacheNode_318()));
+      this.mNode_304Instance = local;
+    }
+    return (Node_304) local;
+  }
+
+  Node_429 cacheNode_429() {
+    Object local = this.mNode_429Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_760(new ProviderImpl(this, 75), this.mDependency_601.ep_38(), this.accessNode_59(), new CachingProviderImpl(this, 31), this.accessNode_311(), new ProviderImpl(this, 369), new ProviderImpl(this, 298), this.accessNode_292(), new ProviderImpl(this, 187), new CachingProviderImpl(this, 386), this.accessNode_467(), new ProviderImpl(this, 117), new ProviderImpl(this, 137), new CachingProviderImpl(this, 52), new ProviderImpl(this, 114), new ProviderImpl(this, 500), this.cacheNode_334(), new ProviderImpl(this, 316), this.mDependency_601.ep_3(), this.accessNode_219(), new ProviderImpl(this, 415), this.accessNode_439(), this.accessNode_303()));
+      this.mNode_429Instance = local;
+    }
+    return (Node_429) local;
+  }
+
+  Node_389 accessNode_389() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_761(new CachingProviderImpl(this, 188), this.accessNode_295(), new CachingProviderImpl(this, 104), this.accessNode_438(), this.cacheNode_356()));
+  }
+
+  Node_508 accessNode_508() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_762(new CachingProviderImpl(this, 61), this.mDependency_601.ep_18(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), this.cacheNode_422(), this.mSet_20, this.cacheNode_547(), new CachingProviderImpl(this, 275), this.cacheNode_310(), this.accessNode_264(), this.accessNode_219(), new ProviderImpl(this, 508), Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), this.accessNode_148(), this.accessNode_534(), new ProviderImpl(this, 460), this.accessNode_150(), new CachingProviderImpl(this, 152), this.accessNode_386(), new ProviderImpl(this, 392), this.accessNode_46()));
+  }
+
+  Node_466 accessNode_466() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_763(new ProviderImpl(this, 22), new ProviderImpl(this, 456), new ProviderImpl(this, 141), new ProviderImpl(this, 370), new CachingProviderImpl(this, 266), new ProviderImpl(this, 419), new ProviderImpl(this, 70), new ProviderImpl(this, 15), new CachingProviderImpl(this, 326), new ProviderImpl(this, 472), this.cacheNode_198(), this.cacheNode_260(), new ProviderImpl(this, 248), this.mDependency_601.ep_48(), this.accessNode_219(), new ProviderImpl(this, 178), new ProviderImpl(this, 424), this.accessNode_48(), new ProviderImpl(this, 279)));
+  }
+
+  Node_348 accessNode_348() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_764(this.mDependency_601.ep_16(), this.accessNode_211(), new ProviderImpl(this, 344), this.cacheNode_273(), new ProviderImpl(this, 13), new ProviderImpl(this, 101), this.mSet_18, this.accessNode_480(), this.accessNode_42(), new CachingProviderImpl(this, 412), new CachingProviderImpl(this, 25), this.cacheNode_487(), new CachingProviderImpl(this, 188), new ProviderImpl(this, 463), new CachingProviderImpl(this, 294), new ProviderImpl(this, 75)));
+  }
+
+  Node_293 accessNode_293() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_765(new CachingProviderImpl(this, 25), this.accessNode_597(), this.cacheNode_15(), this.accessNode_136(), new ProviderImpl(this, 498), this.accessNode_342(), this.accessNode_405(), this.cacheNode_459(), this.accessNode_182(), this.mDependency_601.ep_52(), new ProviderImpl(this, 297), this.accessNode_535(), this.mDependency_601.ep_55(), this.accessNode_105(), this.accessNode_333(), this.cacheNode_553(), this.accessNode_585(), this.accessNode_385(), this.mDependency_601.ep_5(), this.mSet_31, this.accessNode_63()));
+  }
+
+  Node_190 cacheNode_190() {
+    Object local = this.mNode_190Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_766(new CachingProviderImpl(this, 136), this.mDependency_601.ep_4(), this.accessNode_93(), this.mDependency_601.ep_3(), this.accessNode_515(), new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 136), this.mDependency_601.ep_40(), new ProviderImpl(this, 125), this.accessNode_179(), new CachingProviderImpl(this, 173), new ProviderImpl(this, 472), this.mDependency_601.ep_25(), this.mDependency_601.ep_56(), this.accessNode_105(), new CachingProviderImpl(this, 17), new CachingProviderImpl(this, 410), new ProviderImpl(this, 516)));
+      this.mNode_190Instance = local;
+    }
+    return (Node_190) local;
+  }
+
+  Node_269 cacheNode_269() {
+    Object local = this.mNode_269Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_767(this.accessNode_96(), this.accessNode_295(), this.accessNode_590(), new CachingProviderImpl(this, 149), new ProviderImpl(this, 465), new CachingProviderImpl(this, 184), this.accessNode_21()));
+      this.mNode_269Instance = local;
+    }
+    return (Node_269) local;
+  }
+
+  Node_103 accessNode_103() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_768(this.mDependency_601.ep_14(), new CachingProviderImpl(this, 31), this.accessNode_510(), new ProviderImpl(this, 424), this.cacheNode_527(), this.cacheNode_565(), this.accessNode_529(), this.mDependency_601.ep_3(), new ProviderImpl(this, 229), this.cacheNode_98(), new ProviderImpl(this, 0), new CachingProviderImpl(this, 223), this.cacheNode_580(), new ProviderImpl(this, 336), new CachingProviderImpl(this, 347), this.mDependency_601.ep_50(), this.accessNode_154(), this.cacheNode_360(), new ProviderImpl(this, 397), this.cacheNode_286(), this.accessNode_534(), this.mSet_44, new ProviderImpl(this, 255), new CachingProviderImpl(this, 372), new CachingProviderImpl(this, 85)));
+  }
+
+  Node_521 cacheNode_521() {
+    Object local = this.mNode_521Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_769(new ProviderImpl(this, 75), new ProviderImpl(this, 178), this.accessNode_134(), new ProviderImpl(this, 489), this.mDependency_601.ep_19(), this.cacheNode_424(), new ProviderImpl(this, 296), new CachingProviderImpl(this, 93), new ProviderImpl(this, 206), this.mSet_17));
+      this.mNode_521Instance = local;
+    }
+    return (Node_521) local;
+  }
+
+  Node_101 cacheNode_101() {
+    Object local = this.mNode_101Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_770(Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), new CachingProviderImpl(this, 320), new ProviderImpl(this, 77), this.accessNode_535(), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new ProviderImpl(this, 101), new CachingProviderImpl(this, 524), new ProviderImpl(this, 219), new ProviderImpl(this, 220), new CachingProviderImpl(this, 215), this.cacheNode_160(), new ProviderImpl(this, 141), this.cacheNode_426(), new CachingProviderImpl(this, 425), new CachingProviderImpl(this, 173), this.mSet_3, this.mDependency_601.ep_28()));
+      this.mNode_101Instance = local;
+    }
+    return (Node_101) local;
+  }
+
+  Node_460 cacheNode_460() {
+    Object local = this.mNode_460Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_771(this.mSet_10, new ProviderImpl(this, 24), this.accessNode_111(), new CachingProviderImpl(this, 294), this.mSet_51, this.mDependency_601.ep_19(), this.cacheNode_258(), this.cacheNode_151(), new CachingProviderImpl(this, 209), new CachingProviderImpl(this, 454)));
+      this.mNode_460Instance = local;
+    }
+    return (Node_460) local;
+  }
+
+  Node_153 accessNode_153() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_772(this.cacheNode_404(), new CachingProviderImpl(this, 483), this.accessNode_364(), this.accessNode_529(), this.mSet_49, new CachingProviderImpl(this, 429), this.mDependency_601.ep_13(), new ProviderImpl(this, 348), new ProviderImpl(this, 462), this.accessNode_590(), this.cacheNode_11(), this.accessNode_351(), new Node_181(), this.cacheNode_168()));
+  }
+
+  Node_333 accessNode_333() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_773(new ProviderImpl(this, 477), this.cacheNode_218(), new CachingProviderImpl(this, 32), this.mSet_20, new ProviderImpl(this, 25), new ProviderImpl(this, 41), this.accessNode_344(), new CachingProviderImpl(this, 446), this.mSet_12, this.cacheNode_366(), new ProviderImpl(this, 426), this.mDependency_601.ep_20(), this.mDependency_601.ep_57(), new CachingProviderImpl(this, 480), this.cacheNode_151(), Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), new ProviderImpl(this, 137), new CachingProviderImpl(this, 482), new CachingProviderImpl(this, 398), new ProviderImpl(this, 337), this.cacheNode_146()));
+  }
+
+  Node_388 accessNode_388() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_774(this.accessNode_385(), this.cacheNode_258(), this.cacheNode_80()));
+  }
+
+  Node_431 cacheNode_431() {
+    Object local = this.mNode_431Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_775(this.accessNode_571(), new ProviderImpl(this, 348), this.accessNode_337(), new CachingProviderImpl(this, 34), new ProviderImpl(this, 0), this.cacheNode_426(), this.mDependency_601.ep_12(), this.mDependency_601.ep_44(), this.mSet_32, new CachingProviderImpl(this, 62), new CachingProviderImpl(this, 126), new ProviderImpl(this, 208), this.mDependency_601.ep_23(), this.accessNode_154(), this.cacheNode_40(), this.mSet_27, new ProviderImpl(this, 143), new ProviderImpl(this, 313), new ProviderImpl(this, 239), new ProviderImpl(this, 322), this.cacheNode_250(), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new CachingProviderImpl(this, 209), new CachingProviderImpl(this, 275), new ProviderImpl(this, 484), this.accessNode_548(), new CachingProviderImpl(this, 91), new ProviderImpl(this, 154), this.mDependency_601.ep_53()));
+      this.mNode_431Instance = local;
+    }
+    return (Node_431) local;
+  }
+
+  Node_128 cacheNode_128() {
+    Object local = this.mNode_128Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_776(this.accessNode_430(), this.mSet_14, this.accessNode_257(), this.cacheNode_233(), this.mDependency_601.ep_43(), this.accessNode_113(), this.cacheNode_29(), this.cacheNode_488()));
+      this.mNode_128Instance = local;
+    }
+    return (Node_128) local;
+  }
+
+  Node_456 accessNode_456() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_777(new CachingProviderImpl(this, 206), new ProviderImpl(this, 220), new CachingProviderImpl(this, 480)));
+  }
+
+  Node_37 cacheNode_37() {
+    Object local = this.mNode_37Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_778(new CachingProviderImpl(this, 266), new CachingProviderImpl(this, 402), new ProviderImpl(this, 258), new ProviderImpl(this, 169), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 188), new ProviderImpl(this, 344), new CachingProviderImpl(this, 520), this.accessNode_133(), new ProviderImpl(this, 65), this.accessNode_381(), this.accessNode_82(), new ProviderImpl(this, 424), this.cacheNode_584(), new CachingProviderImpl(this, 206), this.mSet_12, new ProviderImpl(this, 387), this.accessNode_297(), this.mDependency_601.ep_27(), new ProviderImpl(this, 478), new ProviderImpl(this, 310), new CachingProviderImpl(this, 49)));
+      this.mNode_37Instance = local;
+    }
+    return (Node_37) local;
+  }
+
+  Node_2 cacheNode_2() {
+    Object local = this.mNode_2Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_779());
+      this.mNode_2Instance = local;
+    }
+    return (Node_2) local;
+  }
+
+  Node_343 accessNode_343() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_780(new ProviderImpl(this, 452), this.mSet_23, this.cacheNode_271(), this.mDependency_601.ep_47(), this.cacheNode_457(), new CachingProviderImpl(this, 222), this.cacheNode_570(), this.cacheNode_104(), this.cacheNode_441(), this.accessNode_421(), new CachingProviderImpl(this, 95), this.cacheNode_460(), this.accessNode_179(), this.accessNode_595(), this.mDependency_601.ep_15(), this.accessNode_590(), new CachingProviderImpl(this, 197), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.mSet_33, this.mSet_6, this.mDependency_601.ep_42(), this.cacheNode_565(), this.accessNode_362()));
+  }
+
+  Node_384 cacheNode_384() {
+    Object local = this.mNode_384Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_781(this.mSet_47, new CachingProviderImpl(this, 58), this.accessNode_350(), new ProviderImpl(this, 21), this.cacheNode_464(), this.mDependency_601.ep_0()));
+      this.mNode_384Instance = local;
+    }
+    return (Node_384) local;
+  }
+
+  Node_84 cacheNode_84() {
+    Object local = this.mNode_84Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_782(this.mDependency_601.ep_25(), this.cacheNode_537(), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), this.mSet_17, this.cacheNode_233(), this.mSet_40, this.cacheNode_468(), this.cacheNode_325(), this.cacheNode_407(), new CachingProviderImpl(this, 234), new CachingProviderImpl(this, 386), new CachingProviderImpl(this, 505), this.accessNode_535(), this.cacheNode_530(), this.mSet_39, this.accessNode_332(), this.accessNode_186(), this.cacheNode_141(), this.cacheNode_506(), this.accessNode_377(), this.accessNode_303(), this.mSet_20, this.cacheNode_559(), this.mDependency_601.ep_55(), this.accessNode_386(), this.accessNode_494(), this.cacheNode_347(), new ProviderImpl(this, 246), this.cacheNode_353()));
+      this.mNode_84Instance = local;
+    }
+    return (Node_84) local;
+  }
+
+  Node_258 cacheNode_258() {
+    Object local = this.mNode_258Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_783());
+      this.mNode_258Instance = local;
+    }
+    return (Node_258) local;
+  }
+
+  Node_235 cacheNode_235() {
+    Object local = this.mNode_235Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_784(new ProviderImpl(this, 18), new CachingProviderImpl(this, 32), this.accessNode_427(), this.mSet_30, new ProviderImpl(this, 348), this.mDependency_601.ep_35(), this.cacheNode_147(), new ProviderImpl(this, 9), this.accessNode_571(), this.cacheNode_530(), this.cacheNode_40(), this.mDependency_601.ep_0(), this.mDependency_601.ep_2(), this.mDependency_601.ep_5(), this.cacheNode_139(), new ProviderImpl(this, 176), new ProviderImpl(this, 391)));
+      this.mNode_235Instance = local;
+    }
+    return (Node_235) local;
+  }
+
+  Node_121 cacheNode_121() {
+    Object local = this.mNode_121Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_785(new CachingProviderImpl(this, 482), new ProviderImpl(this, 491), new ProviderImpl(this, 15), this.mDependency_601.ep_32(), this.mDependency_601.ep_13(), new ProviderImpl(this, 336), this.mSet_14, new ProviderImpl(this, 117), new CachingProviderImpl(this, 62), new ProviderImpl(this, 268), this.mSet_17, new ProviderImpl(this, 342), this.mDependency_601.ep_35(), this.mDependency_601.ep_56(), new CachingProviderImpl(this, 272), new ProviderImpl(this, 350), new ProviderImpl(this, 228), new CachingProviderImpl(this, 293), this.accessNode_383(), new ProviderImpl(this, 46), this.mSet_21, this.cacheNode_98(), new ProviderImpl(this, 490), this.accessNode_134(), this.mDependency_601.ep_3(), new ProviderImpl(this, 245), this.mSet_31, new CachingProviderImpl(this, 417)));
+      this.mNode_121Instance = local;
+    }
+    return (Node_121) local;
+  }
+
+  Node_524 accessNode_524() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_786(new ProviderImpl(this, 344), new ProviderImpl(this, 200), new ProviderImpl(this, 28), new ProviderImpl(this, 397), this.mSet_27, this.cacheNode_584(), new ProviderImpl(this, 220), this.cacheNode_433(), new CachingProviderImpl(this, 504), this.cacheNode_206(), new ProviderImpl(this, 170), this.accessNode_51(), new CachingProviderImpl(this, 271), new CachingProviderImpl(this, 20), this.mDependency_601.ep_1(), new ProviderImpl(this, 46), this.cacheNode_360(), this.accessNode_533(), new ProviderImpl(this, 96), this.mSet_4, new CachingProviderImpl(this, 234), new CachingProviderImpl(this, 402)));
+  }
+
+  Node_501 accessNode_501() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_787(this.mSet_13, Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new ProviderImpl(this, 99), new ProviderImpl(this, 183), new ProviderImpl(this, 250), new CachingProviderImpl(this, 29), this.cacheNode_490(), new ProviderImpl(this, 525), this.mSet_19, new CachingProviderImpl(this, 430)));
+  }
+
+  Node_249 cacheNode_249() {
+    Object local = this.mNode_249Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_788(new CachingProviderImpl(this, 161), new ProviderImpl(this, 232), new CachingProviderImpl(this, 297)));
+      this.mNode_249Instance = local;
+    }
+    return (Node_249) local;
+  }
+
+  Node_186 accessNode_186() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_789(new CachingProviderImpl(this, 459), new ProviderImpl(this, 380), this.mSet_27, new ProviderImpl(this, 72), this.cacheNode_238(), new CachingProviderImpl(this, 372), new ProviderImpl(this, 175), this.accessNode_16(), this.mDependency_601.ep_17(), new CachingProviderImpl(this, 273)));
+  }
+
+  Node_477 cacheNode_477() {
+    Object local = this.mNode_477Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_790(new ProviderImpl(this, 121), new CachingProviderImpl(this, 393), new CachingProviderImpl(this, 25), this.accessNode_390(), this.accessNode_165(), new ProviderImpl(this, 317), this.mDependency_601.ep_31(), this.accessNode_152(), new CachingProviderImpl(this, 277), this.accessNode_595(), this.cacheNode_500(), this.accessNode_597(), this.cacheNode_341(), this.cacheNode_33(), this.mDependency_601.ep_42(), this.mSet_26, this.cacheNode_162(), this.accessNode_333(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), this.cacheNode_581(), this.accessNode_383()));
+      this.mNode_477Instance = local;
+    }
+    return (Node_477) local;
+  }
+
+  Node_336 accessNode_336() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_792(new ProviderImpl(this, 221), this.accessNode_467(), new ProviderImpl(this, 374), new CachingProviderImpl(this, 497)));
+  }
+
+  Node_592 cacheNode_592() {
+    Object local = this.mNode_592Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_793(this.accessNode_42(), this.cacheNode_457(), this.cacheNode_206(), this.accessNode_599(), new CachingProviderImpl(this, 214), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 69), this.mDependency_601.ep_1(), new ProviderImpl(this, 177), this.mSet_28, this.cacheNode_284(), new ProviderImpl(this, 464), this.accessNode_179(), this.cacheNode_598(), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), this.cacheNode_424(), new ProviderImpl(this, 50), Checks.checkProvisionNotNull(Module_608.Companion.provides_856()), this.accessNode_295(), this.accessNode_152(), this.accessNode_232(), this.accessNode_512(), this.cacheNode_562(), new ProviderImpl(this, 486), new ProviderImpl(this, 148), this.cacheNode_441(), new ProviderImpl(this, 508)));
+      this.mNode_592Instance = local;
+    }
+    return (Node_592) local;
+  }
+
+  Node_443 accessNode_443() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_794(this.accessNode_543(), new ProviderImpl(this, 134), new CachingProviderImpl(this, 522), this.cacheNode_340(), this.accessNode_329(), this.accessNode_336(), this.cacheNode_551(), new ProviderImpl(this, 229), new CachingProviderImpl(this, 450)));
+  }
+
+  Node_38 cacheNode_38() {
+    Object local = this.mNode_38Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_795());
+      this.mNode_38Instance = local;
+    }
+    return (Node_38) local;
+  }
+
+  Node_82 accessNode_82() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_796(new CachingProviderImpl(this, 223), new ProviderImpl(this, 19), this.mDependency_601.ep_39(), new ProviderImpl(this, 153), new CachingProviderImpl(this, 253), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 61), new ProviderImpl(this, 484), new CachingProviderImpl(this, 321), new CachingProviderImpl(this, 215), this.mDependency_601.ep_43()));
+  }
+
+  Node_245 cacheNode_245() {
+    Object local = this.mNode_245Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_797());
+      this.mNode_245Instance = local;
+    }
+    return (Node_245) local;
+  }
+
+  Node_487 cacheNode_487() {
+    Object local = this.mNode_487Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_798(new ProviderImpl(this, 38), this.mSet_6, new CachingProviderImpl(this, 471), new CachingProviderImpl(this, 276), this.cacheNode_40(), new CachingProviderImpl(this, 52), this.cacheNode_193(), this.mDependency_601.ep_36(), new ProviderImpl(this, 333), this.accessNode_4(), new ProviderImpl(this, 24), new ProviderImpl(this, 189), new ProviderImpl(this, 180), new ProviderImpl(this, 336), this.cacheNode_560(), new ProviderImpl(this, 141), new CachingProviderImpl(this, 293), new CachingProviderImpl(this, 69)));
+      this.mNode_487Instance = local;
+    }
+    return (Node_487) local;
+  }
+
+  Node_152 accessNode_152() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_799(new ProviderImpl(this, 304), this.cacheNode_424(), this.accessNode_571(), this.cacheNode_521(), this.mSet_3, this.accessNode_140(), new ProviderImpl(this, 223), this.accessNode_126(), new ProviderImpl(this, 63), this.accessNode_507(), this.accessNode_552()));
+  }
+
+  Node_331 accessNode_331() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_800(this.accessNode_203(), new CachingProviderImpl(this, 440), new ProviderImpl(this, 395), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 205), new ProviderImpl(this, 376), new ProviderImpl(this, 526), new ProviderImpl(this, 280), new CachingProviderImpl(this, 250), this.mSet_35, this.mSet_33));
+  }
+
+  Node_555 cacheNode_555() {
+    Object local = this.mNode_555Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_801(this.accessNode_142()));
+      this.mNode_555Instance = local;
+    }
+    return (Node_555) local;
+  }
+
+  Node_155 cacheNode_155() {
+    Object local = this.mNode_155Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_803(this.cacheNode_229(), new ProviderImpl(this, 282), new CachingProviderImpl(this, 321), new ProviderImpl(this, 433), new CachingProviderImpl(this, 223), new CachingProviderImpl(this, 460), new ProviderImpl(this, 385), new ProviderImpl(this, 456), new ProviderImpl(this, 177), new ProviderImpl(this, 366), new ProviderImpl(this, 268), this.mDependency_601.ep_29()));
+      this.mNode_155Instance = local;
+    }
+    return (Node_155) local;
+  }
+
+  Node_25 cacheNode_25() {
+    Object local = this.mNode_25Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_804(new ProviderImpl(this, 348), this.cacheNode_121(), this.mSet_2, this.accessNode_329(), new CachingProviderImpl(this, 20)));
+      this.mNode_25Instance = local;
+    }
+    return (Node_25) local;
+  }
+
+  Node_28 accessNode_28() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_805(this.cacheNode_218(), new ProviderImpl(this, 46), new ProviderImpl(this, 185), new CachingProviderImpl(this, 436), this.mSet_7, new ProviderImpl(this, 165), new ProviderImpl(this, 489), this.accessNode_213(), this.cacheNode_487(), this.accessNode_116(), new CachingProviderImpl(this, 129), this.cacheNode_135(), new ProviderImpl(this, 475), new ProviderImpl(this, 115), this.cacheNode_318(), this.cacheNode_155(), this.mDependency_601.ep_3(), this.cacheNode_160(), new ProviderImpl(this, 1), this.accessNode_264(), this.cacheNode_407(), this.accessNode_483(), this.accessNode_140(), new ProviderImpl(this, 110), this.cacheNode_572(), this.cacheNode_261(), this.accessNode_365(), this.accessNode_504()));
+  }
+
+  Node_95 cacheNode_95() {
+    Object local = this.mNode_95Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_806());
+      this.mNode_95Instance = local;
+    }
+    return (Node_95) local;
+  }
+
+  Node_464 cacheNode_464() {
+    Object local = this.mNode_464Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_807(this.cacheNode_559(), this.accessNode_558(), this.accessNode_282(), this.mSet_40, this.cacheNode_416(), this.cacheNode_468(), Checks.checkProvisionNotNull(Module_608.Companion.provides_802())));
+      this.mNode_464Instance = local;
+    }
+    return (Node_464) local;
+  }
+
+  Node_265 accessNode_265() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_808(new CachingProviderImpl(this, 482), new CachingProviderImpl(this, 126), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), this.accessNode_389(), new CachingProviderImpl(this, 527), this.mSet_46));
+  }
+
+  Node_134 accessNode_134() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_809(new CachingProviderImpl(this, 84), new CachingProviderImpl(this, 388), this.accessNode_494(), this.accessNode_512(), this.mDependency_601.ep_9(), this.accessNode_59(), new ProviderImpl(this, 352), this.accessNode_397(), new ProviderImpl(this, 389), new ProviderImpl(this, 85), new ProviderImpl(this, 22), this.accessNode_85(), new ProviderImpl(this, 390), new CachingProviderImpl(this, 82), new ProviderImpl(this, 391), new CachingProviderImpl(this, 186), new ProviderImpl(this, 213), new ProviderImpl(this, 12), this.cacheNode_459(), this.mDependency_601.ep_55(), this.cacheNode_499(), this.mSet_50, new ProviderImpl(this, 47)));
+  }
+
+  Node_312 accessNode_312() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_811(this.mSet_51, this.cacheNode_13(), this.mDependency_601.ep_34(), this.mSet_29, new CachingProviderImpl(this, 128), this.cacheNode_575(), this.cacheNode_407(), this.accessNode_480(), this.accessNode_517(), new CachingProviderImpl(this, 160), this.cacheNode_578()));
+  }
+
+  Node_119 accessNode_119() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_812(this.accessNode_152(), this.accessNode_342(), new ProviderImpl(this, 220)));
+  }
+
+  Node_387 accessNode_387() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_813(new ProviderImpl(this, 235), this.cacheNode_570(), this.cacheNode_537(), new ProviderImpl(this, 499), this.accessNode_153(), new CachingProviderImpl(this, 428)));
+  }
+
+  Node_273 cacheNode_273() {
+    Object local = this.mNode_273Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_814());
+      this.mNode_273Instance = local;
+    }
+    return (Node_273) local;
+  }
+
+  Node_473 accessNode_473() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_815(this.mSet_7, this.cacheNode_244(), this.accessNode_134(), this.accessNode_85(), new ProviderImpl(this, 402), this.mDependency_601.ep_28(), this.cacheNode_131(), this.mSet_37, new CachingProviderImpl(this, 315), this.accessNode_317(), this.cacheNode_99(), this.cacheNode_420(), new CachingProviderImpl(this, 159), new CachingProviderImpl(this, 122), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 243), new ProviderImpl(this, 460), this.accessNode_239(), this.accessNode_59(), this.accessNode_263(), this.accessNode_590(), this.accessNode_23(), new ProviderImpl(this, 342), this.accessNode_582(), this.cacheNode_120(), new CachingProviderImpl(this, 191), this.cacheNode_531(), this.accessNode_599(), new ProviderImpl(this, 154), this.cacheNode_593()));
+  }
+
+  Node_311 accessNode_311() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_816(this.accessNode_18(), new ProviderImpl(this, 137), new ProviderImpl(this, 374), new ProviderImpl(this, 392), new CachingProviderImpl(this, 474), new ProviderImpl(this, 472), this.mSet_27, this.mSet_16, this.cacheNode_215(), this.mDependency_601.ep_48(), this.cacheNode_114(), new CachingProviderImpl(this, 286), this.cacheNode_551(), this.mDependency_601.ep_31(), new ProviderImpl(this, 435), this.mSet_8, this.mSet_30, this.accessNode_385(), this.accessNode_480(), this.accessNode_116(), new CachingProviderImpl(this, 205), this.mDependency_601.ep_13(), new CachingProviderImpl(this, 293), this.mSet_6, new CachingProviderImpl(this, 10)));
+  }
+
+  Node_564 accessNode_564() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_817(this.accessNode_184(), new ProviderImpl(this, 424), this.accessNode_85(), new ProviderImpl(this, 268), this.mDependency_601.ep_35(), this.accessNode_56(), new ProviderImpl(this, 376), this.cacheNode_360(), new ProviderImpl(this, 516), new ProviderImpl(this, 23), this.mDependency_601.ep_24(), this.accessNode_134(), new CachingProviderImpl(this, 25), Checks.checkProvisionNotNull(Module_608.Companion.provides_832()), this.accessNode_454(), new ProviderImpl(this, 187), this.cacheNode_233(), new ProviderImpl(this, 414), this.accessNode_561()));
+  }
+
+  Node_314 accessNode_314() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_818(this.cacheNode_527(), this.cacheNode_147(), new ProviderImpl(this, 313), this.accessNode_22(), this.accessNode_561(), new ProviderImpl(this, 137), this.cacheNode_511(), this.cacheNode_551(), this.cacheNode_372(), new CachingProviderImpl(this, 79)));
+  }
+
+  Node_395 accessNode_395() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_819(new CachingProviderImpl(this, 487), this.accessNode_45(), this.accessNode_543(), new ProviderImpl(this, 346), new CachingProviderImpl(this, 260), this.accessNode_282(), new ProviderImpl(this, 266), new ProviderImpl(this, 70), new ProviderImpl(this, 112), this.cacheNode_391(), new ProviderImpl(this, 187)));
+  }
+
+  Node_461 cacheNode_461() {
+    Object local = this.mNode_461Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_820(this.mSet_41, this.cacheNode_325(), this.mSet_13, new CachingProviderImpl(this, 29), this.mSet_11, this.accessNode_214(), this.cacheNode_206(), this.accessNode_367(), new CachingProviderImpl(this, 253), this.accessNode_179(), this.accessNode_106(), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), this.accessNode_510(), this.accessNode_365(), new CachingProviderImpl(this, 525), this.accessNode_466(), this.accessNode_16(), this.accessNode_186(), new ProviderImpl(this, 352), new CachingProviderImpl(this, 522), this.accessNode_103()));
+      this.mNode_461Instance = local;
+    }
+    return (Node_461) local;
+  }
+
+  Node_553 cacheNode_553() {
+    Object local = this.mNode_553Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_821(new CachingProviderImpl(this, 428), new CachingProviderImpl(this, 131), this.cacheNode_490(), new ProviderImpl(this, 492), this.cacheNode_441(), this.mSet_23, new ProviderImpl(this, 346), this.accessNode_350(), this.cacheNode_198(), this.cacheNode_29(), this.accessNode_127(), this.cacheNode_64(), this.mSet_7, this.cacheNode_562(), this.accessNode_137(), this.mDependency_601.ep_57(), new ProviderImpl(this, 18)));
+      this.mNode_553Instance = local;
+    }
+    return (Node_553) local;
+  }
+
+  Node_342 accessNode_342() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_822(this.cacheNode_565(), new CachingProviderImpl(this, 310), new CachingProviderImpl(this, 281), this.mSet_51, new ProviderImpl(this, 274), this.accessNode_427(), this.mSet_17, new ProviderImpl(this, 486), this.cacheNode_207(), this.cacheNode_101(), this.mDependency_601.ep_13(), new ProviderImpl(this, 245), new ProviderImpl(this, 325), this.mDependency_601.ep_32(), this.accessNode_548(), this.cacheNode_155(), new CachingProviderImpl(this, 289), this.cacheNode_40(), this.accessNode_383(), new ProviderImpl(this, 388), this.cacheNode_528(), this.cacheNode_375(), new CachingProviderImpl(this, 254)));
+  }
+
+  Node_215 cacheNode_215() {
+    Object local = this.mNode_215Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_824());
+      this.mNode_215Instance = local;
+    }
+    return (Node_215) local;
+  }
+
+  Node_275 accessNode_275() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_825(new ProviderImpl(this, 244), new CachingProviderImpl(this, 411), new CachingProviderImpl(this, 186), new CachingProviderImpl(this, 482), new CachingProviderImpl(this, 483), new ProviderImpl(this, 403), this.mDependency_601.ep_54(), this.cacheNode_441(), this.accessNode_515(), this.cacheNode_306(), new ProviderImpl(this, 249), new ProviderImpl(this, 229), new ProviderImpl(this, 477), this.mDependency_601.ep_3(), new ProviderImpl(this, 2), this.mDependency_601.ep_0(), new CachingProviderImpl(this, 262), this.mSet_40, this.accessNode_23(), new ProviderImpl(this, 53), this.cacheNode_340(), new CachingProviderImpl(this, 34), new CachingProviderImpl(this, 201)));
+  }
+
+  Node_182 accessNode_182() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_826(this.mDependency_601.ep_25(), this.cacheNode_121(), this.mDependency_601.ep_22(), this.accessNode_425(), new CachingProviderImpl(this, 251), this.accessNode_107(), this.mDependency_601.ep_14(), this.mDependency_601.ep_20(), this.accessNode_27(), this.accessNode_113(), this.accessNode_225(), new CachingProviderImpl(this, 192), this.mSet_50, this.mSet_42, new ProviderImpl(this, 131), new CachingProviderImpl(this, 310)));
+  }
+
+  Node_92 accessNode_92() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_827(new CachingProviderImpl(this, 485)));
+  }
+
+  Node_297 accessNode_297() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_828(new ProviderImpl(this, 137), this.cacheNode_288(), new ProviderImpl(this, 141), new ProviderImpl(this, 519), this.cacheNode_550(), new ProviderImpl(this, 276), new CachingProviderImpl(this, 367), new CachingProviderImpl(this, 305), new CachingProviderImpl(this, 91), this.cacheNode_352(), new ProviderImpl(this, 38), new ProviderImpl(this, 453), new CachingProviderImpl(this, 481), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 95), this.accessNode_385(), this.mSet_10, new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 61), new ProviderImpl(this, 151), new ProviderImpl(this, 201), new ProviderImpl(this, 346), new CachingProviderImpl(this, 206), this.cacheNode_6(), new CachingProviderImpl(this, 103), this.accessNode_23(), this.mSet_24, this.mSet_23));
+  }
+
+  Node_543 accessNode_543() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_829(new CachingProviderImpl(this, 80), new ProviderImpl(this, 321), this.mDependency_601.ep_54(), new ProviderImpl(this, 337), new Node_181(), this.cacheNode_556(), this.cacheNode_233()));
+  }
+
+  Node_386 accessNode_386() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_830(new CachingProviderImpl(this, 139), this.mDependency_601.ep_49(), this.cacheNode_233(), new CachingProviderImpl(this, 417), this.cacheNode_242(), this.mDependency_601.ep_56(), new CachingProviderImpl(this, 402), this.mSet_45, new CachingProviderImpl(this, 398), this.accessNode_92(), new ProviderImpl(this, 316), this.mDependency_601.ep_2(), this.cacheNode_162(), new CachingProviderImpl(this, 260), new ProviderImpl(this, 90), new ProviderImpl(this, 298), this.accessNode_351(), new ProviderImpl(this, 391), new CachingProviderImpl(this, 480), this.mSet_48));
+  }
+
+  Node_76 cacheNode_76() {
+    Object local = this.mNode_76Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_831());
+      this.mNode_76Instance = local;
+    }
+    return (Node_76) local;
+  }
+
+  Node_168 cacheNode_168() {
+    Object local = this.mNode_168Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_833(Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), this.mSet_40, this.accessNode_317()));
+      this.mNode_168Instance = local;
+    }
+    return (Node_168) local;
+  }
+
+  Node_396 accessNode_396() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_834(this.accessNode_297(), new ProviderImpl(this, 131), this.accessNode_164(), this.accessNode_4(), this.accessNode_383(), this.accessNode_300(), this.accessNode_27(), new CachingProviderImpl(this, 170), this.accessNode_187(), new CachingProviderImpl(this, 205), new ProviderImpl(this, 343), new CachingProviderImpl(this, 315), this.accessNode_494(), new ProviderImpl(this, 316), this.accessNode_543(), this.mDependency_601.ep_18(), Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), new CachingProviderImpl(this, 396), new ProviderImpl(this, 255), this.mSet_19, new ProviderImpl(this, 399), this.cacheNode_242(), new ProviderImpl(this, 13), this.cacheNode_67(), new CachingProviderImpl(this, 266), new ProviderImpl(this, 336), new ProviderImpl(this, 12)));
+  }
+
+  Node_364 accessNode_364() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_835(new ProviderImpl(this, 136), new ProviderImpl(this, 22), this.mDependency_601.ep_35(), new ProviderImpl(this, 41), new CachingProviderImpl(this, 347), new ProviderImpl(this, 188), this.accessNode_421(), new ProviderImpl(this, 87), new CachingProviderImpl(this, 304), this.cacheNode_528(), new ProviderImpl(this, 151), this.mDependency_601.ep_6(), new ProviderImpl(this, 185), new ProviderImpl(this, 38), new ProviderImpl(this, 479)));
+  }
+
+  Node_363 accessNode_363() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_836(new CachingProviderImpl(this, 293), new ProviderImpl(this, 169), this.accessNode_330(), new ProviderImpl(this, 516), new CachingProviderImpl(this, 170)));
+  }
+
+  Node_356 cacheNode_356() {
+    Object local = this.mNode_356Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_837(this.accessNode_467(), this.cacheNode_242(), new ProviderImpl(this, 331), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), this.mSet_40, new ProviderImpl(this, 280), new CachingProviderImpl(this, 372), this.accessNode_496(), this.accessNode_410(), this.accessNode_296(), new ProviderImpl(this, 210), Checks.checkProvisionNotNull(Module_608.Companion.provides_699()), this.accessNode_213(), this.cacheNode_310(), this.accessNode_529(), new CachingProviderImpl(this, 525), this.mSet_37, new ProviderImpl(this, 156), this.cacheNode_560(), new ProviderImpl(this, 498), this.accessNode_295(), new ProviderImpl(this, 163), this.mSet_35, new ProviderImpl(this, 176), this.accessNode_171(), this.cacheNode_147(), this.accessNode_93(), this.accessNode_268()));
+      this.mNode_356Instance = local;
+    }
+    return (Node_356) local;
+  }
+
+  Node_89 cacheNode_89() {
+    Object local = this.mNode_89Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_838(this.accessNode_496(), new ProviderImpl(this, 282), this.mSet_7, this.accessNode_386(), this.cacheNode_101(), this.accessNode_456(), this.accessNode_343(), this.mSet_46, new ProviderImpl(this, 4), this.cacheNode_404(), this.accessNode_515(), this.accessNode_74(), new ProviderImpl(this, 218), new CachingProviderImpl(this, 339), this.accessNode_470(), this.accessNode_418(), this.accessNode_222(), this.cacheNode_121(), new ProviderImpl(this, 198), new ProviderImpl(this, 117), this.accessNode_564(), this.accessNode_473(), new CachingProviderImpl(this, 410), this.mSet_34, new CachingProviderImpl(this, 91)));
+      this.mNode_89Instance = local;
+    }
+    return (Node_89) local;
+  }
+
+  Node_60 cacheNode_60() {
+    Object local = this.mNode_60Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_839(this.accessNode_102(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 471), new ProviderImpl(this, 316), new CachingProviderImpl(this, 482), this.cacheNode_249(), this.cacheNode_215(), new ProviderImpl(this, 86), this.cacheNode_401(), this.accessNode_282(), this.cacheNode_580(), this.accessNode_558(), this.accessNode_219(), this.mSet_37, this.accessNode_295(), this.accessNode_574(), new ProviderImpl(this, 62), this.mSet_40, new CachingProviderImpl(this, 21), this.cacheNode_417()));
+      this.mNode_60Instance = local;
+    }
+    return (Node_60) local;
+  }
+
+  Node_299 accessNode_299() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_840(new ProviderImpl(this, 106), this.cacheNode_422(), this.accessNode_93(), this.accessNode_458(), new ProviderImpl(this, 75), this.mDependency_601.ep_48(), this.mDependency_601.ep_33(), this.accessNode_301(), this.accessNode_18(), this.mDependency_601.ep_24(), this.accessNode_543(), this.cacheNode_258(), this.accessNode_501(), this.mSet_2, new CachingProviderImpl(this, 123), this.accessNode_483()));
+  }
+
+  Node_334 cacheNode_334() {
+    Object local = this.mNode_334Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_841(new CachingProviderImpl(this, 306), new ProviderImpl(this, 231)));
+      this.mNode_334Instance = local;
+    }
+    return (Node_334) local;
+  }
+
+  Node_475 cacheNode_475() {
+    Object local = this.mNode_475Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_842(new CachingProviderImpl(this, 83), new CachingProviderImpl(this, 525), new ProviderImpl(this, 120), this.mDependency_601.ep_7(), new ProviderImpl(this, 348), this.accessNode_534(), this.cacheNode_589(), new ProviderImpl(this, 374), this.accessNode_133(), this.accessNode_387(), this.mSet_51, this.cacheNode_286(), new CachingProviderImpl(this, 119), this.accessNode_222(), this.accessNode_336(), this.accessNode_390()));
+      this.mNode_475Instance = local;
+    }
+    return (Node_475) local;
+  }
+
+  Node_561 accessNode_561() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_843(new ProviderImpl(this, 456), new CachingProviderImpl(this, 247), this.cacheNode_391(), this.cacheNode_218(), this.accessNode_432(), this.accessNode_443(), this.accessNode_56(), new CachingProviderImpl(this, 193), new CachingProviderImpl(this, 386), new CachingProviderImpl(this, 55), new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 85), new ProviderImpl(this, 22), this.cacheNode_352(), new ProviderImpl(this, 280), this.accessNode_421(), this.accessNode_305(), this.cacheNode_29(), new CachingProviderImpl(this, 120), new CachingProviderImpl(this, 266), new ProviderImpl(this, 232)));
+  }
+
+  Node_180 cacheNode_180() {
+    Object local = this.mNode_180Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_844(this.mSet_19, this.cacheNode_190(), new CachingProviderImpl(this, 485), new CachingProviderImpl(this, 222), this.mSet_51, this.accessNode_381(), this.mSet_0, this.accessNode_458(), new ProviderImpl(this, 369), this.cacheNode_575(), new ProviderImpl(this, 242), new CachingProviderImpl(this, 188), this.mDependency_601.ep_16()));
+      this.mNode_180Instance = local;
+    }
+    return (Node_180) local;
+  }
+
+  Node_197 accessNode_197() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_845(this.accessNode_393(), this.mDependency_601.ep_51(), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new CachingProviderImpl(this, 294), this.accessNode_332()));
+  }
+
+  Node_218 cacheNode_218() {
+    Object local = this.mNode_218Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_846(this.mDependency_601.ep_7(), new ProviderImpl(this, 307), new CachingProviderImpl(this, 262), new CachingProviderImpl(this, 429), new CachingProviderImpl(this, 272), new ProviderImpl(this, 2), this.mDependency_601.ep_22(), this.mSet_10, this.mSet_7, new CachingProviderImpl(this, 43), this.cacheNode_404(), new CachingProviderImpl(this, 281), new ProviderImpl(this, 218), new CachingProviderImpl(this, 205), this.cacheNode_101(), new ProviderImpl(this, 323), new ProviderImpl(this, 96), new CachingProviderImpl(this, 130), new CachingProviderImpl(this, 139), this.accessNode_216(), this.mDependency_601.ep_30(), this.mSet_29, this.cacheNode_15(), new CachingProviderImpl(this, 60)));
+      this.mNode_218Instance = local;
+    }
+    return (Node_218) local;
+  }
+
+  Node_504 accessNode_504() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_847(this.cacheNode_586(), this.cacheNode_513(), this.accessNode_367(), this.accessNode_470(), this.mSet_40, this.accessNode_558(), new ProviderImpl(this, 466), this.accessNode_358(), this.accessNode_480(), this.mSet_15, this.accessNode_115(), this.accessNode_209(), this.mSet_34, new ProviderImpl(this, 50), this.cacheNode_241(), new ProviderImpl(this, 315), this.accessNode_561(), this.mDependency_601.ep_52(), this.accessNode_216(), new CachingProviderImpl(this, 329), this.accessNode_496(), this.cacheNode_551(), this.mSet_3, this.accessNode_42(), this.cacheNode_391(), new ProviderImpl(this, 303), this.accessNode_21(), this.accessNode_449()));
+  }
+
+  Node_80 cacheNode_80() {
+    Object local = this.mNode_80Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_848(this.accessNode_533(), new ProviderImpl(this, 140), new ProviderImpl(this, 112), this.cacheNode_215(), this.mSet_6, this.cacheNode_391(), new CachingProviderImpl(this, 379), this.accessNode_362(), this.cacheNode_146(), this.accessNode_61(), this.cacheNode_258(), this.cacheNode_162(), this.cacheNode_404(), this.accessNode_274()));
+      this.mNode_80Instance = local;
+    }
+    return (Node_80) local;
+  }
+
+  Node_149 accessNode_149() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_849(this.mDependency_601.ep_22(), this.accessNode_201(), this.cacheNode_66(), new ProviderImpl(this, 318)));
+  }
+
+  Node_172 accessNode_172() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_850(this.accessNode_18(), this.accessNode_299(), new ProviderImpl(this, 346), new ProviderImpl(this, 101), new ProviderImpl(this, 36), new ProviderImpl(this, 73), new ProviderImpl(this, 107), this.cacheNode_426(), this.cacheNode_250(), new ProviderImpl(this, 239), new CachingProviderImpl(this, 25), this.cacheNode_146(), new ProviderImpl(this, 16), new CachingProviderImpl(this, 120), this.accessNode_438(), this.accessNode_447(), this.accessNode_282(), this.accessNode_118(), this.cacheNode_212(), new ProviderImpl(this, 143), this.accessNode_332(), new ProviderImpl(this, 191), this.accessNode_343(), this.accessNode_136(), this.cacheNode_77()));
+  }
+
+  Node_100 cacheNode_100() {
+    Object local = this.mNode_100Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_851(new ProviderImpl(this, 312), this.mSet_40, this.cacheNode_180()));
+      this.mNode_100Instance = local;
+    }
+    return (Node_100) local;
+  }
+
+  Node_531 cacheNode_531() {
+    Object local = this.mNode_531Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_852(new ProviderImpl(this, 496), new ProviderImpl(this, 506), new CachingProviderImpl(this, 480), new ProviderImpl(this, 218), new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 310), this.mDependency_601.ep_30(), this.cacheNode_328(), this.accessNode_51()));
+      this.mNode_531Instance = local;
+    }
+    return (Node_531) local;
+  }
+
+  Node_533 accessNode_533() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_853(new ProviderImpl(this, 331), new CachingProviderImpl(this, 206), new CachingProviderImpl(this, 25), this.mDependency_601.ep_33(), this.mDependency_601.ep_21(), this.mDependency_601.ep_39(), new ProviderImpl(this, 271), new ProviderImpl(this, 445), this.mSet_48, this.mDependency_601.ep_14(), new ProviderImpl(this, 91), new CachingProviderImpl(this, 289), new CachingProviderImpl(this, 497), new CachingProviderImpl(this, 236), new ProviderImpl(this, 258), new ProviderImpl(this, 99), new CachingProviderImpl(this, 83), this.mDependency_601.ep_6(), new ProviderImpl(this, 280)));
+  }
+
+  Node_238 cacheNode_238() {
+    Object local = this.mNode_238Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_854(new ProviderImpl(this, 35), this.accessNode_336(), new CachingProviderImpl(this, 82), new ProviderImpl(this, 189), new CachingProviderImpl(this, 161), new CachingProviderImpl(this, 197), new ProviderImpl(this, 187), new ProviderImpl(this, 245), new ProviderImpl(this, 195)));
+      this.mNode_238Instance = local;
+    }
+    return (Node_238) local;
+  }
+
+  Node_58 cacheNode_58() {
+    Object local = this.mNode_58Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_855(new ProviderImpl(this, 50), this.accessNode_329(), this.cacheNode_234(), this.cacheNode_551(), this.mSet_42, this.cacheNode_233(), this.mDependency_601.ep_21(), this.accessNode_397(), this.cacheNode_404(), new CachingProviderImpl(this, 253), this.cacheNode_2(), this.cacheNode_176()));
+      this.mNode_58Instance = local;
+    }
+    return (Node_58) local;
+  }
+
+  Node_330 accessNode_330() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_857(new ProviderImpl(this, 107), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), new ProviderImpl(this, 12), this.cacheNode_72(), this.mDependency_601.ep_57()));
+  }
+
+  Node_43 accessNode_43() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_858(this.accessNode_399(), new CachingProviderImpl(this, 315), new ProviderImpl(this, 6), new CachingProviderImpl(this, 307), this.cacheNode_550(), new ProviderImpl(this, 374), this.accessNode_134(), this.accessNode_61(), new ProviderImpl(this, 330)));
+  }
+
+  Node_536 accessNode_536() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_859(new CachingProviderImpl(this, 482), new CachingProviderImpl(this, 524), this.accessNode_501(), this.mDependency_601.ep_1(), new CachingProviderImpl(this, 52), this.accessNode_419(), this.cacheNode_242(), this.accessNode_394()));
+  }
+
+  Node_575 cacheNode_575() {
+    Object local = this.mNode_575Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_860(new CachingProviderImpl(this, 253), new CachingProviderImpl(this, 223), this.accessNode_348(), this.accessNode_395(), this.cacheNode_537(), new ProviderImpl(this, 373)));
+      this.mNode_575Instance = local;
+    }
+    return (Node_575) local;
+  }
+
+  Node_114 cacheNode_114() {
+    Object local = this.mNode_114Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_861(this.accessNode_524(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 61)));
+      this.mNode_114Instance = local;
+    }
+    return (Node_114) local;
+  }
+
+  Node_413 cacheNode_413() {
+    Object local = this.mNode_413Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_862(new ProviderImpl(this, 155), this.mSet_11, new CachingProviderImpl(this, 294), this.mDependency_601.ep_15(), new ProviderImpl(this, 404), this.accessNode_23(), this.accessNode_18(), this.mDependency_601.ep_7(), this.accessNode_305(), this.cacheNode_570(), this.mDependency_601.ep_23(), new ProviderImpl(this, 213), this.mSet_34, new CachingProviderImpl(this, 248), this.accessNode_494(), this.cacheNode_215(), new CachingProviderImpl(this, 42), this.accessNode_115(), new CachingProviderImpl(this, 144), this.mSet_30, new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 206), this.cacheNode_459(), this.mDependency_601.ep_54(), new CachingProviderImpl(this, 474), this.cacheNode_530(), this.mSet_18, new CachingProviderImpl(this, 222), this.mSet_14));
+      this.mNode_413Instance = local;
+    }
+    return (Node_413) local;
+  }
+
+  Node_257 accessNode_257() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_863(this.mSet_42, new CachingProviderImpl(this, 347), new ProviderImpl(this, 390), this.cacheNode_334(), this.accessNode_163(), new CachingProviderImpl(this, 412), new CachingProviderImpl(this, 160), new ProviderImpl(this, 218), this.cacheNode_238(), this.cacheNode_284(), this.mDependency_601.ep_54(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), this.mSet_21, this.cacheNode_460(), this.cacheNode_83(), this.mDependency_601.ep_22(), new ProviderImpl(this, 187), new CachingProviderImpl(this, 288), this.accessNode_548(), this.mDependency_601.ep_20(), this.accessNode_303(), this.accessNode_339(), new ProviderImpl(this, 508), new ProviderImpl(this, 181), this.mDependency_601.ep_4(), new ProviderImpl(this, 385), new ProviderImpl(this, 5), new ProviderImpl(this, 156), new CachingProviderImpl(this, 269)));
+  }
+
+  Node_102 accessNode_102() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_864(new ProviderImpl(this, 444), new ProviderImpl(this, 415), new ProviderImpl(this, 399), this.mDependency_601.ep_1(), new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 8), new ProviderImpl(this, 425), new ProviderImpl(this, 328), this.mDependency_601.ep_37(), new ProviderImpl(this, 229), new ProviderImpl(this, 403), this.mSet_13, this.accessNode_595(), this.cacheNode_249(), this.accessNode_51(), this.accessNode_456(), new CachingProviderImpl(this, 120), new ProviderImpl(this, 440), Checks.checkProvisionNotNull(Module_608.Companion.provides_856()), new ProviderImpl(this, 230), this.cacheNode_366(), this.mDependency_601.ep_19(), new ProviderImpl(this, 256)));
+  }
+
+  Node_362 accessNode_362() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_865(this.mDependency_601.ep_30(), this.accessNode_399(), this.accessNode_385(), this.accessNode_564(), new CachingProviderImpl(this, 454), this.cacheNode_6(), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), new ProviderImpl(this, 41), this.accessNode_51(), this.cacheNode_121(), this.mDependency_601.ep_35(), this.cacheNode_29(), this.cacheNode_190(), this.accessNode_576(), new ProviderImpl(this, 344), new CachingProviderImpl(this, 216), new CachingProviderImpl(this, 166), this.cacheNode_67(), this.cacheNode_15(), this.accessNode_175(), new ProviderImpl(this, 143), this.cacheNode_122(), this.cacheNode_598(), new ProviderImpl(this, 165)));
+  }
+
+  Node_520 cacheNode_520() {
+    Object local = this.mNode_520Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_866());
+      this.mNode_520Instance = local;
+    }
+    return (Node_520) local;
+  }
+
+  Node_8 accessNode_8() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_867(this.cacheNode_101(), this.mDependency_601.ep_4(), new CachingProviderImpl(this, 442), new CachingProviderImpl(this, 315), this.cacheNode_490(), new ProviderImpl(this, 25), new CachingProviderImpl(this, 25), this.mSet_46, this.mSet_12, this.accessNode_571(), new ProviderImpl(this, 285), new CachingProviderImpl(this, 120), new ProviderImpl(this, 61), new CachingProviderImpl(this, 327), this.accessNode_333(), new CachingProviderImpl(this, 82), this.mSet_32, this.cacheNode_413(), new ProviderImpl(this, 91), new ProviderImpl(this, 159), this.mDependency_601.ep_10()));
+  }
+
+  Node_404 cacheNode_404() {
+    Object local = this.mNode_404Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_868(this.mSet_39, new ProviderImpl(this, 456), new CachingProviderImpl(this, 59), new ProviderImpl(this, 33), new ProviderImpl(this, 213), new CachingProviderImpl(this, 25), this.cacheNode_101(), new CachingProviderImpl(this, 343), new ProviderImpl(this, 374), new CachingProviderImpl(this, 306), this.mDependency_601.ep_43(), new ProviderImpl(this, 37), new CachingProviderImpl(this, 47), new CachingProviderImpl(this, 215), new ProviderImpl(this, 287)));
+      this.mNode_404Instance = local;
+    }
+    return (Node_404) local;
+  }
+
+  Node_40 cacheNode_40() {
+    Object local = this.mNode_40Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_869());
+      this.mNode_40Instance = local;
+    }
+    return (Node_40) local;
+  }
+
+  Node_240 accessNode_240() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_870(this.cacheNode_531(), this.mSet_14, this.cacheNode_104(), new ProviderImpl(this, 280), this.mDependency_601.ep_9(), this.accessNode_343(), this.mSet_28, this.cacheNode_26(), this.cacheNode_37(), new ProviderImpl(this, 17), this.cacheNode_477(), this.mSet_41, this.cacheNode_426(), new CachingProviderImpl(this, 266), this.mSet_42, new CachingProviderImpl(this, 109), this.accessNode_179(), this.mDependency_601.ep_41(), this.accessNode_12(), this.accessNode_364(), this.accessNode_18(), this.accessNode_182(), this.cacheNode_445()));
+  }
+
+  Node_86 accessNode_86() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_871(this.mSet_17, new CachingProviderImpl(this, 69), new CachingProviderImpl(this, 347), this.accessNode_264(), new ProviderImpl(this, 285), this.accessNode_5(), this.mDependency_601.ep_34(), this.accessNode_313(), this.accessNode_27(), this.cacheNode_2(), new ProviderImpl(this, 232), this.mDependency_601.ep_17(), new ProviderImpl(this, 527), this.cacheNode_461()));
+  }
+
+  Node_421 accessNode_421() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_872(this.cacheNode_104(), this.cacheNode_193(), this.mDependency_601.ep_15(), this.accessNode_439(), new ProviderImpl(this, 24), this.mDependency_601.ep_34(), this.cacheNode_234(), new ProviderImpl(this, 113), new ProviderImpl(this, 75)));
+  }
+
+  Node_156 cacheNode_156() {
+    Object local = this.mNode_156Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_873(this.accessNode_301(), this.cacheNode_318(), this.mSet_1, this.cacheNode_253(), this.mSet_50, new CachingProviderImpl(this, 355)));
+      this.mNode_156Instance = local;
+    }
+    return (Node_156) local;
+  }
+
+  Node_374 accessNode_374() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_874(this.mDependency_601.ep_35(), this.cacheNode_415(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 126), this.accessNode_483(), this.accessNode_409(), this.accessNode_166(), this.accessNode_599(), this.mSet_4, new CachingProviderImpl(this, 25), this.accessNode_496(), this.cacheNode_420()));
+  }
+
+  Node_571 accessNode_571() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_875(new ProviderImpl(this, 280), new ProviderImpl(this, 336), new ProviderImpl(this, 42), new ProviderImpl(this, 148), new CachingProviderImpl(this, 23), new ProviderImpl(this, 376), new CachingProviderImpl(this, 89), new CachingProviderImpl(this, 470), new ProviderImpl(this, 325), new ProviderImpl(this, 187), new CachingProviderImpl(this, 209), new CachingProviderImpl(this, 382), new ProviderImpl(this, 2), this.mSet_10, this.accessNode_597(), new CachingProviderImpl(this, 7), new ProviderImpl(this, 214), new CachingProviderImpl(this, 126), new CachingProviderImpl(this, 98), new ProviderImpl(this, 477), new ProviderImpl(this, 489), new ProviderImpl(this, 34), this.cacheNode_506(), new ProviderImpl(this, 178), this.cacheNode_238(), new ProviderImpl(this, 431), new ProviderImpl(this, 433)));
+  }
+
+  Node_78 accessNode_78() {
+    return Checks.checkProvisionNotNull(Module_608.Companion.provides_876(this.accessNode_518(), Checks.checkProvisionNotNull(Module_608.Companion.provides_699()), this.accessNode_350(), this.accessNode_103(), new CachingProviderImpl(this, 155), this.cacheNode_441(), this.cacheNode_460(), this.mDependency_601.ep_43(), this.accessNode_512(), this.cacheNode_361(), this.accessNode_534(), this.mDependency_601.ep_23(), this.cacheNode_316(), this.accessNode_240()));
+  }
+
+  Node_391 cacheNode_391() {
+    Object local = this.mNode_391Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_608.Companion.provides_877(new CachingProviderImpl(this, 222), new ProviderImpl(this, 156), new ProviderImpl(this, 492), this.cacheNode_11()));
+      this.mNode_391Instance = local;
+    }
+    return (Node_391) local;
+  }
+
+  Node_104 cacheNode_104() {
+    Object local = this.mNode_104Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_104(this.cacheNode_520(), new ProviderImpl(this, 399), this.mDependency_601.ep_56(), this.cacheNode_551(), new ProviderImpl(this, 2), this.cacheNode_340(), new ProviderImpl(this, 518), this.accessNode_51(), new CachingProviderImpl(this, 10), new ProviderImpl(this, 185), new ProviderImpl(this, 287), this.accessNode_133(), this.mSet_13, new CachingProviderImpl(this, 188), this.mDependency_601.ep_50(), this.accessNode_419(), new ProviderImpl(this, 390), new CachingProviderImpl(this, 504), this.cacheNode_422(), new CachingProviderImpl(this, 254));
+      this.mNode_104Instance = local;
+    }
+    return (Node_104) local;
+  }
+
+  Node_105 accessNode_105() {
+    return new Node_105(new ProviderImpl(this, 50), new ProviderImpl(this, 74), new CachingProviderImpl(this, 260), new ProviderImpl(this, 344), new CachingProviderImpl(this, 463), new CachingProviderImpl(this, 104), this.mDependency_601.ep_55(), this.mSet_32, new ProviderImpl(this, 183), new ProviderImpl(this, 510), new CachingProviderImpl(this, 52), new CachingProviderImpl(this, 396), new CachingProviderImpl(this, 446), new CachingProviderImpl(this, 119), this.mDependency_601.ep_33(), new ProviderImpl(this, 449), this.cacheNode_404(), this.cacheNode_457(), Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), new ProviderImpl(this, 110), this.cacheNode_426(), new ProviderImpl(this, 410), this.accessNode_497());
+  }
+
+  Node_106 accessNode_106() {
+    return new Node_106(new ProviderImpl(this, 107), new ProviderImpl(this, 447), new CachingProviderImpl(this, 248), new ProviderImpl(this, 20), new CachingProviderImpl(this, 405), new CachingProviderImpl(this, 321), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 136), this.mSet_10, this.accessNode_596(), new CachingProviderImpl(this, 448), this.mDependency_601.ep_36(), new ProviderImpl(this, 93), new ProviderImpl(this, 41), new CachingProviderImpl(this, 61), new CachingProviderImpl(this, 347), new CachingProviderImpl(this, 233), this.cacheNode_551());
+  }
+
+  Node_109 accessNode_109() {
+    return new Node_109(new CachingProviderImpl(this, 334), new ProviderImpl(this, 51), new ProviderImpl(this, 258), new ProviderImpl(this, 341), new ProviderImpl(this, 266), this.accessNode_59(), new CachingProviderImpl(this, 60), new CachingProviderImpl(this, 409), new ProviderImpl(this, 38), new ProviderImpl(this, 267), this.cacheNode_306(), this.cacheNode_250(), new CachingProviderImpl(this, 440), new ProviderImpl(this, 207), new CachingProviderImpl(this, 291), new ProviderImpl(this, 63), this.accessNode_232(), new CachingProviderImpl(this, 461), new CachingProviderImpl(this, 438), new ProviderImpl(this, 195), this.accessNode_303());
+  }
+
+  Node_113 accessNode_113() {
+    return new Node_113(this.accessNode_597(), new ProviderImpl(this, 366), new CachingProviderImpl(this, 79), new CachingProviderImpl(this, 446), new ProviderImpl(this, 461), new CachingProviderImpl(this, 469), this.accessNode_184(), new ProviderImpl(this, 41), this.cacheNode_551(), new CachingProviderImpl(this, 204), this.cacheNode_551(), new ProviderImpl(this, 385), new CachingProviderImpl(this, 500), new ProviderImpl(this, 74), new ProviderImpl(this, 508), this.mDependency_601.ep_13(), new ProviderImpl(this, 462), new ProviderImpl(this, 235), this.accessNode_92());
+  }
+
+  Node_116 accessNode_116() {
+    return new Node_116(this.cacheNode_6(), this.mDependency_601.ep_34(), this.accessNode_59(), new ProviderImpl(this, 511), new CachingProviderImpl(this, 297), this.mDependency_601.ep_52(), new ProviderImpl(this, 449), this.accessNode_303(), new ProviderImpl(this, 169), new ProviderImpl(this, 8), new ProviderImpl(this, 435), Checks.checkProvisionNotNull(Module_608.Companion.provides_832()), this.cacheNode_207(), new CachingProviderImpl(this, 367), this.accessNode_533(), new ProviderImpl(this, 92), this.accessNode_529());
+  }
+
+  Node_118 accessNode_118() {
+    return new Node_118(this.accessNode_418(), new CachingProviderImpl(this, 222), new CachingProviderImpl(this, 480), new ProviderImpl(this, 65), new ProviderImpl(this, 270), this.accessNode_111(), new ProviderImpl(this, 74), this.mSet_36, new ProviderImpl(this, 221), this.cacheNode_6(), this.cacheNode_151(), new ProviderImpl(this, 154), this.cacheNode_101(), this.cacheNode_2(), new ProviderImpl(this, 224), new CachingProviderImpl(this, 25), this.accessNode_419(), this.mDependency_601.ep_56(), this.mDependency_601.ep_42(), new CachingProviderImpl(this, 483), this.accessNode_133(), this.accessNode_232(), new ProviderImpl(this, 79), new ProviderImpl(this, 24), this.accessNode_45(), new ProviderImpl(this, 255));
+  }
+
+  Node_12 accessNode_12() {
+    return new Node_12(this.mSet_50, this.mSet_11, this.accessNode_517(), this.cacheNode_13(), this.cacheNode_146(), this.cacheNode_37(), this.cacheNode_11(), this.cacheNode_212(), this.accessNode_470(), this.accessNode_339(), this.mSet_26, new ProviderImpl(this, 62), this.cacheNode_500(), this.accessNode_295(), this.cacheNode_120(), this.cacheNode_379(), new CachingProviderImpl(this, 226), this.accessNode_298(), this.cacheNode_229(), this.accessNode_116(), this.accessNode_566(), new ProviderImpl(this, 117), this.cacheNode_475(), this.accessNode_149());
+  }
+
+  Node_120 cacheNode_120() {
+    Object local = this.mNode_120Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_120(this.accessNode_102(), this.mDependency_601.ep_53(), this.accessNode_134(), this.cacheNode_502(), new CachingProviderImpl(this, 361), this.cacheNode_284(), this.accessNode_140(), this.mDependency_601.ep_4(), this.mSet_11, this.mSet_35, this.accessNode_136(), this.accessNode_596(), this.mDependency_601.ep_23(), new ProviderImpl(this, 515), this.accessNode_148(), this.cacheNode_260(), this.accessNode_107(), new CachingProviderImpl(this, 160), this.cacheNode_218(), this.accessNode_599(), this.accessNode_342(), this.mDependency_601.ep_6(), new CachingProviderImpl(this, 446), new CachingProviderImpl(this, 257), this.accessNode_199());
+      this.mNode_120Instance = local;
+    }
+    return (Node_120) local;
+  }
+
+  Node_123 cacheNode_123() {
+    Object local = this.mNode_123Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_123(this.mDependency_601.ep_29(), this.cacheNode_457(), new CachingProviderImpl(this, 247), new ProviderImpl(this, 136), new ProviderImpl(this, 63), this.mSet_36, new ProviderImpl(this, 99), new ProviderImpl(this, 275), this.accessNode_164(), this.cacheNode_288(), this.cacheNode_114(), new CachingProviderImpl(this, 64), new CachingProviderImpl(this, 139), new ProviderImpl(this, 390), new ProviderImpl(this, 403), new ProviderImpl(this, 410), new ProviderImpl(this, 472), this.accessNode_337(), this.cacheNode_155(), new ProviderImpl(this, 373));
+      this.mNode_123Instance = local;
+    }
+    return (Node_123) local;
+  }
+
+  Node_127 accessNode_127() {
+    return new Node_127(new CachingProviderImpl(this, 260), new CachingProviderImpl(this, 81), new ProviderImpl(this, 375), new ProviderImpl(this, 72));
+  }
+
+  Node_13 cacheNode_13() {
+    Object local = this.mNode_13Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_13(this.accessNode_136(), this.cacheNode_64(), this.mDependency_601.ep_41(), new ProviderImpl(this, 236), new ProviderImpl(this, 338), this.accessNode_529(), new ProviderImpl(this, 75), new ProviderImpl(this, 173), new ProviderImpl(this, 392), new CachingProviderImpl(this, 52), this.cacheNode_310(), this.cacheNode_114(), this.cacheNode_404(), this.cacheNode_104(), this.mDependency_601.ep_28(), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new ProviderImpl(this, 141), new CachingProviderImpl(this, 32), this.accessNode_405(), new CachingProviderImpl(this, 487), this.cacheNode_598(), this.cacheNode_325(), this.cacheNode_347(), new ProviderImpl(this, 377));
+      this.mNode_13Instance = local;
+    }
+    return (Node_13) local;
+  }
+
+  Node_131 cacheNode_131() {
+    Object local = this.mNode_131Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_131(this.cacheNode_67(), this.mDependency_601.ep_49(), this.mSet_34, Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), this.cacheNode_391(), this.mSet_31, this.accessNode_430(), this.accessNode_297(), new ProviderImpl(this, 46), new ProviderImpl(this, 113), this.mSet_12, new ProviderImpl(this, 431), new CachingProviderImpl(this, 361), this.mSet_30, new CachingProviderImpl(this, 269), new CachingProviderImpl(this, 98), new ProviderImpl(this, 1), new ProviderImpl(this, 22), this.cacheNode_424(), this.cacheNode_245(), this.cacheNode_160(), this.accessNode_387());
+      this.mNode_131Instance = local;
+    }
+    return (Node_131) local;
+  }
+
+  Node_132 accessNode_132() {
+    return new Node_132(new CachingProviderImpl(this, 4), new CachingProviderImpl(this, 309), new CachingProviderImpl(this, 310), this.cacheNode_431(), this.accessNode_296(), this.cacheNode_424(), this.cacheNode_562(), new CachingProviderImpl(this, 313), new CachingProviderImpl(this, 314), this.accessNode_507(), this.mSet_14, this.accessNode_134(), new ProviderImpl(this, 316), this.accessNode_456(), this.cacheNode_498(), new ProviderImpl(this, 318), this.cacheNode_2(), new ProviderImpl(this, 320), this.accessNode_339(), this.mDependency_601.ep_30(), this.cacheNode_420(), this.accessNode_430(), new ProviderImpl(this, 322), new CachingProviderImpl(this, 52), this.accessNode_61(), this.accessNode_377(), new ProviderImpl(this, 323), new ProviderImpl(this, 324), this.accessNode_12(), new ProviderImpl(this, 156));
+  }
+
+  Node_133 accessNode_133() {
+    return new Node_133(new CachingProviderImpl(this, 469), this.accessNode_164(), new CachingProviderImpl(this, 286), this.cacheNode_360(), new ProviderImpl(this, 330), this.cacheNode_143(), new CachingProviderImpl(this, 9), new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 25), this.mSet_3, new CachingProviderImpl(this, 275), this.mDependency_601.ep_36(), new ProviderImpl(this, 7), new ProviderImpl(this, 318), new CachingProviderImpl(this, 119), this.cacheNode_207(), new ProviderImpl(this, 117));
+  }
+
+  Node_138 cacheNode_138() {
+    Object local = this.mNode_138Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_138(this.mDependency_601.ep_16(), this.accessNode_393(), this.cacheNode_404(), this.cacheNode_273(), this.mSet_41, this.mDependency_601.ep_35(), new CachingProviderImpl(this, 59), this.mSet_12, new ProviderImpl(this, 467), this.cacheNode_33(), this.mSet_49);
+      this.mNode_138Instance = local;
+    }
+    return (Node_138) local;
+  }
+
+  Node_141 cacheNode_141() {
+    Object local = this.mNode_141Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_141(new ProviderImpl(this, 33), new ProviderImpl(this, 526), this.mSet_27, new ProviderImpl(this, 476), new CachingProviderImpl(this, 423), this.accessNode_399(), new ProviderImpl(this, 456), new ProviderImpl(this, 41), this.cacheNode_244());
+      this.mNode_141Instance = local;
+    }
+    return (Node_141) local;
+  }
+
+  Node_142 accessNode_142() {
+    return new Node_142(this.cacheNode_479(), this.mDependency_601.ep_46(), this.mDependency_601.ep_5(), new ProviderImpl(this, 296), this.accessNode_103(), this.mDependency_601.ep_37(), new ProviderImpl(this, 298), this.mDependency_601.ep_57(), this.accessNode_385(), this.accessNode_337(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), this.mDependency_601.ep_48(), this.cacheNode_325(), new ProviderImpl(this, 218), new ProviderImpl(this, 278), this.cacheNode_521(), this.cacheNode_101(), this.mSet_11, new ProviderImpl(this, 163), new ProviderImpl(this, 302), new CachingProviderImpl(this, 303), this.accessNode_189(), this.accessNode_333(), this.accessNode_430(), new CachingProviderImpl(this, 306), this.mSet_40, this.cacheNode_404(), this.cacheNode_281(), this.cacheNode_469());
+  }
+
+  Node_143 cacheNode_143() {
+    Object local = this.mNode_143Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_143(new ProviderImpl(this, 308), this.mSet_17, this.mDependency_601.ep_50());
+      this.mNode_143Instance = local;
+    }
+    return (Node_143) local;
+  }
+
+  Node_147 cacheNode_147() {
+    Object local = this.mNode_147Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_147(new ProviderImpl(this, 61), new CachingProviderImpl(this, 84), new CachingProviderImpl(this, 321), this.mSet_7, new ProviderImpl(this, 238));
+      this.mNode_147Instance = local;
+    }
+    return (Node_147) local;
+  }
+
+  Node_148 accessNode_148() {
+    return new Node_148(new CachingProviderImpl(this, 44), new ProviderImpl(this, 477), new ProviderImpl(this, 162), new ProviderImpl(this, 383), this.mSet_42, new ProviderImpl(this, 176), new ProviderImpl(this, 308), this.cacheNode_233(), new CachingProviderImpl(this, 126), new ProviderImpl(this, 225), this.mDependency_601.ep_36(), this.accessNode_214(), this.cacheNode_424(), this.accessNode_282(), this.mSet_31, this.mDependency_601.ep_57(), this.accessNode_434(), this.cacheNode_528());
+  }
+
+  Node_15 cacheNode_15() {
+    Object local = this.mNode_15Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_15(new ProviderImpl(this, 90), this.mDependency_601.ep_21(), this.accessNode_432(), new CachingProviderImpl(this, 262), new ProviderImpl(this, 427), this.cacheNode_459(), this.cacheNode_528(), new CachingProviderImpl(this, 505), new CachingProviderImpl(this, 139), new ProviderImpl(this, 318), new CachingProviderImpl(this, 507), this.accessNode_209(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 60), new CachingProviderImpl(this, 304), new ProviderImpl(this, 228));
+      this.mNode_15Instance = local;
+    }
+    return (Node_15) local;
+  }
+
+  Node_151 cacheNode_151() {
+    Object local = this.mNode_151Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_151(new ProviderImpl(this, 227));
+      this.mNode_151Instance = local;
+    }
+    return (Node_151) local;
+  }
+
+  Node_16 accessNode_16() {
+    return new Node_16(this.cacheNode_83(), new ProviderImpl(this, 232), new ProviderImpl(this, 88), this.mSet_51, this.mDependency_601.ep_40(), new ProviderImpl(this, 108), new CachingProviderImpl(this, 100), this.mDependency_601.ep_48(), new CachingProviderImpl(this, 139), new ProviderImpl(this, 143), new CachingProviderImpl(this, 272), new ProviderImpl(this, 489), this.mDependency_601.ep_2(), this.accessNode_275(), this.cacheNode_273(), new CachingProviderImpl(this, 192));
+  }
+
+  Node_163 accessNode_163() {
+    return new Node_163(this.cacheNode_457(), new ProviderImpl(this, 102), new CachingProviderImpl(this, 103), new CachingProviderImpl(this, 104), new ProviderImpl(this, 75), new CachingProviderImpl(this, 105), new ProviderImpl(this, 83), this.accessNode_133(), new CachingProviderImpl(this, 78), this.mSet_12, new ProviderImpl(this, 107), new ProviderImpl(this, 108), this.accessNode_548(), new ProviderImpl(this, 110), this.accessNode_179(), new ProviderImpl(this, 112), new ProviderImpl(this, 113), this.cacheNode_306(), new ProviderImpl(this, 114), this.cacheNode_352(), this.cacheNode_192(), new ProviderImpl(this, 117), this.mDependency_601.ep_2(), this.accessNode_140(), new CachingProviderImpl(this, 120));
+  }
+
+  Node_164 accessNode_164() {
+    return new Node_164(new ProviderImpl(this, 61), new ProviderImpl(this, 154), new CachingProviderImpl(this, 401), this.mSet_26, new ProviderImpl(this, 145), new CachingProviderImpl(this, 106), new ProviderImpl(this, 342), new CachingProviderImpl(this, 206), new CachingProviderImpl(this, 129), new CachingProviderImpl(this, 152), new ProviderImpl(this, 240), new CachingProviderImpl(this, 411), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), new CachingProviderImpl(this, 191), this.mSet_28);
+  }
+
+  Node_165 accessNode_165() {
+    return new Node_165(Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), new ProviderImpl(this, 449), new ProviderImpl(this, 344), new CachingProviderImpl(this, 450), this.mDependency_601.ep_12(), this.accessNode_232(), this.accessNode_455(), this.mSet_45, new ProviderImpl(this, 426), this.mSet_2, this.cacheNode_198(), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 253), new ProviderImpl(this, 258), new ProviderImpl(this, 453), new ProviderImpl(this, 323), new ProviderImpl(this, 414));
+  }
+
+  Node_175 accessNode_175() {
+    return new Node_175(new CachingProviderImpl(this, 386), this.accessNode_543(), new CachingProviderImpl(this, 83), new ProviderImpl(this, 92), this.accessNode_458(), this.cacheNode_233(), this.accessNode_339(), new ProviderImpl(this, 235), this.mSet_0, new CachingProviderImpl(this, 247), this.accessNode_569(), this.accessNode_248(), new ProviderImpl(this, 134), new CachingProviderImpl(this, 485), new ProviderImpl(this, 352), this.mDependency_601.ep_21(), new CachingProviderImpl(this, 434));
+  }
+
+  Node_176 cacheNode_176() {
+    Object local = this.mNode_176Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_176(new ProviderImpl(this, 390), this.cacheNode_135(), new CachingProviderImpl(this, 334), new ProviderImpl(this, 164), new ProviderImpl(this, 218), this.accessNode_576(), Checks.checkProvisionNotNull(Module_608.Companion.provides_856()), this.mSet_40, new ProviderImpl(this, 96), this.cacheNode_67(), this.mSet_15, this.mDependency_601.ep_41(), new ProviderImpl(this, 280), this.cacheNode_598(), new ProviderImpl(this, 113), this.cacheNode_417(), this.cacheNode_575(), this.cacheNode_33(), this.accessNode_348(), this.accessNode_166(), this.accessNode_552(), new CachingProviderImpl(this, 25), new ProviderImpl(this, 132), this.cacheNode_479(), this.accessNode_191(), new ProviderImpl(this, 300));
+      this.mNode_176Instance = local;
+    }
+    return (Node_176) local;
+  }
+
+  Node_178 accessNode_178() {
+    return new Node_178(this.mDependency_601.ep_1(), this.accessNode_439(), new CachingProviderImpl(this, 215), this.cacheNode_550(), new ProviderImpl(this, 412), this.accessNode_447(), this.cacheNode_168(), this.accessNode_440());
+  }
+
+  Node_179 accessNode_179() {
+    return new Node_179(new ProviderImpl(this, 49), new CachingProviderImpl(this, 7), new CachingProviderImpl(this, 26), new CachingProviderImpl(this, 167), this.mSet_20, new ProviderImpl(this, 232), new CachingProviderImpl(this, 222), new ProviderImpl(this, 422), new CachingProviderImpl(this, 327), this.accessNode_93(), this.mSet_15, this.mSet_47);
+  }
+
+  Node_184 accessNode_184() {
+    return new Node_184(new CachingProviderImpl(this, 269), new CachingProviderImpl(this, 425), new ProviderImpl(this, 24), new ProviderImpl(this, 408), new ProviderImpl(this, 391), new ProviderImpl(this, 440), new CachingProviderImpl(this, 34), this.accessNode_496(), this.mDependency_601.ep_4(), new ProviderImpl(this, 326), new ProviderImpl(this, 344), new ProviderImpl(this, 462), new CachingProviderImpl(this, 276), this.cacheNode_551(), this.accessNode_383(), new ProviderImpl(this, 249), new CachingProviderImpl(this, 297), new CachingProviderImpl(this, 54), this.mSet_3, new ProviderImpl(this, 32), new ProviderImpl(this, 431), this.mDependency_601.ep_25(), new ProviderImpl(this, 130), this.mSet_9, this.cacheNode_281(), new CachingProviderImpl(this, 61), this.accessNode_344());
+  }
+
+  Node_187 accessNode_187() {
+    return new Node_187(new CachingProviderImpl(this, 326), new ProviderImpl(this, 508), new ProviderImpl(this, 385), new CachingProviderImpl(this, 515), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 197), new ProviderImpl(this, 511), new CachingProviderImpl(this, 358), new CachingProviderImpl(this, 340), new ProviderImpl(this, 92), new CachingProviderImpl(this, 247), this.mSet_30, new CachingProviderImpl(this, 45), new CachingProviderImpl(this, 454), new ProviderImpl(this, 373));
+  }
+
+  Node_189 accessNode_189() {
+    return new Node_189(new CachingProviderImpl(this, 192), new CachingProviderImpl(this, 471), new ProviderImpl(this, 116), this.accessNode_455(), this.mSet_12, this.mSet_7, new ProviderImpl(this, 161), new ProviderImpl(this, 203), this.mDependency_601.ep_26(), new ProviderImpl(this, 392), new CachingProviderImpl(this, 327), new ProviderImpl(this, 46), this.accessNode_515(), this.cacheNode_391(), this.cacheNode_235(), new ProviderImpl(this, 268), new ProviderImpl(this, 33));
+  }
+
+  Node_191 accessNode_191() {
+    return new Node_191(this.accessNode_136(), this.mSet_13, new CachingProviderImpl(this, 123), new Node_181(), this.cacheNode_361(), new CachingProviderImpl(this, 126), this.cacheNode_340(), this.mDependency_601.ep_26(), this.accessNode_385(), new ProviderImpl(this, 130), new CachingProviderImpl(this, 131), this.cacheNode_206(), this.cacheNode_360(), this.cacheNode_288(), new ProviderImpl(this, 135), new ProviderImpl(this, 136), this.cacheNode_359(), this.mSet_14);
+  }
+
+  Node_198 cacheNode_198() {
+    Object local = this.mNode_198Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_198(this.accessNode_211(), new ProviderImpl(this, 180));
+      this.mNode_198Instance = local;
+    }
+    return (Node_198) local;
+  }
+
+  Node_199 accessNode_199() {
+    return new Node_199(this.accessNode_364(), this.cacheNode_500(), this.accessNode_446());
+  }
+
+  Node_20 cacheNode_20() {
+    Object local = this.mNode_20Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_20(this.cacheNode_499(), this.mDependency_601.ep_44(), new ProviderImpl(this, 27), this.mDependency_601.ep_0(), new CachingProviderImpl(this, 524), new CachingProviderImpl(this, 393), new ProviderImpl(this, 477), this.accessNode_136(), new CachingProviderImpl(this, 78), new ProviderImpl(this, 101), new ProviderImpl(this, 46), this.accessNode_296(), this.accessNode_351(), this.cacheNode_162(), new CachingProviderImpl(this, 396), new ProviderImpl(this, 315), this.accessNode_330(), new CachingProviderImpl(this, 247), new ProviderImpl(this, 441), new CachingProviderImpl(this, 186), this.mSet_27, this.accessNode_297(), this.mDependency_601.ep_28(), new ProviderImpl(this, 403), new CachingProviderImpl(this, 222), this.cacheNode_198(), this.cacheNode_229(), new ProviderImpl(this, 342), this.accessNode_348());
+      this.mNode_20Instance = local;
+    }
+    return (Node_20) local;
+  }
+
+  Node_202 cacheNode_202() {
+    Object local = this.mNode_202Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_202(this.accessNode_324(), this.accessNode_454(), this.cacheNode_155(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), this.cacheNode_79(), new ProviderImpl(this, 141), this.mSet_50, this.accessNode_298(), new ProviderImpl(this, 416), new CachingProviderImpl(this, 498), this.mDependency_601.ep_45(), this.cacheNode_341(), this.cacheNode_60(), this.cacheNode_231(), new ProviderImpl(this, 299), new CachingProviderImpl(this, 247), this.accessNode_529(), new CachingProviderImpl(this, 31), this.mDependency_601.ep_42(), this.accessNode_299(), new ProviderImpl(this, 284), this.mSet_35, new ProviderImpl(this, 163), this.cacheNode_477());
+      this.mNode_202Instance = local;
+    }
+    return (Node_202) local;
+  }
+
+  Node_203 accessNode_203() {
+    return new Node_203(this.cacheNode_238(), this.mSet_30, new CachingProviderImpl(this, 205), new ProviderImpl(this, 195), this.mDependency_601.ep_51(), this.mDependency_601.ep_50(), new CachingProviderImpl(this, 253), new ProviderImpl(this, 245), new ProviderImpl(this, 113), new ProviderImpl(this, 391), new CachingProviderImpl(this, 95), new ProviderImpl(this, 454));
+  }
+
+  Node_206 cacheNode_206() {
+    Object local = this.mNode_206Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_206(new CachingProviderImpl(this, 448), new CachingProviderImpl(this, 304), new CachingProviderImpl(this, 332), this.accessNode_533(), new CachingProviderImpl(this, 334), new ProviderImpl(this, 285), new ProviderImpl(this, 61), new CachingProviderImpl(this, 129), new CachingProviderImpl(this, 502), new CachingProviderImpl(this, 97), this.cacheNode_528(), new CachingProviderImpl(this, 386), new CachingProviderImpl(this, 305), new ProviderImpl(this, 221), new CachingProviderImpl(this, 35), new ProviderImpl(this, 379), new ProviderImpl(this, 408), this.cacheNode_325(), this.mDependency_601.ep_35(), new CachingProviderImpl(this, 223), this.mSet_18, new ProviderImpl(this, 503), new CachingProviderImpl(this, 119));
+      this.mNode_206Instance = local;
+    }
+    return (Node_206) local;
+  }
+
+  Node_209 accessNode_209() {
+    return new Node_209(Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), new CachingProviderImpl(this, 290), new ProviderImpl(this, 162), new ProviderImpl(this, 96), this.mDependency_601.ep_28(), Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), new CachingProviderImpl(this, 315), new ProviderImpl(this, 472));
+  }
+
+  Node_21 accessNode_21() {
+    return new Node_21(this.accessNode_134(), this.cacheNode_463());
+  }
+
+  Node_211 accessNode_211() {
+    return new Node_211(new ProviderImpl(this, 484), new CachingProviderImpl(this, 170), this.accessNode_56(), new ProviderImpl(this, 132), new CachingProviderImpl(this, 522), new CachingProviderImpl(this, 515), new CachingProviderImpl(this, 248), this.cacheNode_584(), new ProviderImpl(this, 449), this.cacheNode_143(), new ProviderImpl(this, 72), this.cacheNode_431(), this.accessNode_5(), this.cacheNode_151(), new ProviderImpl(this, 490), new CachingProviderImpl(this, 358), new CachingProviderImpl(this, 463), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 149), new CachingProviderImpl(this, 10), this.mDependency_601.ep_55(), new CachingProviderImpl(this, 459), new CachingProviderImpl(this, 253), new CachingProviderImpl(this, 412), new ProviderImpl(this, 390), this.cacheNode_114(), this.mDependency_601.ep_44(), this.accessNode_337());
+  }
+
+  Node_212 cacheNode_212() {
+    Object local = this.mNode_212Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_212(new CachingProviderImpl(this, 421), this.cacheNode_273(), this.mDependency_601.ep_23(), new ProviderImpl(this, 245), new ProviderImpl(this, 391), this.mSet_26, new CachingProviderImpl(this, 234));
+      this.mNode_212Instance = local;
+    }
+    return (Node_212) local;
+  }
+
+  Node_213 accessNode_213() {
+    return new Node_213(this.cacheNode_156(), new CachingProviderImpl(this, 205), this.accessNode_61(), this.accessNode_329(), new CachingProviderImpl(this, 482), new ProviderImpl(this, 374), this.mSet_13, this.cacheNode_20(), this.accessNode_597(), new CachingProviderImpl(this, 400), this.accessNode_515(), new CachingProviderImpl(this, 377), this.mDependency_601.ep_12(), this.cacheNode_550(), this.cacheNode_258(), this.cacheNode_60(), this.mDependency_601.ep_5());
+  }
+
+  Node_214 accessNode_214() {
+    return new Node_214(new ProviderImpl(this, 354), this.mSet_10, this.cacheNode_404(), new CachingProviderImpl(this, 448), new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 82), new ProviderImpl(this, 380), this.accessNode_395(), new CachingProviderImpl(this, 444));
+  }
+
+  Node_216 accessNode_216() {
+    return new Node_216(new CachingProviderImpl(this, 482), new ProviderImpl(this, 377), new ProviderImpl(this, 330), this.cacheNode_160(), this.cacheNode_157(), new CachingProviderImpl(this, 372), new CachingProviderImpl(this, 355), new ProviderImpl(this, 134), this.mDependency_601.ep_17(), new CachingProviderImpl(this, 522), new CachingProviderImpl(this, 7), this.cacheNode_406(), new ProviderImpl(this, 37), new CachingProviderImpl(this, 291), this.mSet_14, new ProviderImpl(this, 300));
+  }
+
+  Node_219 accessNode_219() {
+    return new Node_219(new ProviderImpl(this, 342), new CachingProviderImpl(this, 365), new CachingProviderImpl(this, 401), new ProviderImpl(this, 337), this.accessNode_133(), this.mDependency_601.ep_25(), this.mSet_30, new CachingProviderImpl(this, 286), this.mSet_40, this.mSet_21, this.mDependency_601.ep_17(), new ProviderImpl(this, 414), this.mDependency_601.ep_22(), this.mSet_41);
+  }
+
+  Node_222 accessNode_222() {
+    return new Node_222(this.cacheNode_316(), new CachingProviderImpl(this, 367), new ProviderImpl(this, 473), new ProviderImpl(this, 444), this.cacheNode_25(), new ProviderImpl(this, 56), new ProviderImpl(this, 230), new ProviderImpl(this, 419), new ProviderImpl(this, 338), new ProviderImpl(this, 433), new CachingProviderImpl(this, 146), this.cacheNode_570(), this.accessNode_92(), new ProviderImpl(this, 65), new CachingProviderImpl(this, 266), this.mDependency_601.ep_5(), new ProviderImpl(this, 148), new ProviderImpl(this, 496), this.accessNode_418(), this.mSet_48, this.mDependency_601.ep_57(), this.mDependency_601.ep_6(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 25), new ProviderImpl(this, 154), new ProviderImpl(this, 156), this.accessNode_393(), this.accessNode_214(), new ProviderImpl(this, 300));
+  }
+
+  Node_224 cacheNode_224() {
+    Object local = this.mNode_224Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_224(new ProviderImpl(this, 96), this.accessNode_507(), new ProviderImpl(this, 2), this.cacheNode_15(), this.accessNode_397(), this.accessNode_314(), new ProviderImpl(this, 350), this.accessNode_126(), this.mSet_27, Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.cacheNode_157(), this.accessNode_185(), new ProviderImpl(this, 496), new ProviderImpl(this, 298), this.mDependency_601.ep_14(), this.accessNode_496(), this.accessNode_453());
+      this.mNode_224Instance = local;
+    }
+    return (Node_224) local;
+  }
+
+  Node_225 accessNode_225() {
+    return new Node_225(this.mDependency_601.ep_3(), this.cacheNode_356(), new ProviderImpl(this, 526), this.accessNode_109(), this.accessNode_332(), this.cacheNode_349(), this.cacheNode_104(), this.accessNode_185(), new CachingProviderImpl(this, 126), this.accessNode_427(), this.cacheNode_281(), this.mDependency_601.ep_54(), this.mDependency_601.ep_27(), new ProviderImpl(this, 472), this.accessNode_21(), this.accessNode_430(), this.accessNode_467(), new ProviderImpl(this, 232), this.accessNode_280(), this.accessNode_93(), this.accessNode_495(), new CachingProviderImpl(this, 434), this.mSet_43, new ProviderImpl(this, 226), Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), new ProviderImpl(this, 213), new ProviderImpl(this, 268));
+  }
+
+  Node_226 cacheNode_226() {
+    Object local = this.mNode_226Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_226(this.cacheNode_528(), this.mSet_14, this.cacheNode_592(), this.cacheNode_77(), this.accessNode_374(), this.mDependency_601.ep_13());
+      this.mNode_226Instance = local;
+    }
+    return (Node_226) local;
+  }
+
+  Node_229 cacheNode_229() {
+    Object local = this.mNode_229Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_229(new CachingProviderImpl(this, 205), new ProviderImpl(this, 218), new ProviderImpl(this, 96), this.accessNode_59(), this.accessNode_184(), new CachingProviderImpl(this, 509), new ProviderImpl(this, 298), new CachingProviderImpl(this, 334), this.cacheNode_565(), new ProviderImpl(this, 213), new ProviderImpl(this, 499), this.mDependency_601.ep_28(), new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 513), new CachingProviderImpl(this, 206), new CachingProviderImpl(this, 365), this.mSet_46, Checks.checkProvisionNotNull(Module_608.Companion.provides_856()), this.mSet_17, new ProviderImpl(this, 493), this.accessNode_363(), new CachingProviderImpl(this, 418), new CachingProviderImpl(this, 43), this.mSet_10, new CachingProviderImpl(this, 310));
+      this.mNode_229Instance = local;
+    }
+    return (Node_229) local;
+  }
+
+  Node_23 accessNode_23() {
+    return new Node_23(this.cacheNode_341(), new ProviderImpl(this, 295));
+  }
+
+  Node_230 cacheNode_230() {
+    Object local = this.mNode_230Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_230(this.cacheNode_519(), new CachingProviderImpl(this, 260), new CachingProviderImpl(this, 367), new ProviderImpl(this, 184), this.cacheNode_218(), new ProviderImpl(this, 348), new ProviderImpl(this, 207), new ProviderImpl(this, 142), this.accessNode_92(), this.mSet_23, this.accessNode_118(), this.mDependency_601.ep_42(), new ProviderImpl(this, 408));
+      this.mNode_230Instance = local;
+    }
+    return (Node_230) local;
+  }
+
+  Node_231 cacheNode_231() {
+    Object local = this.mNode_231Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_231(this.accessNode_432(), new ProviderImpl(this, 41), this.accessNode_268(), this.cacheNode_530(), this.cacheNode_20(), this.cacheNode_306(), new ProviderImpl(this, 273), this.cacheNode_83(), this.mSet_31, this.accessNode_515(), this.mDependency_601.ep_37(), this.cacheNode_527(), new ProviderImpl(this, 373), this.accessNode_536(), this.accessNode_381(), this.mDependency_601.ep_14(), new ProviderImpl(this, 145), this.cacheNode_260(), this.accessNode_21(), this.cacheNode_58(), new ProviderImpl(this, 105));
+      this.mNode_231Instance = local;
+    }
+    return (Node_231) local;
+  }
+
+  Node_232 accessNode_232() {
+    return new Node_232(new CachingProviderImpl(this, 286), this.cacheNode_441(), this.mSet_18, new ProviderImpl(this, 170), this.mDependency_601.ep_0(), new ProviderImpl(this, 185), new CachingProviderImpl(this, 144), new ProviderImpl(this, 369));
+  }
+
+  Node_234 cacheNode_234() {
+    Object local = this.mNode_234Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_234(new ProviderImpl(this, 102), this.mDependency_601.ep_7(), new ProviderImpl(this, 22), new ProviderImpl(this, 72), this.cacheNode_547(), this.cacheNode_531(), new ProviderImpl(this, 218));
+      this.mNode_234Instance = local;
+    }
+    return (Node_234) local;
+  }
+
+  Node_239 accessNode_239() {
+    return new Node_239(this.mSet_28, this.mSet_37, new ProviderImpl(this, 245), new CachingProviderImpl(this, 401), new ProviderImpl(this, 526), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 281), this.accessNode_303(), this.cacheNode_76(), new CachingProviderImpl(this, 334), new ProviderImpl(this, 148), new ProviderImpl(this, 77), this.mDependency_601.ep_3(), this.cacheNode_284(), new ProviderImpl(this, 299), new CachingProviderImpl(this, 450), this.mSet_2, new ProviderImpl(this, 224), this.cacheNode_520(), new ProviderImpl(this, 472), this.accessNode_164(), this.accessNode_427(), this.mDependency_601.ep_37(), this.accessNode_92(), this.cacheNode_95());
+  }
+
+  Node_241 cacheNode_241() {
+    Object local = this.mNode_241Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_241(this.cacheNode_429(), this.cacheNode_180(), this.accessNode_568());
+      this.mNode_241Instance = local;
+    }
+    return (Node_241) local;
+  }
+
+  Node_243 cacheNode_243() {
+    Object local = this.mNode_243Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_243(this.accessNode_28(), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), new CachingProviderImpl(this, 494), new Node_181());
+      this.mNode_243Instance = local;
+    }
+    return (Node_243) local;
+  }
+
+  Node_244 cacheNode_244() {
+    Object local = this.mNode_244Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_244(new CachingProviderImpl(this, 434), new CachingProviderImpl(this, 61), this.accessNode_510(), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 281), this.accessNode_150(), this.cacheNode_15(), this.accessNode_552(), this.accessNode_439(), this.cacheNode_506(), this.cacheNode_37(), new ProviderImpl(this, 113), new ProviderImpl(this, 366), this.accessNode_171(), new ProviderImpl(this, 139), this.accessNode_307());
+      this.mNode_244Instance = local;
+    }
+    return (Node_244) local;
+  }
+
+  Node_248 accessNode_248() {
+    return new Node_248(new CachingProviderImpl(this, 25), new ProviderImpl(this, 184), new ProviderImpl(this, 444), this.cacheNode_406(), this.accessNode_467(), this.cacheNode_460(), new ProviderImpl(this, 396), new ProviderImpl(this, 467), new CachingProviderImpl(this, 31), new ProviderImpl(this, 281), new CachingProviderImpl(this, 364), this.cacheNode_15(), this.cacheNode_519(), new CachingProviderImpl(this, 120), new ProviderImpl(this, 238), new CachingProviderImpl(this, 32), new ProviderImpl(this, 408), new CachingProviderImpl(this, 468), this.accessNode_23(), this.accessNode_105(), new ProviderImpl(this, 240), this.accessNode_364(), new ProviderImpl(this, 22), this.accessNode_363(), this.mSet_36, this.mDependency_601.ep_27(), this.cacheNode_138(), new CachingProviderImpl(this, 136), new ProviderImpl(this, 300), this.mDependency_601.ep_1());
+  }
+
+  Node_250 cacheNode_250() {
+    Object local = this.mNode_250Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_250(new CachingProviderImpl(this, 458), new CachingProviderImpl(this, 260), new ProviderImpl(this, 65), this.accessNode_381(), new ProviderImpl(this, 177), new CachingProviderImpl(this, 147), new ProviderImpl(this, 154), this.mDependency_601.ep_19(), new ProviderImpl(this, 175), new ProviderImpl(this, 2), new ProviderImpl(this, 449), new CachingProviderImpl(this, 98), new ProviderImpl(this, 230), new ProviderImpl(this, 127), this.mDependency_601.ep_45(), new CachingProviderImpl(this, 61), this.accessNode_92(), this.cacheNode_288(), new ProviderImpl(this, 33), new CachingProviderImpl(this, 264), this.mSet_31, new ProviderImpl(this, 460));
+      this.mNode_250Instance = local;
+    }
+    return (Node_250) local;
+  }
+
+  Node_253 cacheNode_253() {
+    Object local = this.mNode_253Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_253(this.accessNode_82(), this.cacheNode_72(), new ProviderImpl(this, 359), new ProviderImpl(this, 344), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 30), this.cacheNode_584(), new CachingProviderImpl(this, 421), this.mDependency_601.ep_56(), this.accessNode_524(), this.accessNode_154(), this.cacheNode_572());
+      this.mNode_253Instance = local;
+    }
+    return (Node_253) local;
+  }
+
+  Node_260 cacheNode_260() {
+    Object local = this.mNode_260Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_260(new ProviderImpl(this, 12), new CachingProviderImpl(this, 39), this.accessNode_107(), new ProviderImpl(this, 41), this.accessNode_51(), new CachingProviderImpl(this, 42), new CachingProviderImpl(this, 43), new CachingProviderImpl(this, 44), Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), this.cacheNode_519(), new ProviderImpl(this, 46), new CachingProviderImpl(this, 47), new CachingProviderImpl(this, 48), new CachingProviderImpl(this, 49), this.cacheNode_588(), new ProviderImpl(this, 50), this.mSet_5, new CachingProviderImpl(this, 52), this.cacheNode_547(), new ProviderImpl(this, 54), this.mSet_6, new CachingProviderImpl(this, 55), this.accessNode_397(), this.mSet_7);
+      this.mNode_260Instance = local;
+    }
+    return (Node_260) local;
+  }
+
+  Node_263 accessNode_263() {
+    return new Node_263(this.accessNode_393(), new CachingProviderImpl(this, 407), new CachingProviderImpl(this, 405), this.cacheNode_340(), new CachingProviderImpl(this, 9), this.mDependency_601.ep_15(), this.accessNode_187(), this.mDependency_601.ep_20(), this.accessNode_439(), new ProviderImpl(this, 366), new ProviderImpl(this, 96), new CachingProviderImpl(this, 437), this.cacheNode_319(), new ProviderImpl(this, 275), this.accessNode_171(), new ProviderImpl(this, 189), new ProviderImpl(this, 240), this.cacheNode_431(), this.accessNode_430(), new CachingProviderImpl(this, 139), this.accessNode_312(), new CachingProviderImpl(this, 293), this.cacheNode_406(), this.cacheNode_151());
+  }
+
+  Node_264 accessNode_264() {
+    return new Node_264(this.mDependency_601.ep_31(), this.accessNode_494(), new CachingProviderImpl(this, 138), this.cacheNode_586(), this.mDependency_601.ep_46(), this.accessNode_232(), new ProviderImpl(this, 447), new ProviderImpl(this, 169), this.accessNode_492(), new CachingProviderImpl(this, 297), this.mDependency_601.ep_52(), new ProviderImpl(this, 212), this.cacheNode_499(), this.mSet_27, Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), this.mSet_26, this.accessNode_381(), new ProviderImpl(this, 348), new CachingProviderImpl(this, 10), this.mSet_3, this.cacheNode_79(), new ProviderImpl(this, 499), this.mSet_47, this.cacheNode_391(), this.accessNode_447(), new ProviderImpl(this, 207));
+  }
+
+  Node_267 cacheNode_267() {
+    Object local = this.mNode_267Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_267(new CachingProviderImpl(this, 126), new CachingProviderImpl(this, 454), this.mDependency_601.ep_20(), new ProviderImpl(this, 88), new CachingProviderImpl(this, 147), new ProviderImpl(this, 513), new ProviderImpl(this, 180), this.mDependency_601.ep_55(), new CachingProviderImpl(this, 276), this.accessNode_397(), new CachingProviderImpl(this, 412), new ProviderImpl(this, 72), new ProviderImpl(this, 416), new CachingProviderImpl(this, 31), this.mDependency_601.ep_14(), new CachingProviderImpl(this, 315), this.mSet_40, this.accessNode_222(), new ProviderImpl(this, 75), new CachingProviderImpl(this, 288));
+      this.mNode_267Instance = local;
+    }
+    return (Node_267) local;
+  }
+
+  Node_268 accessNode_268() {
+    return new Node_268(this.accessNode_517(), new ProviderImpl(this, 92), new CachingProviderImpl(this, 494), this.accessNode_438(), Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), new CachingProviderImpl(this, 227), this.cacheNode_328(), new ProviderImpl(this, 348), this.accessNode_59(), new ProviderImpl(this, 399), new CachingProviderImpl(this, 79), this.mDependency_601.ep_27(), new ProviderImpl(this, 301), this.mDependency_601.ep_9(), this.accessNode_116(), new CachingProviderImpl(this, 461), new ProviderImpl(this, 431), this.cacheNode_551(), new ProviderImpl(this, 252), new ProviderImpl(this, 106), new ProviderImpl(this, 73), this.accessNode_239(), new ProviderImpl(this, 456), new ProviderImpl(this, 292), new CachingProviderImpl(this, 262), this.accessNode_393(), this.accessNode_280(), new CachingProviderImpl(this, 310));
+  }
+
+  Node_271 cacheNode_271() {
+    Object local = this.mNode_271Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_271(new CachingProviderImpl(this, 105), this.cacheNode_527(), this.accessNode_109(), this.mSet_30, this.accessNode_425(), new ProviderImpl(this, 74));
+      this.mNode_271Instance = local;
+    }
+    return (Node_271) local;
+  }
+
+  Node_280 accessNode_280() {
+    return new Node_280(new CachingProviderImpl(this, 32), this.accessNode_314(), new ProviderImpl(this, 50), new ProviderImpl(this, 496), new ProviderImpl(this, 81), new CachingProviderImpl(this, 281));
+  }
+
+  Node_281 cacheNode_281() {
+    Object local = this.mNode_281Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_281(this.mSet_8, new ProviderImpl(this, 24), new ProviderImpl(this, 218), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 32), new CachingProviderImpl(this, 463), new ProviderImpl(this, 258), new CachingProviderImpl(this, 160), new ProviderImpl(this, 101), new ProviderImpl(this, 419), new CachingProviderImpl(this, 171), this.mSet_35, this.cacheNode_95(), new ProviderImpl(this, 141), this.mDependency_601.ep_40(), new CachingProviderImpl(this, 223), this.mDependency_601.ep_47(), new CachingProviderImpl(this, 79), new CachingProviderImpl(this, 34), this.mSet_48);
+      this.mNode_281Instance = local;
+    }
+    return (Node_281) local;
+  }
+
+  Node_285 cacheNode_285() {
+    Object local = this.mNode_285Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_285(this.accessNode_44());
+      this.mNode_285Instance = local;
+    }
+    return (Node_285) local;
+  }
+
+  Node_286 cacheNode_286() {
+    Object local = this.mNode_286Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_286(Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new CachingProviderImpl(this, 161), new CachingProviderImpl(this, 136), this.mSet_46, this.accessNode_298(), this.accessNode_18(), new CachingProviderImpl(this, 417), new CachingProviderImpl(this, 454), new CachingProviderImpl(this, 434), new CachingProviderImpl(this, 458), new ProviderImpl(this, 517));
+      this.mNode_286Instance = local;
+    }
+    return (Node_286) local;
+  }
+
+  Node_292 accessNode_292() {
+    return new Node_292(new CachingProviderImpl(this, 39), this.mSet_9, new ProviderImpl(this, 453), new CachingProviderImpl(this, 205), new ProviderImpl(this, 20), new ProviderImpl(this, 37), new CachingProviderImpl(this, 266), this.mDependency_601.ep_49(), new CachingProviderImpl(this, 263), new ProviderImpl(this, 395), this.accessNode_106(), this.mSet_45, this.mDependency_601.ep_33());
+  }
+
+  Node_295 accessNode_295() {
+    return new Node_295(new CachingProviderImpl(this, 130), new CachingProviderImpl(this, 525), new ProviderImpl(this, 455), new ProviderImpl(this, 282), new CachingProviderImpl(this, 87), new CachingProviderImpl(this, 136), new ProviderImpl(this, 246), this.accessNode_292(), new CachingProviderImpl(this, 406), new ProviderImpl(this, 167), this.mSet_26, this.accessNode_512(), new CachingProviderImpl(this, 84));
+  }
+
+  Node_296 accessNode_296() {
+    return new Node_296(this.accessNode_106(), this.mSet_1, new ProviderImpl(this, 356), new ProviderImpl(this, 357), Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), this.cacheNode_38(), this.mSet_27, new ProviderImpl(this, 289), this.accessNode_51(), new CachingProviderImpl(this, 219), new ProviderImpl(this, 315));
+  }
+
+  Node_301 accessNode_301() {
+    return new Node_301(this.mSet_0, Checks.checkProvisionNotNull(Module_608.Companion.provides_856()), new CachingProviderImpl(this, 91), new CachingProviderImpl(this, 248), this.accessNode_518(), this.cacheNode_457(), new ProviderImpl(this, 268), this.accessNode_203(), this.accessNode_163(), new ProviderImpl(this, 153), this.mSet_4, this.mDependency_601.ep_44(), new ProviderImpl(this, 63), this.cacheNode_271());
+  }
+
+  Node_309 accessNode_309() {
+    return new Node_309(new CachingProviderImpl(this, 167), new ProviderImpl(this, 433), new CachingProviderImpl(this, 398), new CachingProviderImpl(this, 275), new ProviderImpl(this, 154), new CachingProviderImpl(this, 276), new ProviderImpl(this, 208), new CachingProviderImpl(this, 281), new CachingProviderImpl(this, 297), new ProviderImpl(this, 141), new ProviderImpl(this, 412), new ProviderImpl(this, 478), new CachingProviderImpl(this, 175), this.cacheNode_249(), this.accessNode_336(), new ProviderImpl(this, 513), this.cacheNode_83(), this.mDependency_601.ep_7(), this.accessNode_467(), new ProviderImpl(this, 137), this.mSet_49, new ProviderImpl(this, 356), new CachingProviderImpl(this, 139), new ProviderImpl(this, 163), this.cacheNode_7());
+  }
+
+  Node_31 cacheNode_31() {
+    Object local = this.mNode_31Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_31(new ProviderImpl(this, 162), this.cacheNode_366(), new CachingProviderImpl(this, 334), this.cacheNode_258(), this.accessNode_397(), this.accessNode_115(), this.accessNode_454(), this.accessNode_74(), new ProviderImpl(this, 12));
+      this.mNode_31Instance = local;
+    }
+    return (Node_31) local;
+  }
+
+  Node_313 accessNode_313() {
+    return new Node_313(new CachingProviderImpl(this, 303), this.mSet_26, new CachingProviderImpl(this, 184), new ProviderImpl(this, 228), this.mSet_11, this.accessNode_418(), this.cacheNode_360(), new ProviderImpl(this, 374), this.cacheNode_511(), this.mSet_22, this.cacheNode_151(), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 93), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.mSet_35, new CachingProviderImpl(this, 201), new ProviderImpl(this, 375), new CachingProviderImpl(this, 186), this.mSet_30, new Node_181());
+  }
+
+  Node_316 cacheNode_316() {
+    Object local = this.mNode_316Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_316(new ProviderImpl(this, 206), new CachingProviderImpl(this, 372), this.accessNode_163(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), new CachingProviderImpl(this, 103));
+      this.mNode_316Instance = local;
+    }
+    return (Node_316) local;
+  }
+
+  Node_317 accessNode_317() {
+    return new Node_317(new ProviderImpl(this, 395), this.accessNode_329(), new CachingProviderImpl(this, 525), this.accessNode_209(), new ProviderImpl(this, 228), this.cacheNode_100(), new ProviderImpl(this, 478), this.mDependency_601.ep_8(), this.mDependency_601.ep_5(), new ProviderImpl(this, 485), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 188), new ProviderImpl(this, 238), new ProviderImpl(this, 148), new ProviderImpl(this, 231), new CachingProviderImpl(this, 272), new ProviderImpl(this, 466), new CachingProviderImpl(this, 281), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 454), this.accessNode_126(), this.accessNode_564());
+  }
+
+  Node_318 cacheNode_318() {
+    Object local = this.mNode_318Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_318(this.accessNode_458(), this.cacheNode_81(), this.mSet_46, this.cacheNode_98(), new CachingProviderImpl(this, 361), new ProviderImpl(this, 526), this.cacheNode_64());
+      this.mNode_318Instance = local;
+    }
+    return (Node_318) local;
+  }
+
+  Node_319 cacheNode_319() {
+    Object local = this.mNode_319Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_319(new ProviderImpl(this, 409), this.mSet_16, this.accessNode_127(), this.accessNode_216(), this.accessNode_305(), this.cacheNode_26(), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new ProviderImpl(this, 51), this.cacheNode_459(), this.accessNode_82(), this.cacheNode_415(), this.cacheNode_289(), new ProviderImpl(this, 244), this.mDependency_601.ep_3());
+      this.mNode_319Instance = local;
+    }
+    return (Node_319) local;
+  }
+
+  Node_320 accessNode_320() {
+    return new Node_320(this.accessNode_178(), this.accessNode_495(), this.mDependency_601.ep_34(), this.cacheNode_417(), new ProviderImpl(this, 319), this.accessNode_332(), this.cacheNode_521(), this.mDependency_601.ep_53(), new Node_181(), this.mSet_37, this.accessNode_185(), this.cacheNode_241());
+  }
+
+  Node_322 cacheNode_322() {
+    Object local = this.mNode_322Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_322(this.accessNode_203(), this.mSet_24, this.cacheNode_316(), this.cacheNode_318(), this.cacheNode_135(), this.accessNode_600(), this.cacheNode_33(), this.mSet_43, this.accessNode_395(), this.mDependency_601.ep_42(), this.accessNode_232(), this.cacheNode_269(), this.mSet_40, new CachingProviderImpl(this, 248), new ProviderImpl(this, 196), this.mSet_8, new ProviderImpl(this, 33));
+      this.mNode_322Instance = local;
+    }
+    return (Node_322) local;
+  }
+
+  Node_324 accessNode_324() {
+    return new Node_324(new CachingProviderImpl(this, 487), this.cacheNode_460(), this.cacheNode_215(), new CachingProviderImpl(this, 417), this.accessNode_56(), this.cacheNode_76(), new CachingProviderImpl(this, 206), new CachingProviderImpl(this, 9), new CachingProviderImpl(this, 120), this.cacheNode_519(), new ProviderImpl(this, 24), new CachingProviderImpl(this, 509), new ProviderImpl(this, 180), new CachingProviderImpl(this, 372), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 247), new ProviderImpl(this, 296), this.accessNode_107(), new CachingProviderImpl(this, 165), this.mSet_6, new CachingProviderImpl(this, 512), this.cacheNode_6(), this.accessNode_111(), new CachingProviderImpl(this, 481), this.accessNode_22());
+  }
+
+  Node_325 cacheNode_325() {
+    Object local = this.mNode_325Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_325(this.mSet_38, new CachingProviderImpl(this, 165), new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 259), new CachingProviderImpl(this, 269), this.mDependency_601.ep_40(), this.mDependency_601.ep_27(), new ProviderImpl(this, 33), new CachingProviderImpl(this, 161));
+      this.mNode_325Instance = local;
+    }
+    return (Node_325) local;
+  }
+
+  Node_328 cacheNode_328() {
+    Object local = this.mNode_328Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_328(this.mSet_36, new ProviderImpl(this, 375), new CachingProviderImpl(this, 62), this.accessNode_510(), this.accessNode_257(), this.mDependency_601.ep_9(), this.mDependency_601.ep_51());
+      this.mNode_328Instance = local;
+    }
+    return (Node_328) local;
+  }
+
+  Node_329 accessNode_329() {
+    return new Node_329(new ProviderImpl(this, 69), this.mDependency_601.ep_24(), new ProviderImpl(this, 344), new CachingProviderImpl(this, 78), new ProviderImpl(this, 352), new CachingProviderImpl(this, 209));
+  }
+
+  Node_337 accessNode_337() {
+    return new Node_337(new ProviderImpl(this, 33), this.mDependency_601.ep_30(), new ProviderImpl(this, 207), new CachingProviderImpl(this, 160), new ProviderImpl(this, 208), new CachingProviderImpl(this, 209), this.accessNode_134(), this.cacheNode_360(), this.cacheNode_404(), this.mDependency_601.ep_27(), this.accessNode_599());
+  }
+
+  Node_339 accessNode_339() {
+    return new Node_339(this.accessNode_324(), this.mDependency_601.ep_30(), new ProviderImpl(this, 33), new ProviderImpl(this, 270), this.mSet_45);
+  }
+
+  Node_344 accessNode_344() {
+    return new Node_344(new ProviderImpl(this, 236), this.mSet_24, new CachingProviderImpl(this, 469), new CachingProviderImpl(this, 120), this.accessNode_383(), new ProviderImpl(this, 241), this.cacheNode_479(), new CachingProviderImpl(this, 327), new ProviderImpl(this, 220), new ProviderImpl(this, 114), this.mDependency_601.ep_9(), new ProviderImpl(this, 291), new ProviderImpl(this, 506), new ProviderImpl(this, 180), new CachingProviderImpl(this, 244), this.mSet_17, this.mSet_7, new ProviderImpl(this, 352), new ProviderImpl(this, 516), new CachingProviderImpl(this, 188), new ProviderImpl(this, 185), new CachingProviderImpl(this, 104));
+  }
+
+  Node_347 cacheNode_347() {
+    Object local = this.mNode_347Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_347(this.cacheNode_64(), this.mDependency_601.ep_7(), new CachingProviderImpl(this, 25), this.cacheNode_475(), this.mSet_44, new ProviderImpl(this, 261), new CachingProviderImpl(this, 211), new ProviderImpl(this, 374), new CachingProviderImpl(this, 231), this.cacheNode_553(), new CachingProviderImpl(this, 26), this.mDependency_601.ep_48(), this.mDependency_601.ep_54(), new CachingProviderImpl(this, 485), new ProviderImpl(this, 517), this.mSet_39, new CachingProviderImpl(this, 126), this.mDependency_601.ep_10(), this.mSet_7);
+      this.mNode_347Instance = local;
+    }
+    return (Node_347) local;
+  }
+
+  Node_349 cacheNode_349() {
+    Object local = this.mNode_349Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_349(new ProviderImpl(this, 304), new CachingProviderImpl(this, 188), new ProviderImpl(this, 476), this.cacheNode_575(), this.mSet_17, this.accessNode_107(), new CachingProviderImpl(this, 487), new CachingProviderImpl(this, 340), this.accessNode_536());
+      this.mNode_349Instance = local;
+    }
+    return (Node_349) local;
+  }
+
+  Node_352 cacheNode_352() {
+    Object local = this.mNode_352Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_352(this.accessNode_111(), this.mSet_41, this.accessNode_535(), new CachingProviderImpl(this, 288), new CachingProviderImpl(this, 60), new CachingProviderImpl(this, 483), this.mDependency_601.ep_14(), new CachingProviderImpl(this, 32), new ProviderImpl(this, 336), new ProviderImpl(this, 490), new ProviderImpl(this, 70), new ProviderImpl(this, 154));
+      this.mNode_352Instance = local;
+    }
+    return (Node_352) local;
+  }
+
+  Node_353 cacheNode_353() {
+    Object local = this.mNode_353Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_353(new ProviderImpl(this, 96), this.accessNode_152(), new CachingProviderImpl(this, 507), this.accessNode_136(), new CachingProviderImpl(this, 66), new ProviderImpl(this, 50), this.cacheNode_366(), this.accessNode_43(), this.cacheNode_261());
+      this.mNode_353Instance = local;
+    }
+    return (Node_353) local;
+  }
+
+  Node_359 cacheNode_359() {
+    Object local = this.mNode_359Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_359(new ProviderImpl(this, 316), new ProviderImpl(this, 180), this.accessNode_430(), new ProviderImpl(this, 421), this.accessNode_197(), this.mDependency_601.ep_15(), this.mDependency_601.ep_1(), this.mDependency_601.ep_9(), new ProviderImpl(this, 383), new ProviderImpl(this, 133));
+      this.mNode_359Instance = local;
+    }
+    return (Node_359) local;
+  }
+
+  Node_365 accessNode_365() {
+    return new Node_365(new CachingProviderImpl(this, 514), this.mDependency_601.ep_12(), this.cacheNode_206(), new CachingProviderImpl(this, 458), this.mSet_0, new CachingProviderImpl(this, 104), new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 84), new ProviderImpl(this, 33), new CachingProviderImpl(this, 485), new ProviderImpl(this, 154), this.mDependency_601.ep_55(), new ProviderImpl(this, 499), new ProviderImpl(this, 196), this.mSet_9, this.mSet_48, this.mDependency_601.ep_1(), this.accessNode_456(), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), this.accessNode_186(), this.accessNode_363(), this.cacheNode_147(), this.cacheNode_559(), new CachingProviderImpl(this, 363), new ProviderImpl(this, 392), this.mDependency_601.ep_32(), this.cacheNode_143());
+  }
+
+  Node_366 cacheNode_366() {
+    Object local = this.mNode_366Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_366(this.accessNode_367(), this.accessNode_106(), new CachingProviderImpl(this, 84), new CachingProviderImpl(this, 85), new ProviderImpl(this, 86), this.mSet_11, this.cacheNode_250(), new CachingProviderImpl(this, 89), new ProviderImpl(this, 90), new CachingProviderImpl(this, 91), new CachingProviderImpl(this, 17), this.accessNode_303(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), new ProviderImpl(this, 92), new CachingProviderImpl(this, 66), new CachingProviderImpl(this, 93), new ProviderImpl(this, 94), new CachingProviderImpl(this, 95), new ProviderImpl(this, 96), this.mSet_12, new ProviderImpl(this, 98), new ProviderImpl(this, 99), new ProviderImpl(this, 100), new ProviderImpl(this, 15));
+      this.mNode_366Instance = local;
+    }
+    return (Node_366) local;
+  }
+
+  Node_367 accessNode_367() {
+    return new Node_367(new ProviderImpl(this, 287), new ProviderImpl(this, 230), new CachingProviderImpl(this, 266), new CachingProviderImpl(this, 69), this.mDependency_601.ep_56(), new ProviderImpl(this, 3), new ProviderImpl(this, 288), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), this.mSet_8, new ProviderImpl(this, 280), new CachingProviderImpl(this, 289), new CachingProviderImpl(this, 290), this.mSet_30, new CachingProviderImpl(this, 292), new CachingProviderImpl(this, 293), new CachingProviderImpl(this, 294), new CachingProviderImpl(this, 8), new ProviderImpl(this, 46), new ProviderImpl(this, 70), this.mSet_3, new CachingProviderImpl(this, 236), this.cacheNode_160(), this.mSet_31, new ProviderImpl(this, 295));
+  }
+
+  Node_377 accessNode_377() {
+    return new Node_377(this.mSet_30, this.mDependency_601.ep_2(), this.cacheNode_490(), this.accessNode_297(), this.cacheNode_157(), new ProviderImpl(this, 415), new CachingProviderImpl(this, 275), this.mDependency_601.ep_51(), new ProviderImpl(this, 455), new ProviderImpl(this, 200), this.mDependency_601.ep_21(), this.accessNode_543(), this.mDependency_601.ep_3(), this.cacheNode_570(), this.accessNode_216(), this.accessNode_51(), new CachingProviderImpl(this, 136), this.accessNode_393(), this.accessNode_179(), this.cacheNode_37(), new CachingProviderImpl(this, 139), new ProviderImpl(this, 462), this.cacheNode_20(), new CachingProviderImpl(this, 360), new CachingProviderImpl(this, 78), new ProviderImpl(this, 164), new CachingProviderImpl(this, 93), new CachingProviderImpl(this, 463));
+  }
+
+  Node_381 accessNode_381() {
+    return new Node_381(this.mSet_31, new ProviderImpl(this, 37), new ProviderImpl(this, 96), new ProviderImpl(this, 163), new ProviderImpl(this, 481));
+  }
+
+  Node_385 accessNode_385() {
+    return new Node_385(this.mSet_46, this.mDependency_601.ep_40(), this.mDependency_601.ep_7(), this.accessNode_419(), new CachingProviderImpl(this, 482), new ProviderImpl(this, 453), this.mDependency_601.ep_30(), this.mSet_44, new CachingProviderImpl(this, 222), this.accessNode_109(), new CachingProviderImpl(this, 126), new CachingProviderImpl(this, 340), new CachingProviderImpl(this, 78), new ProviderImpl(this, 415), new ProviderImpl(this, 417), this.accessNode_133(), new CachingProviderImpl(this, 446), new CachingProviderImpl(this, 321), new ProviderImpl(this, 291), new ProviderImpl(this, 499), new CachingProviderImpl(this, 450));
+  }
+
+  Node_390 accessNode_390() {
+    return new Node_390(this.mDependency_601.ep_17(), this.mDependency_601.ep_20(), new CachingProviderImpl(this, 450), this.mSet_35, this.accessNode_185(), this.mDependency_601.ep_53(), this.accessNode_543(), new CachingProviderImpl(this, 199), this.accessNode_300(), new CachingProviderImpl(this, 222), this.accessNode_344(), this.cacheNode_565(), this.accessNode_166(), this.mDependency_601.ep_7());
+  }
+
+  Node_394 accessNode_394() {
+    return new Node_394(new ProviderImpl(this, 374), new ProviderImpl(this, 38), this.cacheNode_316(), this.accessNode_82(), this.accessNode_574(), this.mSet_48, this.accessNode_303(), new CachingProviderImpl(this, 95), this.mSet_41, new ProviderImpl(this, 424), this.cacheNode_33(), new CachingProviderImpl(this, 140), this.accessNode_216(), new CachingProviderImpl(this, 190), this.mSet_27, this.accessNode_600(), this.accessNode_324(), this.accessNode_393(), this.accessNode_351(), this.cacheNode_67(), new ProviderImpl(this, 113), this.accessNode_211(), this.accessNode_186(), new ProviderImpl(this, 427), new CachingProviderImpl(this, 428), this.mSet_36, this.cacheNode_235(), this.accessNode_54(), this.accessNode_265());
+  }
+
+  Node_399 accessNode_399() {
+    return new Node_399(new CachingProviderImpl(this, 8));
+  }
+
+  Node_4 accessNode_4() {
+    return new Node_4(new CachingProviderImpl(this, 381), this.cacheNode_114(), new CachingProviderImpl(this, 448), new ProviderImpl(this, 83), new CachingProviderImpl(this, 171), new ProviderImpl(this, 491), this.cacheNode_206(), new CachingProviderImpl(this, 25), new ProviderImpl(this, 373), this.accessNode_432(), new ProviderImpl(this, 228), this.accessNode_455(), new ProviderImpl(this, 25), new ProviderImpl(this, 268), new ProviderImpl(this, 248), this.cacheNode_233(), this.accessNode_443(), new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 320), this.cacheNode_391(), this.cacheNode_215());
+  }
+
+  Node_405 accessNode_405() {
+    return new Node_405(this.accessNode_59(), this.mDependency_601.ep_14(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), this.cacheNode_328(), new CachingProviderImpl(this, 120), new CachingProviderImpl(this, 262), this.accessNode_590(), this.accessNode_152(), new CachingProviderImpl(this, 79), new ProviderImpl(this, 137), new ProviderImpl(this, 191), new CachingProviderImpl(this, 170), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.cacheNode_531(), this.mSet_16, Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), new CachingProviderImpl(this, 382), this.mDependency_601.ep_35(), this.cacheNode_417(), new ProviderImpl(this, 331), this.mDependency_601.ep_23(), this.accessNode_393(), new CachingProviderImpl(this, 31), this.cacheNode_138(), this.accessNode_213());
+  }
+
+  Node_407 cacheNode_407() {
+    Object local = this.mNode_407Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_407(this.accessNode_363(), new CachingProviderImpl(this, 139), new CachingProviderImpl(this, 219), new ProviderImpl(this, 275), new ProviderImpl(this, 518), new ProviderImpl(this, 165), this.accessNode_534(), new CachingProviderImpl(this, 19), new ProviderImpl(this, 465), new ProviderImpl(this, 212), this.mSet_8, this.accessNode_492(), this.mSet_25, new ProviderImpl(this, 280), this.mSet_36, new ProviderImpl(this, 390), new CachingProviderImpl(this, 223), this.cacheNode_361(), this.accessNode_92(), new CachingProviderImpl(this, 222), this.accessNode_119(), new ProviderImpl(this, 423), new ProviderImpl(this, 268));
+      this.mNode_407Instance = local;
+    }
+    return (Node_407) local;
+  }
+
+  Node_409 accessNode_409() {
+    return new Node_409(this.accessNode_386(), this.accessNode_342(), this.accessNode_574(), new CachingProviderImpl(this, 384), this.accessNode_508(), new CachingProviderImpl(this, 396), new ProviderImpl(this, 164));
+  }
+
+  Node_414 accessNode_414() {
+    return new Node_414(new ProviderImpl(this, 507), this.mDependency_601.ep_0(), this.mSet_40, new CachingProviderImpl(this, 136), this.cacheNode_162(), new ProviderImpl(this, 366), new ProviderImpl(this, 7), new ProviderImpl(this, 245), new ProviderImpl(this, 499), this.accessNode_264(), this.accessNode_534(), this.accessNode_136(), new CachingProviderImpl(this, 89), this.cacheNode_143(), this.cacheNode_530(), this.mDependency_601.ep_20(), this.accessNode_186(), this.mDependency_601.ep_23(), this.cacheNode_15(), new CachingProviderImpl(this, 525), new CachingProviderImpl(this, 119), new CachingProviderImpl(this, 42), this.cacheNode_244(), new ProviderImpl(this, 107), this.accessNode_455(), this.mSet_29, this.cacheNode_459(), this.accessNode_343(), new CachingProviderImpl(this, 423));
+  }
+
+  Node_415 cacheNode_415() {
+    Object local = this.mNode_415Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_415(this.cacheNode_562(), this.cacheNode_404(), this.accessNode_343(), new CachingProviderImpl(this, 25), this.cacheNode_500(), this.accessNode_296(), this.mSet_37, new CachingProviderImpl(this, 482), new ProviderImpl(this, 439), new ProviderImpl(this, 148), this.mSet_31, new ProviderImpl(this, 472), new ProviderImpl(this, 526), new CachingProviderImpl(this, 31), this.cacheNode_325(), this.cacheNode_193(), this.mDependency_601.ep_45(), this.mSet_40, this.accessNode_166(), this.cacheNode_198(), this.cacheNode_475());
+      this.mNode_415Instance = local;
+    }
+    return (Node_415) local;
+  }
+
+  Node_417 cacheNode_417() {
+    Object local = this.mNode_417Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_417(new ProviderImpl(this, 148), new CachingProviderImpl(this, 55), new ProviderImpl(this, 11), new CachingProviderImpl(this, 78), new CachingProviderImpl(this, 269), this.cacheNode_424(), new ProviderImpl(this, 391), new ProviderImpl(this, 385), this.accessNode_337(), this.mSet_38, this.accessNode_597(), this.accessNode_175(), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), this.cacheNode_38(), new ProviderImpl(this, 105), this.accessNode_61(), this.cacheNode_592(), new ProviderImpl(this, 457), this.mDependency_601.ep_9(), this.mDependency_601.ep_6());
+      this.mNode_417Instance = local;
+    }
+    return (Node_417) local;
+  }
+
+  Node_418 accessNode_418() {
+    return new Node_418(new ProviderImpl(this, 471), this.cacheNode_95(), new CachingProviderImpl(this, 505));
+  }
+
+  Node_419 accessNode_419() {
+    return new Node_419(this.cacheNode_551(), new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 171), new CachingProviderImpl(this, 172), this.mDependency_601.ep_35(), new ProviderImpl(this, 75), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 175), new ProviderImpl(this, 176), new ProviderImpl(this, 177), new ProviderImpl(this, 178), new ProviderImpl(this, 179), new ProviderImpl(this, 176), new ProviderImpl(this, 180), this.cacheNode_49(), this.mSet_1, new CachingProviderImpl(this, 43), new ProviderImpl(this, 12), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), this.accessNode_510(), this.cacheNode_406(), new CachingProviderImpl(this, 184), this.cacheNode_83(), new CachingProviderImpl(this, 186), new ProviderImpl(this, 187), new CachingProviderImpl(this, 188), new CachingProviderImpl(this, 189));
+  }
+
+  Node_42 accessNode_42() {
+    return new Node_42(this.mDependency_601.ep_55(), this.accessNode_92(), this.mSet_0, new CachingProviderImpl(this, 103), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), new ProviderImpl(this, 521), new ProviderImpl(this, 15), new ProviderImpl(this, 336), new ProviderImpl(this, 344), this.mSet_5, this.mDependency_601.ep_3(), new CachingProviderImpl(this, 126), new ProviderImpl(this, 467), new ProviderImpl(this, 232), this.accessNode_396());
+  }
+
+  Node_425 accessNode_425() {
+    return new Node_425(new CachingProviderImpl(this, 468), new ProviderImpl(this, 476), this.accessNode_86(), this.mDependency_601.ep_45());
+  }
+
+  Node_426 cacheNode_426() {
+    Object local = this.mNode_426Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_426(new CachingProviderImpl(this, 17), this.mSet_40, new CachingProviderImpl(this, 223), new CachingProviderImpl(this, 54), this.cacheNode_519(), new ProviderImpl(this, 245), new ProviderImpl(this, 258), this.cacheNode_441(), new CachingProviderImpl(this, 266));
+      this.mNode_426Instance = local;
+    }
+    return (Node_426) local;
+  }
+
+  Node_427 accessNode_427() {
+    return new Node_427(new CachingProviderImpl(this, 481), this.cacheNode_49(), new ProviderImpl(this, 490), this.mDependency_601.ep_54(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 184), new ProviderImpl(this, 294), new ProviderImpl(this, 228), this.accessNode_517(), this.accessNode_329(), this.cacheNode_479(), new ProviderImpl(this, 207), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 205), new ProviderImpl(this, 238), this.mSet_38, this.mDependency_601.ep_0(), this.mSet_23, new CachingProviderImpl(this, 61), new ProviderImpl(this, 318), new CachingProviderImpl(this, 460));
+  }
+
+  Node_430 accessNode_430() {
+    return new Node_430(new CachingProviderImpl(this, 10), this.accessNode_115(), new ProviderImpl(this, 433), new CachingProviderImpl(this, 483), this.cacheNode_234(), this.cacheNode_404(), new CachingProviderImpl(this, 192), new CachingProviderImpl(this, 136), new ProviderImpl(this, 15), new ProviderImpl(this, 437), this.mSet_37, this.cacheNode_391(), this.mDependency_601.ep_7(), new ProviderImpl(this, 526), new ProviderImpl(this, 262), this.accessNode_27(), new ProviderImpl(this, 113), new CachingProviderImpl(this, 278), new ProviderImpl(this, 366), this.mDependency_601.ep_24());
+  }
+
+  Node_432 accessNode_432() {
+    return new Node_432(new ProviderImpl(this, 67), this.accessNode_164());
+  }
+
+  Node_434 accessNode_434() {
+    return new Node_434(new ProviderImpl(this, 465), this.accessNode_576(), this.mDependency_601.ep_53(), new ProviderImpl(this, 296), new CachingProviderImpl(this, 275), new CachingProviderImpl(this, 364), new ProviderImpl(this, 62), this.mDependency_601.ep_35(), this.mSet_33, new ProviderImpl(this, 397), this.mDependency_601.ep_19(), this.accessNode_171(), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 52), this.mDependency_601.ep_32(), this.accessNode_393(), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), new ProviderImpl(this, 184), this.mDependency_601.ep_37(), new ProviderImpl(this, 134), this.accessNode_16(), new CachingProviderImpl(this, 421), this.cacheNode_407(), this.mSet_42);
+  }
+
+  Node_438 accessNode_438() {
+    return new Node_438(this.cacheNode_530(), this.cacheNode_258(), new ProviderImpl(this, 50), this.cacheNode_218(), this.accessNode_297(), this.mSet_48, new CachingProviderImpl(this, 227), this.accessNode_324(), this.accessNode_432(), this.mSet_0, this.accessNode_535(), new ProviderImpl(this, 205), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.accessNode_175(), new ProviderImpl(this, 385), new ProviderImpl(this, 164), this.mDependency_601.ep_13(), this.accessNode_494(), this.mDependency_601.ep_30(), this.cacheNode_11(), this.accessNode_534(), new CachingProviderImpl(this, 257), this.accessNode_239(), new ProviderImpl(this, 312), new CachingProviderImpl(this, 388), this.cacheNode_245(), this.accessNode_405());
+  }
+
+  Node_441 cacheNode_441() {
+    Object local = this.mNode_441Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_441();
+      this.mNode_441Instance = local;
+    }
+    return (Node_441) local;
+  }
+
+  Node_446 accessNode_446() {
+    return new Node_446(this.cacheNode_242(), this.accessNode_515(), new ProviderImpl(this, 33), this.accessNode_599(), new CachingProviderImpl(this, 139), this.cacheNode_334(), this.cacheNode_475(), new ProviderImpl(this, 245), new ProviderImpl(this, 222), this.accessNode_512(), this.mDependency_601.ep_16(), this.accessNode_166(), this.cacheNode_202(), this.cacheNode_551(), new ProviderImpl(this, 467));
+  }
+
+  Node_447 accessNode_447() {
+    return new Node_447(this.accessNode_518(), this.accessNode_397(), this.mSet_30, this.mDependency_601.ep_24(), new CachingProviderImpl(this, 275), this.mDependency_601.ep_42(), new ProviderImpl(this, 195), new CachingProviderImpl(this, 188), new CachingProviderImpl(this, 460), new CachingProviderImpl(this, 396), new CachingProviderImpl(this, 160), this.mSet_8, new ProviderImpl(this, 108), new ProviderImpl(this, 340), this.cacheNode_26());
+  }
+
+  Node_449 accessNode_449() {
+    return new Node_449(new ProviderImpl(this, 353), this.cacheNode_6(), new CachingProviderImpl(this, 291), new CachingProviderImpl(this, 8), new CachingProviderImpl(this, 149), this.cacheNode_391(), this.cacheNode_404(), Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), Checks.checkProvisionNotNull(Module_608.Companion.provides_832()), this.cacheNode_499(), new ProviderImpl(this, 392), new ProviderImpl(this, 218), new ProviderImpl(this, 503), this.accessNode_432(), this.accessNode_455(), new CachingProviderImpl(this, 332), new ProviderImpl(this, 27), new ProviderImpl(this, 354), this.mSet_40, new ProviderImpl(this, 187), new CachingProviderImpl(this, 205), new ProviderImpl(this, 408), new CachingProviderImpl(this, 250), this.mSet_33, this.mDependency_601.ep_25(), new ProviderImpl(this, 348), this.cacheNode_285());
+  }
+
+  Node_45 accessNode_45() {
+    return new Node_45(new ProviderImpl(this, 177), new ProviderImpl(this, 228), Checks.checkProvisionNotNull(Module_608.Companion.provides_832()), this.cacheNode_198(), new ProviderImpl(this, 151), this.mDependency_601.ep_11(), this.cacheNode_334(), new CachingProviderImpl(this, 262), this.mSet_16, new ProviderImpl(this, 493), new ProviderImpl(this, 304), new ProviderImpl(this, 50), this.cacheNode_258(), this.mDependency_601.ep_3(), this.cacheNode_83(), this.cacheNode_2(), new CachingProviderImpl(this, 152), new CachingProviderImpl(this, 222), this.accessNode_4(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), new ProviderImpl(this, 117), this.mSet_51, this.cacheNode_340(), this.accessNode_43());
+  }
+
+  Node_453 accessNode_453() {
+    return new Node_453(this.accessNode_494(), this.mSet_18, this.mDependency_601.ep_3(), this.accessNode_48(), new CachingProviderImpl(this, 79), this.cacheNode_322(), this.mSet_7, new ProviderImpl(this, 148));
+  }
+
+  Node_454 accessNode_454() {
+    return new Node_454(this.accessNode_455(), new CachingProviderImpl(this, 293), this.accessNode_42());
+  }
+
+  Node_455 accessNode_455() {
+    return new Node_455(new CachingProviderImpl(this, 104), new ProviderImpl(this, 330), this.mDependency_601.ep_48(), this.mDependency_601.ep_45(), this.mDependency_601.ep_14(), new ProviderImpl(this, 335), new CachingProviderImpl(this, 286), this.accessNode_336(), this.mSet_43, new ProviderImpl(this, 102), this.accessNode_292(), new CachingProviderImpl(this, 505), this.cacheNode_366(), this.mDependency_601.ep_41(), new ProviderImpl(this, 218), new CachingProviderImpl(this, 320), new ProviderImpl(this, 141), new ProviderImpl(this, 472), new CachingProviderImpl(this, 139), new CachingProviderImpl(this, 412), new CachingProviderImpl(this, 377), new CachingProviderImpl(this, 58), new ProviderImpl(this, 220), new ProviderImpl(this, 358), this.mDependency_601.ep_34(), new ProviderImpl(this, 403));
+  }
+
+  Node_457 cacheNode_457() {
+    Object local = this.mNode_457Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_457(new ProviderImpl(this, 391), new ProviderImpl(this, 110), this.mDependency_601.ep_16(), new CachingProviderImpl(this, 286), this.mSet_3, this.cacheNode_570(), this.mDependency_601.ep_3(), this.cacheNode_192(), new ProviderImpl(this, 323), new ProviderImpl(this, 472), new CachingProviderImpl(this, 237), new CachingProviderImpl(this, 136), new ProviderImpl(this, 342), this.mSet_25, new ProviderImpl(this, 148), this.mDependency_601.ep_55(), new ProviderImpl(this, 128), this.accessNode_595(), new ProviderImpl(this, 329), new ProviderImpl(this, 4), new CachingProviderImpl(this, 448), this.accessNode_329(), this.accessNode_494(), new CachingProviderImpl(this, 205), new CachingProviderImpl(this, 396), new ProviderImpl(this, 235), this.mSet_44, new CachingProviderImpl(this, 82));
+      this.mNode_457Instance = local;
+    }
+    return (Node_457) local;
+  }
+
+  Node_458 accessNode_458() {
+    return new Node_458(this.mDependency_601.ep_55(), this.accessNode_383(), new ProviderImpl(this, 230), this.accessNode_85(), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new ProviderImpl(this, 205), new ProviderImpl(this, 232), new CachingProviderImpl(this, 233), new CachingProviderImpl(this, 234), new ProviderImpl(this, 175), new ProviderImpl(this, 235), new ProviderImpl(this, 22), this.accessNode_5(), this.accessNode_515(), new ProviderImpl(this, 238), this.mSet_22, this.cacheNode_212(), new CachingProviderImpl(this, 89), new ProviderImpl(this, 50), this.mDependency_601.ep_13(), this.mSet_23, this.mSet_24, this.mSet_16);
+  }
+
+  Node_459 cacheNode_459() {
+    Object local = this.mNode_459Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_459(new ProviderImpl(this, 208), this.mDependency_601.ep_35(), this.mSet_0, new ProviderImpl(this, 148), new ProviderImpl(this, 12), new ProviderImpl(this, 154), new ProviderImpl(this, 467), this.accessNode_543(), new CachingProviderImpl(this, 85), new CachingProviderImpl(this, 398), new ProviderImpl(this, 127), new ProviderImpl(this, 483), this.mSet_47, new ProviderImpl(this, 403), new CachingProviderImpl(this, 470), this.mSet_29);
+      this.mNode_459Instance = local;
+    }
+    return (Node_459) local;
+  }
+
+  Node_46 accessNode_46() {
+    return new Node_46(new ProviderImpl(this, 96), new ProviderImpl(this, 41), this.cacheNode_190(), this.cacheNode_215(), this.accessNode_496(), this.accessNode_535(), this.accessNode_548(), this.cacheNode_72(), new CachingProviderImpl(this, 170), this.cacheNode_273(), new ProviderImpl(this, 383), this.cacheNode_141());
+  }
+
+  Node_467 accessNode_467() {
+    return new Node_467(this.mSet_40, this.mSet_29, new CachingProviderImpl(this, 487), new ProviderImpl(this, 239));
+  }
+
+  Node_468 cacheNode_468() {
+    Object local = this.mNode_468Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_468(this.mSet_0, new ProviderImpl(this, 526), this.accessNode_377(), new ProviderImpl(this, 508));
+      this.mNode_468Instance = local;
+    }
+    return (Node_468) local;
+  }
+
+  Node_469 cacheNode_469() {
+    Object local = this.mNode_469Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_469(this.accessNode_395(), new ProviderImpl(this, 418), new CachingProviderImpl(this, 276), this.cacheNode_260(), new CachingProviderImpl(this, 281), new CachingProviderImpl(this, 381), this.cacheNode_242(), new CachingProviderImpl(this, 361), this.cacheNode_33(), this.cacheNode_461(), this.cacheNode_223());
+      this.mNode_469Instance = local;
+    }
+    return (Node_469) local;
+  }
+
+  Node_470 accessNode_470() {
+    return new Node_470(new ProviderImpl(this, 163), new CachingProviderImpl(this, 49), new ProviderImpl(this, 398), this.mSet_3, new ProviderImpl(this, 399), this.mSet_39, new ProviderImpl(this, 318), new ProviderImpl(this, 205), this.cacheNode_135(), new CachingProviderImpl(this, 401));
+  }
+
+  Node_479 cacheNode_479() {
+    Object local = this.mNode_479Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_479(new ProviderImpl(this, 225), new ProviderImpl(this, 13));
+      this.mNode_479Instance = local;
+    }
+    return (Node_479) local;
+  }
+
+  Node_48 accessNode_48() {
+    return new Node_48(new CachingProviderImpl(this, 104), new ProviderImpl(this, 75), this.cacheNode_230());
+  }
+
+  Node_480 accessNode_480() {
+    return new Node_480(new ProviderImpl(this, 319), this.mDependency_601.ep_23(), new ProviderImpl(this, 229), this.mSet_15, new ProviderImpl(this, 303), new ProviderImpl(this, 382), this.mSet_9, new ProviderImpl(this, 162), this.mDependency_601.ep_8(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 165), this.accessNode_596(), this.mDependency_601.ep_43(), this.accessNode_510(), this.mDependency_601.ep_48(), new CachingProviderImpl(this, 500), new ProviderImpl(this, 191), new CachingProviderImpl(this, 276), new ProviderImpl(this, 419), new ProviderImpl(this, 273), new CachingProviderImpl(this, 501), new CachingProviderImpl(this, 343));
+  }
+
+  Node_483 accessNode_483() {
+    return new Node_483(this.cacheNode_413(), this.cacheNode_556(), this.mDependency_601.ep_11(), new ProviderImpl(this, 75), this.accessNode_307(), this.mDependency_601.ep_21(), new ProviderImpl(this, 238), this.mDependency_601.ep_20(), new ProviderImpl(this, 94), new ProviderImpl(this, 212), this.mSet_14, this.accessNode_297(), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), this.accessNode_410(), new CachingProviderImpl(this, 25), this.cacheNode_81(), this.accessNode_467(), new ProviderImpl(this, 267), Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), this.accessNode_533(), this.cacheNode_156(), new CachingProviderImpl(this, 78));
+  }
+
+  Node_488 cacheNode_488() {
+    Object local = this.mNode_488Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_488(this.accessNode_409(), new ProviderImpl(this, 435), this.mSet_41, this.accessNode_136(), this.cacheNode_391(), new CachingProviderImpl(this, 294), this.accessNode_85(), this.mDependency_601.ep_6(), this.accessNode_482(), this.cacheNode_567(), this.cacheNode_31());
+      this.mNode_488Instance = local;
+    }
+    return (Node_488) local;
+  }
+
+  Node_49 cacheNode_49() {
+    Object local = this.mNode_49Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_49(this.mDependency_601.ep_14(), new CachingProviderImpl(this, 349), new CachingProviderImpl(this, 84), new CachingProviderImpl(this, 448));
+      this.mNode_49Instance = local;
+    }
+    return (Node_49) local;
+  }
+
+  Node_490 cacheNode_490() {
+    Object local = this.mNode_490Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_490(this.mSet_25, this.cacheNode_511(), this.accessNode_23(), new ProviderImpl(this, 329), this.cacheNode_361(), new ProviderImpl(this, 300), this.mDependency_601.ep_55(), new ProviderImpl(this, 152), new CachingProviderImpl(this, 269), this.mDependency_601.ep_50(), new ProviderImpl(this, 72), new CachingProviderImpl(this, 429), Checks.checkProvisionNotNull(Module_608.Companion.provides_832()), new ProviderImpl(this, 456), new ProviderImpl(this, 207), this.mDependency_601.ep_33(), new CachingProviderImpl(this, 77), new CachingProviderImpl(this, 459), new ProviderImpl(this, 28), new ProviderImpl(this, 61), new CachingProviderImpl(this, 501), new CachingProviderImpl(this, 248), new ProviderImpl(this, 380), this.cacheNode_193(), new ProviderImpl(this, 493), new CachingProviderImpl(this, 247));
+      this.mNode_490Instance = local;
+    }
+    return (Node_490) local;
+  }
+
+  Node_495 accessNode_495() {
+    return new Node_495(this.accessNode_377(), new ProviderImpl(this, 208), new ProviderImpl(this, 153), this.mSet_31, new ProviderImpl(this, 414), this.accessNode_396(), new CachingProviderImpl(this, 362), this.cacheNode_415(), this.accessNode_150(), this.accessNode_18(), new ProviderImpl(this, 142), this.accessNode_239(), new CachingProviderImpl(this, 400), this.accessNode_383(), this.cacheNode_81(), this.mSet_21, new ProviderImpl(this, 389), new ProviderImpl(this, 141), this.accessNode_332(), new CachingProviderImpl(this, 442), this.cacheNode_238(), this.cacheNode_391(), this.mDependency_601.ep_5(), this.cacheNode_98(), new CachingProviderImpl(this, 460), this.accessNode_184(), this.cacheNode_431(), new CachingProviderImpl(this, 174), this.accessNode_178(), this.mDependency_601.ep_2());
+  }
+
+  Node_496 accessNode_496() {
+    return new Node_496(new CachingProviderImpl(this, 237), new CachingProviderImpl(this, 507), new ProviderImpl(this, 282), this.accessNode_574(), new CachingProviderImpl(this, 505), new ProviderImpl(this, 338), new CachingProviderImpl(this, 222), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 52), new CachingProviderImpl(this, 438), this.accessNode_596(), new ProviderImpl(this, 249), new CachingProviderImpl(this, 461), new CachingProviderImpl(this, 261), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 446), new ProviderImpl(this, 395));
+  }
+
+  Node_497 accessNode_497() {
+    return new Node_497(this.accessNode_93(), new CachingProviderImpl(this, 471), new ProviderImpl(this, 280), this.accessNode_480(), this.cacheNode_450(), new CachingProviderImpl(this, 320));
+  }
+
+  Node_498 cacheNode_498() {
+    Object local = this.mNode_498Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_498(this.cacheNode_206(), new ProviderImpl(this, 63), this.cacheNode_76(), new CachingProviderImpl(this, 440), new ProviderImpl(this, 325), new CachingProviderImpl(this, 401), this.cacheNode_2(), new ProviderImpl(this, 323), new CachingProviderImpl(this, 49), new CachingProviderImpl(this, 310), new CachingProviderImpl(this, 222), this.mDependency_601.ep_4(), this.accessNode_18(), this.mDependency_601.ep_15(), new CachingProviderImpl(this, 157), this.mSet_35, new CachingProviderImpl(this, 334), this.accessNode_470(), this.mDependency_601.ep_57(), this.mDependency_601.ep_27(), new CachingProviderImpl(this, 469), new CachingProviderImpl(this, 425), new ProviderImpl(this, 380), new ProviderImpl(this, 412), this.mDependency_601.ep_53(), new ProviderImpl(this, 421));
+      this.mNode_498Instance = local;
+    }
+    return (Node_498) local;
+  }
+
+  Node_5 accessNode_5() {
+    return new Node_5(new CachingProviderImpl(this, 25), this.cacheNode_101(), new CachingProviderImpl(this, 93), this.cacheNode_584(), this.mSet_38, new CachingProviderImpl(this, 485), this.accessNode_296(), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), this.cacheNode_460(), new CachingProviderImpl(this, 470), new ProviderImpl(this, 350), this.mSet_40, new ProviderImpl(this, 118), new CachingProviderImpl(this, 450), new CachingProviderImpl(this, 518), new ProviderImpl(this, 235), new ProviderImpl(this, 38), this.mDependency_601.ep_0(), new CachingProviderImpl(this, 54), new ProviderImpl(this, 335), new ProviderImpl(this, 249), new ProviderImpl(this, 466), this.mDependency_601.ep_45());
+  }
+
+  Node_500 cacheNode_500() {
+    Object local = this.mNode_500Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_500(this.accessNode_329(), new CachingProviderImpl(this, 381), this.accessNode_595(), new CachingProviderImpl(this, 396), new ProviderImpl(this, 280), this.mDependency_601.ep_47(), this.cacheNode_11(), new ProviderImpl(this, 435), new ProviderImpl(this, 333), new ProviderImpl(this, 436), new CachingProviderImpl(this, 69), this.accessNode_381(), new CachingProviderImpl(this, 248), this.cacheNode_429(), this.accessNode_576(), this.cacheNode_101(), new CachingProviderImpl(this, 382), Checks.checkProvisionNotNull(Module_608.Companion.provides_668()), this.accessNode_414());
+      this.mNode_500Instance = local;
+    }
+    return (Node_500) local;
+  }
+
+  Node_506 cacheNode_506() {
+    Object local = this.mNode_506Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_506(this.cacheNode_306(), new CachingProviderImpl(this, 340), new ProviderImpl(this, 462), new CachingProviderImpl(this, 365), new CachingProviderImpl(this, 468), this.cacheNode_2(), new ProviderImpl(this, 415), new ProviderImpl(this, 276), new ProviderImpl(this, 338), new CachingProviderImpl(this, 93), new ProviderImpl(this, 399), new ProviderImpl(this, 499), new CachingProviderImpl(this, 234), new CachingProviderImpl(this, 196), this.mSet_36, this.accessNode_574(), this.mSet_25);
+      this.mNode_506Instance = local;
+    }
+    return (Node_506) local;
+  }
+
+  Node_507 accessNode_507() {
+    return new Node_507(new ProviderImpl(this, 472), this.cacheNode_76(), this.cacheNode_157(), new CachingProviderImpl(this, 25), this.mSet_48, this.accessNode_558(), this.mDependency_601.ep_30(), new ProviderImpl(this, 63), this.mSet_48, new ProviderImpl(this, 264), new ProviderImpl(this, 218), this.accessNode_443(), this.cacheNode_37(), this.mSet_44, this.cacheNode_490(), new CachingProviderImpl(this, 261), new ProviderImpl(this, 385), this.accessNode_115(), new ProviderImpl(this, 40), this.mDependency_601.ep_42(), new ProviderImpl(this, 226), new CachingProviderImpl(this, 144), new CachingProviderImpl(this, 222), new CachingProviderImpl(this, 429), this.accessNode_301(), new ProviderImpl(this, 187), new CachingProviderImpl(this, 69), new ProviderImpl(this, 72), this.mSet_7);
+  }
+
+  Node_51 accessNode_51() {
+    return new Node_51(new ProviderImpl(this, 218));
+  }
+
+  Node_510 accessNode_510() {
+    return new Node_510(this.accessNode_106(), new CachingProviderImpl(this, 272), new CachingProviderImpl(this, 471), new ProviderImpl(this, 114), new ProviderImpl(this, 386), new ProviderImpl(this, 342), new CachingProviderImpl(this, 256), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), new ProviderImpl(this, 366), new CachingProviderImpl(this, 19), this.mDependency_601.ep_23(), new CachingProviderImpl(this, 446), this.cacheNode_433());
+  }
+
+  Node_511 cacheNode_511() {
+    Object local = this.mNode_511Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_511(new CachingProviderImpl(this, 320), new CachingProviderImpl(this, 446), new CachingProviderImpl(this, 106), new ProviderImpl(this, 369), this.mSet_28, this.cacheNode_79(), new ProviderImpl(this, 447), this.mSet_47, this.cacheNode_76(), Checks.checkProvisionNotNull(Module_608.Companion.provides_832()), new ProviderImpl(this, 107), new ProviderImpl(this, 26), this.mSet_27, this.mSet_11, this.mSet_23, new ProviderImpl(this, 257), new CachingProviderImpl(this, 44), new CachingProviderImpl(this, 306), new ProviderImpl(this, 238), new CachingProviderImpl(this, 458), new ProviderImpl(this, 258), Checks.checkProvisionNotNull(Module_608.Companion.provides_823()), new CachingProviderImpl(this, 305));
+      this.mNode_511Instance = local;
+    }
+    return (Node_511) local;
+  }
+
+  Node_512 accessNode_512() {
+    return new Node_512(this.cacheNode_584(), new ProviderImpl(this, 296), new CachingProviderImpl(this, 234), this.mDependency_601.ep_51(), new ProviderImpl(this, 447), new ProviderImpl(this, 162), new ProviderImpl(this, 101), this.accessNode_336(), new ProviderImpl(this, 33), new ProviderImpl(this, 224), new CachingProviderImpl(this, 58), new ProviderImpl(this, 449), this.mDependency_601.ep_16(), new CachingProviderImpl(this, 201), new ProviderImpl(this, 506), this.cacheNode_550(), new CachingProviderImpl(this, 52), this.cacheNode_81());
+  }
+
+  Node_513 cacheNode_513() {
+    Object local = this.mNode_513Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_513(new CachingProviderImpl(this, 487), this.mSet_48, this.accessNode_18(), new ProviderImpl(this, 2), this.accessNode_548(), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), this.cacheNode_519(), this.mSet_22, this.cacheNode_143(), new ProviderImpl(this, 93), this.cacheNode_104(), new ProviderImpl(this, 38), this.accessNode_102(), new CachingProviderImpl(this, 288), this.accessNode_430(), this.mSet_36, this.cacheNode_341(), this.cacheNode_123(), new CachingProviderImpl(this, 42));
+      this.mNode_513Instance = local;
+    }
+    return (Node_513) local;
+  }
+
+  Node_514 accessNode_514() {
+    return new Node_514(this.mSet_39, new ProviderImpl(this, 33), new ProviderImpl(this, 151), this.accessNode_439(), new ProviderImpl(this, 212), this.cacheNode_547(), this.accessNode_458(), new ProviderImpl(this, 473), this.mSet_43, new CachingProviderImpl(this, 354), new CachingProviderImpl(this, 171), this.accessNode_222(), new CachingProviderImpl(this, 524), this.accessNode_492(), this.cacheNode_433(), this.cacheNode_325(), this.cacheNode_273(), new ProviderImpl(this, 74), this.mDependency_601.ep_31(), new ProviderImpl(this, 385), new CachingProviderImpl(this, 525), this.mDependency_601.ep_48(), new CachingProviderImpl(this, 136), this.cacheNode_513());
+  }
+
+  Node_515 accessNode_515() {
+    return new Node_515(this.accessNode_455(), this.mDependency_601.ep_32(), new ProviderImpl(this, 101), this.cacheNode_160(), this.mSet_26, new CachingProviderImpl(this, 367), new CachingProviderImpl(this, 121), new ProviderImpl(this, 500), new CachingProviderImpl(this, 165), this.mDependency_601.ep_25(), new ProviderImpl(this, 493), new CachingProviderImpl(this, 402), new ProviderImpl(this, 373), this.cacheNode_567());
+  }
+
+  Node_519 cacheNode_519() {
+    Object local = this.mNode_519Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_519(this.mSet_19, new CachingProviderImpl(this, 362), new CachingProviderImpl(this, 39), new ProviderImpl(this, 33), new CachingProviderImpl(this, 314), this.mDependency_601.ep_4(), new CachingProviderImpl(this, 147));
+      this.mNode_519Instance = local;
+    }
+    return (Node_519) local;
+  }
+
+  Node_527 cacheNode_527() {
+    Object local = this.mNode_527Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_527(this.accessNode_524(), new ProviderImpl(this, 346), this.mSet_43, new ProviderImpl(this, 24), new ProviderImpl(this, 220), new CachingProviderImpl(this, 429), new CachingProviderImpl(this, 47), new ProviderImpl(this, 232), new ProviderImpl(this, 342), new ProviderImpl(this, 207), new ProviderImpl(this, 2), new ProviderImpl(this, 368), new CachingProviderImpl(this, 398), new CachingProviderImpl(this, 276), new ProviderImpl(this, 324), new CachingProviderImpl(this, 281), new CachingProviderImpl(this, 509), this.mDependency_601.ep_50(), new ProviderImpl(this, 449), this.mSet_4, this.accessNode_518(), this.cacheNode_215(), new ProviderImpl(this, 249), new CachingProviderImpl(this, 305), new ProviderImpl(this, 107));
+      this.mNode_527Instance = local;
+    }
+    return (Node_527) local;
+  }
+
+  Node_528 cacheNode_528() {
+    Object local = this.mNode_528Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_528(new CachingProviderImpl(this, 275));
+      this.mNode_528Instance = local;
+    }
+    return (Node_528) local;
+  }
+
+  Node_529 accessNode_529() {
+    return new Node_529(this.accessNode_102(), new ProviderImpl(this, 490), new CachingProviderImpl(this, 85), new CachingProviderImpl(this, 104), this.cacheNode_160(), new CachingProviderImpl(this, 25), this.mSet_6, new CachingProviderImpl(this, 297), new CachingProviderImpl(this, 276), this.mSet_27, this.accessNode_496(), this.cacheNode_215(), this.accessNode_333(), this.accessNode_454(), this.mDependency_601.ep_52());
+  }
+
+  Node_53 cacheNode_53() {
+    Object local = this.mNode_53Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_53(this.cacheNode_559(), this.accessNode_383(), new CachingProviderImpl(this, 351), new ProviderImpl(this, 107), this.accessNode_358(), this.cacheNode_460(), this.cacheNode_592(), this.accessNode_186(), this.accessNode_436(), new ProviderImpl(this, 216), this.accessNode_22(), this.accessNode_337(), this.cacheNode_26(), new ProviderImpl(this, 353), new ProviderImpl(this, 354), this.accessNode_54(), new CachingProviderImpl(this, 233), new ProviderImpl(this, 270), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), this.accessNode_263(), this.mDependency_601.ep_22(), this.mSet_15);
+      this.mNode_53Instance = local;
+    }
+    return (Node_53) local;
+  }
+
+  Node_530 cacheNode_530() {
+    Object local = this.mNode_530Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_530(new ProviderImpl(this, 275), this.accessNode_296(), new ProviderImpl(this, 238), new CachingProviderImpl(this, 461), new CachingProviderImpl(this, 305), this.mDependency_601.ep_52(), new ProviderImpl(this, 249), this.mSet_8, new CachingProviderImpl(this, 522), new ProviderImpl(this, 258), this.mDependency_601.ep_15(), this.cacheNode_520(), new ProviderImpl(this, 479), this.mSet_24, new ProviderImpl(this, 62));
+      this.mNode_530Instance = local;
+    }
+    return (Node_530) local;
+  }
+
+  Node_534 accessNode_534() {
+    return new Node_534(this.accessNode_599(), this.mDependency_601.ep_18(), new CachingProviderImpl(this, 91), new CachingProviderImpl(this, 269), new CachingProviderImpl(this, 34), new CachingProviderImpl(this, 61), new CachingProviderImpl(this, 434), this.cacheNode_245(), this.mSet_31, new CachingProviderImpl(this, 248), new ProviderImpl(this, 101), new ProviderImpl(this, 276), new ProviderImpl(this, 506), new CachingProviderImpl(this, 89), new ProviderImpl(this, 346), new CachingProviderImpl(this, 281), this.accessNode_171(), new ProviderImpl(this, 49), new ProviderImpl(this, 441));
+  }
+
+  Node_537 cacheNode_537() {
+    Object local = this.mNode_537Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_537(this.mDependency_601.ep_39(), new ProviderImpl(this, 344), new ProviderImpl(this, 169), new CachingProviderImpl(this, 481), new CachingProviderImpl(this, 482), this.cacheNode_135(), new ProviderImpl(this, 316), new ProviderImpl(this, 216), new CachingProviderImpl(this, 483), this.accessNode_596(), new ProviderImpl(this, 335), new CachingProviderImpl(this, 297), new ProviderImpl(this, 254), this.mSet_17, new CachingProviderImpl(this, 355), this.cacheNode_218(), new ProviderImpl(this, 255), this.mDependency_601.ep_28(), this.cacheNode_206(), this.accessNode_458(), new CachingProviderImpl(this, 409), this.accessNode_331(), this.cacheNode_83(), new CachingProviderImpl(this, 412), this.mDependency_601.ep_12(), this.accessNode_364());
+      this.mNode_537Instance = local;
+    }
+    return (Node_537) local;
+  }
+
+  Node_539 cacheNode_539() {
+    Object local = this.mNode_539Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_539(this.cacheNode_407(), this.accessNode_518(), this.mSet_25, this.cacheNode_162(), new ProviderImpl(this, 86), new CachingProviderImpl(this, 85), new ProviderImpl(this, 258), new CachingProviderImpl(this, 205), this.mSet_26, new ProviderImpl(this, 260), this.mSet_9, new CachingProviderImpl(this, 44), new ProviderImpl(this, 261), new CachingProviderImpl(this, 262), this.mSet_27, this.cacheNode_354(), this.accessNode_18());
+      this.mNode_539Instance = local;
+    }
+    return (Node_539) local;
+  }
+
+  Node_54 accessNode_54() {
+    return new Node_54(this.mSet_44, new CachingProviderImpl(this, 471), this.accessNode_438());
+  }
+
+  Node_541 accessNode_541() {
+    return new Node_541(new CachingProviderImpl(this, 10), this.accessNode_517(), new ProviderImpl(this, 141), new ProviderImpl(this, 256), this.mDependency_601.ep_27(), this.accessNode_336(), this.cacheNode_267(), new ProviderImpl(this, 166), new ProviderImpl(this, 269), new CachingProviderImpl(this, 8), this.accessNode_358(), new ProviderImpl(this, 402), this.accessNode_140(), this.accessNode_388());
+  }
+
+  Node_547 cacheNode_547() {
+    Object local = this.mNode_547Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_547(new ProviderImpl(this, 18), new CachingProviderImpl(this, 286), new CachingProviderImpl(this, 124), new CachingProviderImpl(this, 386), this.mSet_38);
+      this.mNode_547Instance = local;
+    }
+    return (Node_547) local;
+  }
+
+  Node_548 accessNode_548() {
+    return new Node_548(this.accessNode_331(), new ProviderImpl(this, 484), this.mDependency_601.ep_6());
+  }
+
+  Node_550 cacheNode_550() {
+    Object local = this.mNode_550Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_550(new CachingProviderImpl(this, 100), this.accessNode_164(), new ProviderImpl(this, 208), new CachingProviderImpl(this, 55), new ProviderImpl(this, 179), new ProviderImpl(this, 476), new ProviderImpl(this, 198), this.cacheNode_2(), new ProviderImpl(this, 67), this.accessNode_92(), new ProviderImpl(this, 422), this.mDependency_601.ep_22(), new CachingProviderImpl(this, 289), this.mSet_20, new ProviderImpl(this, 219), this.cacheNode_506(), new CachingProviderImpl(this, 144), this.mDependency_601.ep_4());
+      this.mNode_550Instance = local;
+    }
+    return (Node_550) local;
+  }
+
+  Node_552 accessNode_552() {
+    return new Node_552(new ProviderImpl(this, 326), new ProviderImpl(this, 327), new ProviderImpl(this, 144), new ProviderImpl(this, 220), this.mDependency_601.ep_51(), new ProviderImpl(this, 265), new ProviderImpl(this, 328), this.accessNode_336(), this.accessNode_497(), this.accessNode_447(), new CachingProviderImpl(this, 160), new CachingProviderImpl(this, 206), this.cacheNode_519(), new CachingProviderImpl(this, 273), new ProviderImpl(this, 330), new CachingProviderImpl(this, 71), this.cacheNode_15(), this.mSet_30, this.mDependency_601.ep_32(), new ProviderImpl(this, 238), new ProviderImpl(this, 34), new ProviderImpl(this, 141), this.accessNode_136(), this.cacheNode_325(), this.accessNode_494(), Checks.checkProvisionNotNull(Module_608.Companion.provides_810()), this.accessNode_189());
+  }
+
+  Node_556 cacheNode_556() {
+    Object local = this.mNode_556Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_556(this.cacheNode_584(), this.mDependency_601.ep_7(), new CachingProviderImpl(this, 398), new ProviderImpl(this, 395), this.accessNode_576(), this.mDependency_601.ep_19(), new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 422), this.mDependency_601.ep_48(), Checks.checkProvisionNotNull(Module_608.Companion.provides_655()), new ProviderImpl(this, 279), this.cacheNode_433(), new ProviderImpl(this, 344), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()), new CachingProviderImpl(this, 468), new CachingProviderImpl(this, 8), this.accessNode_344(), new CachingProviderImpl(this, 60), this.mDependency_601.ep_3());
+      this.mNode_556Instance = local;
+    }
+    return (Node_556) local;
+  }
+
+  Node_558 accessNode_558() {
+    return new Node_558(new CachingProviderImpl(this, 171), this.accessNode_497(), new CachingProviderImpl(this, 358), this.cacheNode_245(), new ProviderImpl(this, 156), this.accessNode_439(), new CachingProviderImpl(this, 340), this.accessNode_85(), this.cacheNode_429(), new CachingProviderImpl(this, 310), new ProviderImpl(this, 181), this.accessNode_418(), new CachingProviderImpl(this, 247), this.mDependency_601.ep_52(), new CachingProviderImpl(this, 215), new ProviderImpl(this, 114), new ProviderImpl(this, 279), this.mDependency_601.ep_28());
+  }
+
+  Node_559 cacheNode_559() {
+    Object local = this.mNode_559Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_559(this.accessNode_574(), new CachingProviderImpl(this, 520), new ProviderImpl(this, 503), this.mDependency_601.ep_25(), this.cacheNode_460(), this.accessNode_381(), new CachingProviderImpl(this, 286), new ProviderImpl(this, 330), new CachingProviderImpl(this, 215), new CachingProviderImpl(this, 304), this.accessNode_386(), this.accessNode_466(), new ProviderImpl(this, 493), new ProviderImpl(this, 465), new CachingProviderImpl(this, 423), new CachingProviderImpl(this, 216), this.mDependency_601.ep_32(), new ProviderImpl(this, 362), this.mDependency_601.ep_35());
+      this.mNode_559Instance = local;
+    }
+    return (Node_559) local;
+  }
+
+  Node_56 accessNode_56() {
+    return new Node_56(this.mSet_40, new CachingProviderImpl(this, 121), this.accessNode_535(), new CachingProviderImpl(this, 262), this.mSet_31, new CachingProviderImpl(this, 85), new ProviderImpl(this, 21), new ProviderImpl(this, 484));
+  }
+
+  Node_560 cacheNode_560() {
+    Object local = this.mNode_560Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_560(this.accessNode_571(), new CachingProviderImpl(this, 91), this.accessNode_292(), new CachingProviderImpl(this, 393), this.accessNode_410(), new CachingProviderImpl(this, 89), this.accessNode_102(), this.cacheNode_146(), this.mDependency_601.ep_12(), new CachingProviderImpl(this, 170), this.accessNode_337(), new ProviderImpl(this, 53), new ProviderImpl(this, 477), new ProviderImpl(this, 232), new ProviderImpl(this, 344), this.accessNode_383(), this.accessNode_365(), new CachingProviderImpl(this, 223), this.accessNode_51(), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), new CachingProviderImpl(this, 523), new CachingProviderImpl(this, 98), new ProviderImpl(this, 300), this.accessNode_467(), new CachingProviderImpl(this, 34), this.mSet_30, this.mSet_29, new ProviderImpl(this, 154));
+      this.mNode_560Instance = local;
+    }
+    return (Node_560) local;
+  }
+
+  Node_562 cacheNode_562() {
+    Object local = this.mNode_562Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_562(new CachingProviderImpl(this, 62), this.accessNode_596(), new ProviderImpl(this, 163), new CachingProviderImpl(this, 51), new ProviderImpl(this, 164), this.accessNode_152(), this.cacheNode_530(), new ProviderImpl(this, 169), this.cacheNode_253(), this.accessNode_329(), this.cacheNode_290(), new ProviderImpl(this, 302));
+      this.mNode_562Instance = local;
+    }
+    return (Node_562) local;
+  }
+
+  Node_565 cacheNode_565() {
+    Object local = this.mNode_565Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_565(this.cacheNode_101(), new CachingProviderImpl(this, 233), this.mDependency_601.ep_39(), new CachingProviderImpl(this, 365), new CachingProviderImpl(this, 386), new CachingProviderImpl(this, 454), new CachingProviderImpl(this, 16), this.mDependency_601.ep_16(), this.accessNode_524(), this.mDependency_601.ep_36(), new CachingProviderImpl(this, 130), this.accessNode_102(), this.accessNode_264(), this.mDependency_601.ep_8(), new ProviderImpl(this, 504), this.mDependency_601.ep_22(), new CachingProviderImpl(this, 7), this.mDependency_601.ep_42(), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()));
+      this.mNode_565Instance = local;
+    }
+    return (Node_565) local;
+  }
+
+  Node_567 cacheNode_567() {
+    Object local = this.mNode_567Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_567(new CachingProviderImpl(this, 507), this.cacheNode_547(), this.accessNode_336(), new CachingProviderImpl(this, 247), new ProviderImpl(this, 96), this.accessNode_492(), new ProviderImpl(this, 143));
+      this.mNode_567Instance = local;
+    }
+    return (Node_567) local;
+  }
+
+  Node_570 cacheNode_570() {
+    Object local = this.mNode_570Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_570(new CachingProviderImpl(this, 261), this.accessNode_548(), this.cacheNode_527(), this.cacheNode_441(), this.cacheNode_450(), new ProviderImpl(this, 318), new CachingProviderImpl(this, 329), new ProviderImpl(this, 404), new ProviderImpl(this, 74));
+      this.mNode_570Instance = local;
+    }
+    return (Node_570) local;
+  }
+
+  Node_572 cacheNode_572() {
+    Object local = this.mNode_572Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_572(this.cacheNode_33(), this.mSet_48, new ProviderImpl(this, 268), this.accessNode_492(), new CachingProviderImpl(this, 222), this.accessNode_85(), this.cacheNode_519(), new CachingProviderImpl(this, 104), this.accessNode_409(), new ProviderImpl(this, 35), this.mSet_35);
+      this.mNode_572Instance = local;
+    }
+    return (Node_572) local;
+  }
+
+  Node_573 accessNode_573() {
+    return new Node_573(new ProviderImpl(this, 166), this.cacheNode_306(), this.accessNode_219(), new CachingProviderImpl(this, 94), new ProviderImpl(this, 163), new CachingProviderImpl(this, 25), this.accessNode_512(), this.accessNode_82(), this.accessNode_105(), this.accessNode_536(), this.cacheNode_76(), this.accessNode_154(), new ProviderImpl(this, 384), new CachingProviderImpl(this, 368), new CachingProviderImpl(this, 445), this.cacheNode_521(), this.accessNode_358(), new CachingProviderImpl(this, 442), this.cacheNode_319(), new ProviderImpl(this, 218), this.cacheNode_416(), this.cacheNode_547(), this.cacheNode_121(), this.accessNode_191(), this.cacheNode_413(), this.cacheNode_460(), this.cacheNode_359(), this.cacheNode_53(), new CachingProviderImpl(this, 334));
+  }
+
+  Node_574 accessNode_574() {
+    return new Node_574(new ProviderImpl(this, 143), this.mDependency_601.ep_18(), new ProviderImpl(this, 162), new CachingProviderImpl(this, 25), new ProviderImpl(this, 414), new ProviderImpl(this, 22), this.accessNode_456(), new CachingProviderImpl(this, 62), new ProviderImpl(this, 124), this.accessNode_595(), new CachingProviderImpl(this, 173), this.mDependency_601.ep_41(), new ProviderImpl(this, 490), new ProviderImpl(this, 249), new CachingProviderImpl(this, 167), this.cacheNode_551(), new ProviderImpl(this, 23), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 358), new ProviderImpl(this, 411), new CachingProviderImpl(this, 40), new ProviderImpl(this, 183), this.mSet_41, new ProviderImpl(this, 9), new CachingProviderImpl(this, 34), new ProviderImpl(this, 298), new CachingProviderImpl(this, 275), new ProviderImpl(this, 383));
+  }
+
+  Node_578 cacheNode_578() {
+    Object local = this.mNode_578Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_578(this.cacheNode_289(), this.cacheNode_490(), new ProviderImpl(this, 186), this.cacheNode_426(), this.mSet_24, new ProviderImpl(this, 163), this.cacheNode_81(), this.accessNode_119(), this.mSet_50, new CachingProviderImpl(this, 429), new ProviderImpl(this, 491), this.accessNode_363(), this.cacheNode_286(), this.accessNode_54(), this.cacheNode_475(), this.cacheNode_271(), this.cacheNode_404(), new CachingProviderImpl(this, 237), new ProviderImpl(this, 432), this.accessNode_152(), new CachingProviderImpl(this, 248), new ProviderImpl(this, 329), this.cacheNode_143(), new CachingProviderImpl(this, 25), this.mSet_0, this.accessNode_600(), this.cacheNode_121(), this.cacheNode_128(), this.mDependency_601.ep_50());
+      this.mNode_578Instance = local;
+    }
+    return (Node_578) local;
+  }
+
+  Node_581 cacheNode_581() {
+    Object local = this.mNode_581Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_581(this.cacheNode_530(), this.accessNode_497(), this.accessNode_172(), new CachingProviderImpl(this, 310));
+      this.mNode_581Instance = local;
+    }
+    return (Node_581) local;
+  }
+
+  Node_582 accessNode_582() {
+    return new Node_582(new CachingProviderImpl(this, 82), new ProviderImpl(this, 309), this.cacheNode_168(), this.accessNode_418(), this.mDependency_601.ep_4(), this.accessNode_298(), new CachingProviderImpl(this, 470), this.mSet_43, new CachingProviderImpl(this, 515), this.accessNode_367(), new ProviderImpl(this, 472), new ProviderImpl(this, 42), this.cacheNode_131(), new ProviderImpl(this, 56));
+  }
+
+  Node_584 cacheNode_584() {
+    Object local = this.mNode_584Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_584(new ProviderImpl(this, 383), Checks.checkProvisionNotNull(Module_608.Companion.provides_748()), this.cacheNode_361(), this.accessNode_419(), this.cacheNode_147(), new CachingProviderImpl(this, 34), new ProviderImpl(this, 374), new ProviderImpl(this, 424), this.mDependency_601.ep_35(), new CachingProviderImpl(this, 197), new ProviderImpl(this, 75), new ProviderImpl(this, 202), new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 171), new ProviderImpl(this, 382), new ProviderImpl(this, 78), new CachingProviderImpl(this, 247));
+      this.mNode_584Instance = local;
+    }
+    return (Node_584) local;
+  }
+
+  Node_585 accessNode_585() {
+    return new Node_585(this.cacheNode_479(), this.accessNode_102(), new CachingProviderImpl(this, 31), this.mDependency_601.ep_54(), new CachingProviderImpl(this, 105), new CachingProviderImpl(this, 69), this.mSet_25, this.accessNode_418(), this.mSet_33, new CachingProviderImpl(this, 281), this.mDependency_601.ep_24(), this.cacheNode_360(), this.mDependency_601.ep_39(), this.accessNode_535(), new CachingProviderImpl(this, 458), new ProviderImpl(this, 491), this.accessNode_339(), new CachingProviderImpl(this, 504), this.mDependency_601.ep_2(), this.accessNode_109(), this.cacheNode_485(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 438));
+  }
+
+  Node_586 cacheNode_586() {
+    Object local = this.mNode_586Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_586(this.cacheNode_457(), new ProviderImpl(this, 424), new ProviderImpl(this, 65), new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 79), new CachingProviderImpl(this, 54), this.accessNode_292(), this.accessNode_574(), new CachingProviderImpl(this, 485), new ProviderImpl(this, 200), new ProviderImpl(this, 486), this.mDependency_601.ep_16(), this.accessNode_313(), new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 406), new CachingProviderImpl(this, 440), new ProviderImpl(this, 331), new CachingProviderImpl(this, 358));
+      this.mNode_586Instance = local;
+    }
+    return (Node_586) local;
+  }
+
+  Node_588 cacheNode_588() {
+    Object local = this.mNode_588Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_588(this.mDependency_601.ep_20(), new CachingProviderImpl(this, 73), new ProviderImpl(this, 337), new CachingProviderImpl(this, 11), new CachingProviderImpl(this, 250), new ProviderImpl(this, 338), new CachingProviderImpl(this, 233), new ProviderImpl(this, 37), this.accessNode_203(), new CachingProviderImpl(this, 226), this.cacheNode_361());
+      this.mNode_588Instance = local;
+    }
+    return (Node_588) local;
+  }
+
+  Node_589 cacheNode_589() {
+    Object local = this.mNode_589Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_589(new CachingProviderImpl(this, 417), this.mSet_20, this.accessNode_96(), new ProviderImpl(this, 393), new Node_181(), new CachingProviderImpl(this, 474), this.mDependency_601.ep_31(), this.cacheNode_238(), this.accessNode_23(), new ProviderImpl(this, 41), new CachingProviderImpl(this, 104), new ProviderImpl(this, 194), this.mSet_23, new ProviderImpl(this, 457), new CachingProviderImpl(this, 286), new ProviderImpl(this, 367), new ProviderImpl(this, 54), new CachingProviderImpl(this, 234), this.cacheNode_37(), this.accessNode_303(), new CachingProviderImpl(this, 209));
+      this.mNode_589Instance = local;
+    }
+    return (Node_589) local;
+  }
+
+  Node_59 accessNode_59() {
+    return new Node_59(this.accessNode_300(), new ProviderImpl(this, 178), new CachingProviderImpl(this, 315), new ProviderImpl(this, 12), Checks.checkProvisionNotNull(Module_608.Companion.provides_699()), new CachingProviderImpl(this, 497), this.mSet_50, new ProviderImpl(this, 141), this.mSet_51, new ProviderImpl(this, 491), new CachingProviderImpl(this, 340), new CachingProviderImpl(this, 502), this.mDependency_601.ep_57(), new ProviderImpl(this, 508), new ProviderImpl(this, 88), new ProviderImpl(this, 484), new CachingProviderImpl(this, 525));
+  }
+
+  Node_590 accessNode_590() {
+    return new Node_590(this.cacheNode_49(), new ProviderImpl(this, 344), new CachingProviderImpl(this, 504), this.cacheNode_15(), new ProviderImpl(this, 446), new CachingProviderImpl(this, 434), new ProviderImpl(this, 350), this.accessNode_432());
+  }
+
+  Node_593 cacheNode_593() {
+    Object local = this.mNode_593Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_593(this.cacheNode_325(), new ProviderImpl(this, 465), new CachingProviderImpl(this, 303), new CachingProviderImpl(this, 188), new ProviderImpl(this, 72), new ProviderImpl(this, 456), this.cacheNode_104(), new CachingProviderImpl(this, 382), new CachingProviderImpl(this, 524), new ProviderImpl(this, 519), new ProviderImpl(this, 498), this.cacheNode_242(), this.mDependency_601.ep_47(), this.accessNode_599(), this.accessNode_514(), this.mSet_1);
+      this.mNode_593Instance = local;
+    }
+    return (Node_593) local;
+  }
+
+  Node_595 accessNode_595() {
+    return new Node_595(Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), new ProviderImpl(this, 308), new CachingProviderImpl(this, 93), new CachingProviderImpl(this, 226), this.mSet_1, new CachingProviderImpl(this, 149), this.mDependency_601.ep_20(), new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 434), new ProviderImpl(this, 499), new CachingProviderImpl(this, 501));
+  }
+
+  Node_596 accessNode_596() {
+    return new Node_596(new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 421), new ProviderImpl(this, 476), this.cacheNode_215(), new ProviderImpl(this, 110), new ProviderImpl(this, 37), this.cacheNode_40(), new ProviderImpl(this, 200));
+  }
+
+  Node_597 accessNode_597() {
+    return new Node_597(new ProviderImpl(this, 229), new ProviderImpl(this, 508), new ProviderImpl(this, 499), new CachingProviderImpl(this, 54), new ProviderImpl(this, 2), new ProviderImpl(this, 143), new CachingProviderImpl(this, 257), new ProviderImpl(this, 235), new ProviderImpl(this, 390), new CachingProviderImpl(this, 272), this.accessNode_456());
+  }
+
+  Node_6 cacheNode_6() {
+    Object local = this.mNode_6Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_6(new CachingProviderImpl(this, 304), this.accessNode_512(), new CachingProviderImpl(this, 413), new ProviderImpl(this, 455), new CachingProviderImpl(this, 289), new CachingProviderImpl(this, 367), new ProviderImpl(this, 376), this.cacheNode_460(), new ProviderImpl(this, 134), this.mDependency_601.ep_1(), new ProviderImpl(this, 456), this.mDependency_601.ep_36(), new CachingProviderImpl(this, 275), this.mDependency_601.ep_18());
+      this.mNode_6Instance = local;
+    }
+    return (Node_6) local;
+  }
+
+  Node_600 accessNode_600() {
+    return new Node_600(this.mSet_20, this.cacheNode_527(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 418), this.mDependency_601.ep_14(), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 515), this.accessNode_8(), new ProviderImpl(this, 490), new ProviderImpl(this, 312), new ProviderImpl(this, 88), new CachingProviderImpl(this, 120), this.cacheNode_49(), this.cacheNode_40(), new ProviderImpl(this, 211), this.accessNode_305(), new ProviderImpl(this, 163), new ProviderImpl(this, 46));
+  }
+
+  Node_63 accessNode_63() {
+    return new Node_63(new ProviderImpl(this, 99), new ProviderImpl(this, 143), this.accessNode_518(), new ProviderImpl(this, 85), new ProviderImpl(this, 75), new CachingProviderImpl(this, 89), new ProviderImpl(this, 154), new ProviderImpl(this, 113), this.mSet_40, new ProviderImpl(this, 342), new CachingProviderImpl(this, 265), new ProviderImpl(this, 477), this.mSet_12, this.mDependency_601.ep_21(), this.mSet_48, new ProviderImpl(this, 380), Checks.checkProvisionNotNull(Module_608.Companion.provides_722()), this.accessNode_590(), this.mSet_46, new ProviderImpl(this, 137), new ProviderImpl(this, 107), new CachingProviderImpl(this, 144), new ProviderImpl(this, 249), new CachingProviderImpl(this, 215), Checks.checkProvisionNotNull(Module_608.Companion.provides_718()));
+  }
+
+  Node_67 cacheNode_67() {
+    Object local = this.mNode_67Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_67(this.cacheNode_431(), this.mSet_10, new CachingProviderImpl(this, 97), this.cacheNode_556(), new CachingProviderImpl(this, 25), this.cacheNode_406(), new ProviderImpl(this, 137), new CachingProviderImpl(this, 463), new ProviderImpl(this, 453), this.accessNode_456(), new CachingProviderImpl(this, 446), this.accessNode_165(), new ProviderImpl(this, 465), new ProviderImpl(this, 477), this.mSet_33, new CachingProviderImpl(this, 387), new CachingProviderImpl(this, 276), new ProviderImpl(this, 456), new CachingProviderImpl(this, 131), new ProviderImpl(this, 366));
+      this.mNode_67Instance = local;
+    }
+    return (Node_67) local;
+  }
+
+  Node_7 cacheNode_7() {
+    Object local = this.mNode_7Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_7(new CachingProviderImpl(this, 412), new ProviderImpl(this, 230), Checks.checkProvisionNotNull(Module_608.Companion.provides_802()), new CachingProviderImpl(this, 276), new CachingProviderImpl(this, 233), this.accessNode_293(), new CachingProviderImpl(this, 291));
+      this.mNode_7Instance = local;
+    }
+    return (Node_7) local;
+  }
+
+  Node_72 cacheNode_72() {
+    Object local = this.mNode_72Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_72(this.accessNode_524(), this.cacheNode_6(), this.accessNode_501(), new ProviderImpl(this, 341));
+      this.mNode_72Instance = local;
+    }
+    return (Node_72) local;
+  }
+
+  Node_74 accessNode_74() {
+    return new Node_74(this.mDependency_601.ep_41(), this.accessNode_305(), new CachingProviderImpl(this, 131), this.mSet_12, this.accessNode_5(), new ProviderImpl(this, 304), this.accessNode_596(), this.cacheNode_426(), this.mDependency_601.ep_40(), new ProviderImpl(this, 489), this.accessNode_320());
+  }
+
+  Node_77 cacheNode_77() {
+    Object local = this.mNode_77Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_77(this.accessNode_175(), new CachingProviderImpl(this, 175), new CachingProviderImpl(this, 388), this.mSet_31, new ProviderImpl(this, 424), this.accessNode_466(), this.accessNode_16(), this.cacheNode_406(), new ProviderImpl(this, 479), new ProviderImpl(this, 135), new CachingProviderImpl(this, 262), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new CachingProviderImpl(this, 9), this.accessNode_434(), this.accessNode_191(), this.cacheNode_589(), this.accessNode_187(), new ProviderImpl(this, 143), this.accessNode_292(), new CachingProviderImpl(this, 3), this.mDependency_601.ep_46(), new ProviderImpl(this, 412), this.cacheNode_379(), new ProviderImpl(this, 156), new CachingProviderImpl(this, 248), this.cacheNode_273(), new ProviderImpl(this, 38));
+      this.mNode_77Instance = local;
+    }
+    return (Node_77) local;
+  }
+
+  Node_79 cacheNode_79() {
+    Object local = this.mNode_79Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_79(new CachingProviderImpl(this, 522), this.cacheNode_2(), this.mDependency_601.ep_26(), this.accessNode_494(), new ProviderImpl(this, 179), this.accessNode_305(), new CachingProviderImpl(this, 60), new CachingProviderImpl(this, 189), this.accessNode_187(), new CachingProviderImpl(this, 222), new ProviderImpl(this, 197), new ProviderImpl(this, 28), this.accessNode_386(), new ProviderImpl(this, 415), this.mSet_33, new CachingProviderImpl(this, 275), new ProviderImpl(this, 111), this.mDependency_601.ep_33(), Checks.checkProvisionNotNull(Module_608.Companion.provides_791()), this.cacheNode_551(), new CachingProviderImpl(this, 54), new ProviderImpl(this, 141), new CachingProviderImpl(this, 100), this.mDependency_601.ep_56(), new ProviderImpl(this, 391), new ProviderImpl(this, 321), this.mSet_8);
+      this.mNode_79Instance = local;
+    }
+    return (Node_79) local;
+  }
+
+  Node_81 cacheNode_81() {
+    Object local = this.mNode_81Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_81(new CachingProviderImpl(this, 126), new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 266), new CachingProviderImpl(this, 223), new CachingProviderImpl(this, 73), this.accessNode_571());
+      this.mNode_81Instance = local;
+    }
+    return (Node_81) local;
+  }
+
+  Node_93 accessNode_93() {
+    return new Node_93(new CachingProviderImpl(this, 497), new CachingProviderImpl(this, 171), Checks.checkProvisionNotNull(Module_608.Companion.provides_715()), new ProviderImpl(this, 208), this.accessNode_127());
+  }
+
+  Node_96 accessNode_96() {
+    return new Node_96(this.mSet_48, new ProviderImpl(this, 342), this.mSet_0, this.mDependency_601.ep_54(), this.cacheNode_11(), new CachingProviderImpl(this, 188), new ProviderImpl(this, 403), this.cacheNode_366(), this.cacheNode_49(), new ProviderImpl(this, 325), this.mDependency_601.ep_10(), new CachingProviderImpl(this, 205), new CachingProviderImpl(this, 275), this.mSet_29, new CachingProviderImpl(this, 450), new ProviderImpl(this, 249));
+  }
+
+  Node_97 accessNode_97() {
+    return new Node_97(this.mDependency_601.ep_20(), new CachingProviderImpl(this, 165), new CachingProviderImpl(this, 425));
+  }
+
+  Node_98 cacheNode_98() {
+    Object local = this.mNode_98Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_98(this.cacheNode_2(), new ProviderImpl(this, 508), new CachingProviderImpl(this, 102), new CachingProviderImpl(this, 84), this.cacheNode_206(), new ProviderImpl(this, 408), new CachingProviderImpl(this, 246));
+      this.mNode_98Instance = local;
+    }
+    return (Node_98) local;
+  }
+
+  Node_99 cacheNode_99() {
+    Object local = this.mNode_99Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_99(this.accessNode_199(), this.accessNode_518(), new CachingProviderImpl(this, 25), this.cacheNode_460(), new CachingProviderImpl(this, 315), this.accessNode_96(), this.mDependency_601.ep_8(), this.cacheNode_349(), this.cacheNode_581(), this.accessNode_515(), new ProviderImpl(this, 359), this.accessNode_395(), this.cacheNode_379(), new CachingProviderImpl(this, 454), this.accessNode_389(), this.cacheNode_104(), this.accessNode_93(), this.cacheNode_281(), new CachingProviderImpl(this, 429), this.cacheNode_572(), new CachingProviderImpl(this, 310), new CachingProviderImpl(this, 406), this.cacheNode_190(), new CachingProviderImpl(this, 118), this.cacheNode_25(), new CachingProviderImpl(this, 464), this.cacheNode_95(), this.accessNode_78());
+      this.mNode_99Instance = local;
+    }
+    return (Node_99) local;
+  }
+
+  public static Component_602.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$Component_602 mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$Component_602 delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$Component_602 mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$Component_602 factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements Component_602.Creator {
+    private Dependency_601 mSetDep_0;
+
+    private Node_88 mSet_0;
+
+    private Node_278 mSet_1;
+
+    private Node_545 mSet_10;
+
+    private Node_471 mSet_11;
+
+    private Node_170 mSet_12;
+
+    private Node_412 mSet_13;
+
+    private Node_52 mSet_14;
+
+    private Node_442 mSet_15;
+
+    private Node_370 mSet_16;
+
+    private Node_259 mSet_17;
+
+    private Node_382 mSet_18;
+
+    private Node_276 mSet_19;
+
+    private Node_9 mSet_2;
+
+    private Node_357 mSet_20;
+
+    private Node_326 mSet_21;
+
+    private Node_94 mSet_22;
+
+    private Node_493 mSet_23;
+
+    private Node_321 mSet_24;
+
+    private Node_378 mSet_25;
+
+    private Node_369 mSet_26;
+
+    private Node_255 mSet_27;
+
+    private Node_516 mSet_28;
+
+    private Node_24 mSet_29;
+
+    private Node_277 mSet_3;
+
+    private Node_392 mSet_30;
+
+    private Node_452 mSet_31;
+
+    private Node_287 mSet_32;
+
+    private Node_110 mSet_33;
+
+    private Node_526 mSet_34;
+
+    private Node_525 mSet_35;
+
+    private Node_204 mSet_36;
+
+    private Node_129 mSet_37;
+
+    private Node_68 mSet_38;
+
+    private Node_400 mSet_39;
+
+    private Node_145 mSet_4;
+
+    private Node_237 mSet_40;
+
+    private Node_35 mSet_41;
+
+    private Node_272 mSet_42;
+
+    private Node_554 mSet_43;
+
+    private Node_39 mSet_44;
+
+    private Node_183 mSet_45;
+
+    private Node_523 mSet_46;
+
+    private Node_17 mSet_47;
+
+    private Node_294 mSet_48;
+
+    private Node_196 mSet_49;
+
+    private Node_522 mSet_5;
+
+    private Node_75 mSet_50;
+
+    private Node_117 mSet_51;
+
+    private Node_125 mSet_6;
+
+    private Node_486 mSet_7;
+
+    private Node_283 mSet_8;
+
+    private Node_335 mSet_9;
+
+    @Override
+    public Component_602.Creator setDep_0(Dependency_601 i) {
+      this.mSetDep_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_0(Node_88 i) {
+      this.mSet_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_1(Node_278 i) {
+      this.mSet_1 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_10(Node_545 i) {
+      this.mSet_10 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_11(Node_471 i) {
+      this.mSet_11 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_12(Node_170 i) {
+      this.mSet_12 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_13(Node_412 i) {
+      this.mSet_13 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_14(Node_52 i) {
+      this.mSet_14 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_15(Node_442 i) {
+      this.mSet_15 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_16(Node_370 i) {
+      this.mSet_16 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_17(Node_259 i) {
+      this.mSet_17 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_18(Node_382 i) {
+      this.mSet_18 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_19(Node_276 i) {
+      this.mSet_19 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_2(Node_9 i) {
+      this.mSet_2 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_20(Node_357 i) {
+      this.mSet_20 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_21(Node_326 i) {
+      this.mSet_21 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_22(Node_94 i) {
+      this.mSet_22 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_23(Node_493 i) {
+      this.mSet_23 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_24(Node_321 i) {
+      this.mSet_24 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_25(Node_378 i) {
+      this.mSet_25 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_26(Node_369 i) {
+      this.mSet_26 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_27(Node_255 i) {
+      this.mSet_27 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_28(Node_516 i) {
+      this.mSet_28 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_29(Node_24 i) {
+      this.mSet_29 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_3(Node_277 i) {
+      this.mSet_3 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_30(Node_392 i) {
+      this.mSet_30 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_31(Node_452 i) {
+      this.mSet_31 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_32(Node_287 i) {
+      this.mSet_32 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_33(Node_110 i) {
+      this.mSet_33 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_34(Node_526 i) {
+      this.mSet_34 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_35(Node_525 i) {
+      this.mSet_35 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_36(Node_204 i) {
+      this.mSet_36 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_37(Node_129 i) {
+      this.mSet_37 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_38(Node_68 i) {
+      this.mSet_38 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_39(Node_400 i) {
+      this.mSet_39 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_4(Node_145 i) {
+      this.mSet_4 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_40(Node_237 i) {
+      this.mSet_40 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_41(Node_35 i) {
+      this.mSet_41 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_42(Node_272 i) {
+      this.mSet_42 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_43(Node_554 i) {
+      this.mSet_43 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_44(Node_39 i) {
+      this.mSet_44 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_45(Node_183 i) {
+      this.mSet_45 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_46(Node_523 i) {
+      this.mSet_46 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_47(Node_17 i) {
+      this.mSet_47 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_48(Node_294 i) {
+      this.mSet_48 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_49(Node_196 i) {
+      this.mSet_49 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_5(Node_522 i) {
+      this.mSet_5 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_50(Node_75 i) {
+      this.mSet_50 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_51(Node_117 i) {
+      this.mSet_51 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_6(Node_125 i) {
+      this.mSet_6 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_7(Node_486 i) {
+      this.mSet_7 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_8(Node_283 i) {
+      this.mSet_8 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602.Creator set_9(Node_335 i) {
+      this.mSet_9 = i;
+      return this;
+    }
+
+    @Override
+    public Component_602 create() {
+      return new Yatagan$Component_602(this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_10, this.mSet_11, this.mSet_12, this.mSet_13, this.mSet_14, this.mSet_15, this.mSet_16, this.mSet_17, this.mSet_18, this.mSet_19, this.mSet_2, this.mSet_20, this.mSet_21, this.mSet_22, this.mSet_23, this.mSet_24, this.mSet_25, this.mSet_26, this.mSet_27, this.mSet_28, this.mSet_29, this.mSet_3, this.mSet_30, this.mSet_31, this.mSet_32, this.mSet_33, this.mSet_34, this.mSet_35, this.mSet_36, this.mSet_37, this.mSet_38, this.mSet_39, this.mSet_4, this.mSet_40, this.mSet_41, this.mSet_42, this.mSet_43, this.mSet_44, this.mSet_45, this.mSet_46, this.mSet_47, this.mSet_48, this.mSet_49, this.mSet_5, this.mSet_50, this.mSet_51, this.mSet_6, this.mSet_7, this.mSet_8, this.mSet_9);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$Component_603.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$Component_603 implements Component_603 {
+  private Object mNode_273Instance;
+
+  private Object mNode_440Instance;
+
+  private Object mNode_387Instance;
+
+  private Object mNode_22Instance;
+
+  private Object mNode_599Instance;
+
+  private Object mNode_121Instance;
+
+  private Object mNode_361Instance;
+
+  private Object mNode_119Instance;
+
+  private Object mNode_342Instance;
+
+  private Object mNode_363Instance;
+
+  private Object mNode_404Instance;
+
+  private Object mNode_152Instance;
+
+  private Object mNode_521Instance;
+
+  private Object mNode_520Instance;
+
+  private Object mNode_389Instance;
+
+  private Object mNode_388Instance;
+
+  private Object mNode_190Instance;
+
+  private Object mNode_25Instance;
+
+  private Object mNode_78Instance;
+
+  private Object mNode_303Instance;
+
+  private Object mNode_71Instance;
+
+  private Object mNode_569Instance;
+
+  private Object mNode_481Instance;
+
+  private Object mNode_568Instance;
+
+  private Object mNode_299Instance;
+
+  private Object mNode_591Instance;
+
+  private Object mNode_284Instance;
+
+  private Object mNode_502Instance;
+
+  private Object mNode_421Instance;
+
+  private Object mNode_436Instance;
+
+  private Object mNode_50Instance;
+
+  private Object mNode_474Instance;
+
+  private Object mNode_576Instance;
+
+  private Object mNode_413Instance;
+
+  private Object mNode_561Instance;
+
+  private Object mNode_494Instance;
+
+  private Object mNode_64Instance;
+
+  private Object mNode_194Instance;
+
+  private Object mNode_354Instance;
+
+  private Object mNode_535Instance;
+
+  private Object mNode_331Instance;
+
+  private Object mNode_310Instance;
+
+  private Object mNode_386Instance;
+
+  private Object mNode_456Instance;
+
+  private Object mNode_393Instance;
+
+  private Object mNode_215Instance;
+
+  private Object mNode_157Instance;
+
+  private Object mNode_429Instance;
+
+  private Object mNode_82Instance;
+
+  private Object mNode_238Instance;
+
+  private Object mNode_372Instance;
+
+  private Object mNode_360Instance;
+
+  private Object mNode_348Instance;
+
+  private Object mNode_192Instance;
+
+  private Object mNode_102Instance;
+
+  private Object mNode_341Instance;
+
+  private Object mNode_201Instance;
+
+  private Object mNode_524Instance;
+
+  private Object mNode_111Instance;
+
+  private Object mNode_84Instance;
+
+  private Object mNode_445Instance;
+
+  private Object mNode_333Instance;
+
+  private Object mNode_137Instance;
+
+  private Object mNode_114Instance;
+
+  private Object mNode_275Instance;
+
+  private Object mNode_207Instance;
+
+  private Object mNode_431Instance;
+
+  private Object mNode_40Instance;
+
+  private Object mNode_172Instance;
+
+  private Object mNode_543Instance;
+
+  private Object mNode_499Instance;
+
+  private Object mNode_171Instance;
+
+  private Object mNode_343Instance;
+
+  private Object mNode_193Instance;
+
+  private Object mNode_249Instance;
+
+  private Object mNode_351Instance;
+
+  private Object mNode_551Instance;
+
+  private Object mNode_566Instance;
+
+  private Object mNode_508Instance;
+
+  private Object mNode_364Instance;
+
+  private Object mNode_92Instance;
+
+  private Object mNode_2Instance;
+
+  private Object mNode_153Instance;
+
+  private Object mNode_44Instance;
+
+  private Object mNode_185Instance;
+
+  private Object mNode_307Instance;
+
+  private Object mNode_197Instance;
+
+  private Object mNode_422Instance;
+
+  private Object mNode_27Instance;
+
+  private Object mNode_261Instance;
+
+  private Object mNode_450Instance;
+
+  private Object mNode_376Instance;
+
+  private Object mNode_577Instance;
+
+  private Object mNode_420Instance;
+
+  private Object mNode_87Instance;
+
+  private Object mNode_167Instance;
+
+  private Object mNode_466Instance;
+
+  private Object mNode_150Instance;
+
+  private Object mNode_306Instance;
+
+  private Object mNode_531Instance;
+
+  private Object mNode_571Instance;
+
+  private Object mNode_282Instance;
+
+  private Object mNode_154Instance;
+
+  private Object mNode_104Instance;
+
+  private Object mNode_120Instance;
+
+  private Object mNode_123Instance;
+
+  private Object mNode_13Instance;
+
+  private Object mNode_131Instance;
+
+  private Object mNode_138Instance;
+
+  private Object mNode_141Instance;
+
+  private Object mNode_143Instance;
+
+  private Object mNode_147Instance;
+
+  private Object mNode_15Instance;
+
+  private Object mNode_151Instance;
+
+  private Object mNode_176Instance;
+
+  private Object mNode_198Instance;
+
+  private Object mNode_20Instance;
+
+  private Object mNode_202Instance;
+
+  private Object mNode_206Instance;
+
+  private Object mNode_212Instance;
+
+  private Object mNode_224Instance;
+
+  private Object mNode_226Instance;
+
+  private Object mNode_229Instance;
+
+  private Object mNode_230Instance;
+
+  private Object mNode_231Instance;
+
+  private Object mNode_234Instance;
+
+  private Object mNode_241Instance;
+
+  private Object mNode_243Instance;
+
+  private Object mNode_244Instance;
+
+  private Object mNode_250Instance;
+
+  private Object mNode_253Instance;
+
+  private Object mNode_260Instance;
+
+  private Object mNode_267Instance;
+
+  private Object mNode_271Instance;
+
+  private Object mNode_281Instance;
+
+  private Object mNode_285Instance;
+
+  private Object mNode_286Instance;
+
+  private Object mNode_31Instance;
+
+  private Object mNode_316Instance;
+
+  private Object mNode_318Instance;
+
+  private Object mNode_319Instance;
+
+  private Object mNode_322Instance;
+
+  private Object mNode_325Instance;
+
+  private Object mNode_328Instance;
+
+  private Object mNode_347Instance;
+
+  private Object mNode_349Instance;
+
+  private Object mNode_352Instance;
+
+  private Object mNode_353Instance;
+
+  private Object mNode_359Instance;
+
+  private Object mNode_366Instance;
+
+  private Object mNode_407Instance;
+
+  private Object mNode_415Instance;
+
+  private Object mNode_417Instance;
+
+  private Object mNode_426Instance;
+
+  private Object mNode_441Instance;
+
+  private Object mNode_457Instance;
+
+  private Object mNode_459Instance;
+
+  private Object mNode_468Instance;
+
+  private Object mNode_469Instance;
+
+  private Object mNode_479Instance;
+
+  private Object mNode_488Instance;
+
+  private Object mNode_49Instance;
+
+  private Object mNode_490Instance;
+
+  private Object mNode_498Instance;
+
+  private Object mNode_500Instance;
+
+  private Object mNode_506Instance;
+
+  private Object mNode_511Instance;
+
+  private Object mNode_513Instance;
+
+  private Object mNode_519Instance;
+
+  private Object mNode_527Instance;
+
+  private Object mNode_528Instance;
+
+  private Object mNode_53Instance;
+
+  private Object mNode_530Instance;
+
+  private Object mNode_537Instance;
+
+  private Object mNode_539Instance;
+
+  private Object mNode_547Instance;
+
+  private Object mNode_550Instance;
+
+  private Object mNode_556Instance;
+
+  private Object mNode_559Instance;
+
+  private Object mNode_560Instance;
+
+  private Object mNode_562Instance;
+
+  private Object mNode_565Instance;
+
+  private Object mNode_567Instance;
+
+  private Object mNode_570Instance;
+
+  private Object mNode_572Instance;
+
+  private Object mNode_578Instance;
+
+  private Object mNode_581Instance;
+
+  private Object mNode_584Instance;
+
+  private Object mNode_586Instance;
+
+  private Object mNode_588Instance;
+
+  private Object mNode_589Instance;
+
+  private Object mNode_593Instance;
+
+  private Object mNode_6Instance;
+
+  private Object mNode_67Instance;
+
+  private Object mNode_7Instance;
+
+  private Object mNode_72Instance;
+
+  private Object mNode_77Instance;
+
+  private Object mNode_79Instance;
+
+  private Object mNode_81Instance;
+
+  private Object mNode_98Instance;
+
+  private Object mNode_99Instance;
+
+  final Node_183 mSet_0;
+
+  final Node_272 mSet_1;
+
+  final Node_237 mSet_10;
+
+  final Node_545 mSet_11;
+
+  final Node_471 mSet_12;
+
+  final Node_357 mSet_13;
+
+  final Node_9 mSet_14;
+
+  final Node_287 mSet_15;
+
+  final Node_255 mSet_16;
+
+  final Node_94 mSet_17;
+
+  final Node_516 mSet_18;
+
+  final Node_369 mSet_19;
+
+  final Node_125 mSet_2;
+
+  final Node_321 mSet_20;
+
+  final Node_75 mSet_21;
+
+  final Node_88 mSet_22;
+
+  final Node_412 mSet_23;
+
+  final Node_400 mSet_24;
+
+  final Node_283 mSet_25;
+
+  final Node_276 mSet_26;
+
+  final Node_525 mSet_27;
+
+  final Node_493 mSet_28;
+
+  final Node_110 mSet_29;
+
+  final Node_326 mSet_3;
+
+  final Node_526 mSet_30;
+
+  final Node_52 mSet_31;
+
+  final Node_294 mSet_32;
+
+  final Node_452 mSet_33;
+
+  final Node_17 mSet_34;
+
+  final Node_382 mSet_35;
+
+  final Node_378 mSet_36;
+
+  final Node_277 mSet_37;
+
+  final Node_554 mSet_38;
+
+  final Node_196 mSet_39;
+
+  final Node_442 mSet_4;
+
+  final Node_522 mSet_40;
+
+  final Node_35 mSet_41;
+
+  final Node_204 mSet_42;
+
+  final Node_259 mSet_43;
+
+  final Node_392 mSet_44;
+
+  final Node_39 mSet_45;
+
+  final Node_486 mSet_46;
+
+  final Node_68 mSet_47;
+
+  final Node_145 mSet_48;
+
+  final Node_370 mSet_49;
+
+  final Node_335 mSet_5;
+
+  final Node_117 mSet_50;
+
+  final Node_278 mSet_51;
+
+  final Node_24 mSet_6;
+
+  final Node_129 mSet_7;
+
+  final Node_170 mSet_8;
+
+  final Node_523 mSet_9;
+
+  final Dependency_601 mDependency_601;
+
+  Yatagan$Component_603(Dependency_601 pSetDep_0, Node_183 pSet_0, Node_272 pSet_1,
+      Node_237 pSet_10, Node_545 pSet_11, Node_471 pSet_12, Node_357 pSet_13, Node_9 pSet_14,
+      Node_287 pSet_15, Node_255 pSet_16, Node_94 pSet_17, Node_516 pSet_18, Node_369 pSet_19,
+      Node_125 pSet_2, Node_321 pSet_20, Node_75 pSet_21, Node_88 pSet_22, Node_412 pSet_23,
+      Node_400 pSet_24, Node_283 pSet_25, Node_276 pSet_26, Node_525 pSet_27, Node_493 pSet_28,
+      Node_110 pSet_29, Node_326 pSet_3, Node_526 pSet_30, Node_52 pSet_31, Node_294 pSet_32,
+      Node_452 pSet_33, Node_17 pSet_34, Node_382 pSet_35, Node_378 pSet_36, Node_277 pSet_37,
+      Node_554 pSet_38, Node_196 pSet_39, Node_442 pSet_4, Node_522 pSet_40, Node_35 pSet_41,
+      Node_204 pSet_42, Node_259 pSet_43, Node_392 pSet_44, Node_39 pSet_45, Node_486 pSet_46,
+      Node_68 pSet_47, Node_145 pSet_48, Node_370 pSet_49, Node_335 pSet_5, Node_117 pSet_50,
+      Node_278 pSet_51, Node_24 pSet_6, Node_129 pSet_7, Node_170 pSet_8, Node_523 pSet_9) {
+    this.mDependency_601 = Checks.checkInputNotNull(pSetDep_0);
+    this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+    this.mSet_10 = Checks.checkInputNotNull(pSet_10);
+    this.mSet_11 = Checks.checkInputNotNull(pSet_11);
+    this.mSet_12 = Checks.checkInputNotNull(pSet_12);
+    this.mSet_13 = Checks.checkInputNotNull(pSet_13);
+    this.mSet_14 = Checks.checkInputNotNull(pSet_14);
+    this.mSet_15 = Checks.checkInputNotNull(pSet_15);
+    this.mSet_16 = Checks.checkInputNotNull(pSet_16);
+    this.mSet_17 = Checks.checkInputNotNull(pSet_17);
+    this.mSet_18 = Checks.checkInputNotNull(pSet_18);
+    this.mSet_19 = Checks.checkInputNotNull(pSet_19);
+    this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+    this.mSet_20 = Checks.checkInputNotNull(pSet_20);
+    this.mSet_21 = Checks.checkInputNotNull(pSet_21);
+    this.mSet_22 = Checks.checkInputNotNull(pSet_22);
+    this.mSet_23 = Checks.checkInputNotNull(pSet_23);
+    this.mSet_24 = Checks.checkInputNotNull(pSet_24);
+    this.mSet_25 = Checks.checkInputNotNull(pSet_25);
+    this.mSet_26 = Checks.checkInputNotNull(pSet_26);
+    this.mSet_27 = Checks.checkInputNotNull(pSet_27);
+    this.mSet_28 = Checks.checkInputNotNull(pSet_28);
+    this.mSet_29 = Checks.checkInputNotNull(pSet_29);
+    this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+    this.mSet_30 = Checks.checkInputNotNull(pSet_30);
+    this.mSet_31 = Checks.checkInputNotNull(pSet_31);
+    this.mSet_32 = Checks.checkInputNotNull(pSet_32);
+    this.mSet_33 = Checks.checkInputNotNull(pSet_33);
+    this.mSet_34 = Checks.checkInputNotNull(pSet_34);
+    this.mSet_35 = Checks.checkInputNotNull(pSet_35);
+    this.mSet_36 = Checks.checkInputNotNull(pSet_36);
+    this.mSet_37 = Checks.checkInputNotNull(pSet_37);
+    this.mSet_38 = Checks.checkInputNotNull(pSet_38);
+    this.mSet_39 = Checks.checkInputNotNull(pSet_39);
+    this.mSet_4 = Checks.checkInputNotNull(pSet_4);
+    this.mSet_40 = Checks.checkInputNotNull(pSet_40);
+    this.mSet_41 = Checks.checkInputNotNull(pSet_41);
+    this.mSet_42 = Checks.checkInputNotNull(pSet_42);
+    this.mSet_43 = Checks.checkInputNotNull(pSet_43);
+    this.mSet_44 = Checks.checkInputNotNull(pSet_44);
+    this.mSet_45 = Checks.checkInputNotNull(pSet_45);
+    this.mSet_46 = Checks.checkInputNotNull(pSet_46);
+    this.mSet_47 = Checks.checkInputNotNull(pSet_47);
+    this.mSet_48 = Checks.checkInputNotNull(pSet_48);
+    this.mSet_49 = Checks.checkInputNotNull(pSet_49);
+    this.mSet_5 = Checks.checkInputNotNull(pSet_5);
+    this.mSet_50 = Checks.checkInputNotNull(pSet_50);
+    this.mSet_51 = Checks.checkInputNotNull(pSet_51);
+    this.mSet_6 = Checks.checkInputNotNull(pSet_6);
+    this.mSet_7 = Checks.checkInputNotNull(pSet_7);
+    this.mSet_8 = Checks.checkInputNotNull(pSet_8);
+    this.mSet_9 = Checks.checkInputNotNull(pSet_9);
+  }
+
+  @Override
+  public Provider<Node_288> getGet_0() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Node_113 getGet_1() {
+    return this.accessNode_113();
+  }
+
+  @Override
+  public Provider<Node_479> getGet_10() {
+    return new ProviderImpl(this, 9);
+  }
+
+  @Override
+  public Node_207 getGet_11() {
+    return this.cacheNode_207();
+  }
+
+  @Override
+  public Node_600 getGet_12() {
+    return this.accessNode_600();
+  }
+
+  @Override
+  public Node_431 getGet_13() {
+    return this.cacheNode_431();
+  }
+
+  @Override
+  public Node_36 getGet_14() {
+    return this.cacheNode_104();
+  }
+
+  @Override
+  public Node_570 getGet_15() {
+    return this.cacheNode_570();
+  }
+
+  @Override
+  public Node_533 getGet_16() {
+    return this.accessNode_533();
+  }
+
+  @Override
+  public Node_164 getGet_17() {
+    return this.accessNode_164();
+  }
+
+  @Override
+  public Node_588 getGet_18() {
+    return this.cacheNode_588();
+  }
+
+  @Override
+  public Provider<Node_40> getGet_19() {
+    return new ProviderImpl(this, 18);
+  }
+
+  @Override
+  public Lazy<Node_480> getGet_2() {
+    return new CachingProviderImpl(this, 2);
+  }
+
+  @Override
+  public Node_578 getGet_20() {
+    return this.cacheNode_578();
+  }
+
+  @Override
+  public Node_320 getGet_21() {
+    return this.accessNode_320();
+  }
+
+  @Override
+  public Node_286 getGet_22() {
+    return this.cacheNode_286();
+  }
+
+  @Override
+  public Node_213 getGet_23() {
+    return this.accessNode_213();
+  }
+
+  @Override
+  public Lazy<Node_122> getGet_24() {
+    return new CachingProviderImpl(this, 23);
+  }
+
+  @Override
+  public Node_99 getGet_25() {
+    return this.cacheNode_99();
+  }
+
+  @Override
+  public Node_478 getGet_26() {
+    return this.mDependency_601.ep_43();
+  }
+
+  @Override
+  public Node_366 getGet_27() {
+    return this.cacheNode_366();
+  }
+
+  @Override
+  public Provider<Node_290> getGet_28() {
+    return new ProviderImpl(this, 27);
+  }
+
+  @Override
+  public Node_172 getGet_29() {
+    return this.cacheNode_172();
+  }
+
+  @Override
+  public Node_430 getGet_3() {
+    return this.accessNode_430();
+  }
+
+  @Override
+  public Node_291 getGet_30() {
+    return this.mDependency_601.ep_27();
+  }
+
+  @Override
+  public Provider<Node_543> getGet_31() {
+    return new ProviderImpl(this, 29);
+  }
+
+  @Override
+  public Node_398 getGet_32() {
+    return this.cacheNode_527();
+  }
+
+  @Override
+  public Node_501 getGet_33() {
+    return this.accessNode_501();
+  }
+
+  @Override
+  public Provider<Node_223> getGet_34() {
+    return new ProviderImpl(this, 32);
+  }
+
+  @Override
+  public Node_499 getGet_35() {
+    return this.cacheNode_499();
+  }
+
+  @Override
+  public Node_171 getGet_36() {
+    return this.cacheNode_171();
+  }
+
+  @Override
+  public Node_343 getGet_37() {
+    return this.cacheNode_343();
+  }
+
+  @Override
+  public Node_473 getGet_38() {
+    return this.accessNode_473();
+  }
+
+  @Override
+  public Node_115 getGet_39() {
+    return this.accessNode_115();
+  }
+
+  @Override
+  public Node_497 getGet_4() {
+    return this.accessNode_497();
+  }
+
+  @Override
+  public Node_251 getGet_40() {
+    return this.mSet_32;
+  }
+
+  @Override
+  public Node_182 getGet_41() {
+    return this.accessNode_182();
+  }
+
+  @Override
+  public Node_193 getGet_42() {
+    return this.cacheNode_193();
+  }
+
+  @Override
+  public Node_249 getGet_43() {
+    return this.cacheNode_249();
+  }
+
+  @Override
+  public Node_256 getGet_44() {
+    return this.accessNode_534();
+  }
+
+  @Override
+  public Provider<Node_210> getGet_45() {
+    return new ProviderImpl(this, 43);
+  }
+
+  @Override
+  public Node_21 getGet_46() {
+    return this.accessNode_21();
+  }
+
+  @Override
+  public Node_415 getGet_47() {
+    return this.cacheNode_415();
+  }
+
+  @Override
+  public Node_572 getGet_48() {
+    return this.cacheNode_572();
+  }
+
+  @Override
+  public Lazy<Node_546> getGet_49() {
+    return new CachingProviderImpl(this, 47);
+  }
+
+  @Override
+  public Node_63 getGet_5() {
+    return this.accessNode_63();
+  }
+
+  @Override
+  public Provider<Node_209> getGet_6() {
+    return new ProviderImpl(this, 5);
+  }
+
+  @Override
+  public Node_275 getGet_7() {
+    return this.cacheNode_275();
+  }
+
+  @Override
+  public Provider<Node_106> getGet_8() {
+    return new ProviderImpl(this, 7);
+  }
+
+  @Override
+  public Lazy<Node_274> getGet_9() {
+    return new CachingProviderImpl(this, 8);
+  }
+
+  @Override
+  public void inject_0(Injectee_607 i) {
+    i.setMember_0(this.cacheNode_99());
+  }
+
+  private Object switch$$access$0(int slot) {
+    switch(slot) {
+      case 0: return this.accessNode_288();
+      case 1: return this.accessNode_113();
+      case 2: return this.accessNode_480();
+      case 3: return this.accessNode_497();
+      case 4: return this.accessNode_63();
+      case 5: return this.accessNode_209();
+      case 6: return this.cacheNode_275();
+      case 7: return this.accessNode_106();
+      case 8: return this.accessNode_274();
+      case 9: return this.cacheNode_479();
+      case 10: return this.cacheNode_207();
+      case 11: return this.accessNode_600();
+      case 12: return this.cacheNode_431();
+      case 13: return this.cacheNode_104();
+      case 14: return this.cacheNode_570();
+      case 15: return this.accessNode_533();
+      case 16: return this.accessNode_164();
+      case 17: return this.cacheNode_588();
+      case 18: return this.cacheNode_40();
+      case 19: return this.cacheNode_578();
+      case 20: return this.accessNode_320();
+      case 21: return this.cacheNode_286();
+      case 22: return this.accessNode_213();
+      case 23: return this.accessNode_122();
+      case 24: return this.cacheNode_99();
+      case 25: return this.mDependency_601.ep_43();
+      case 26: return this.cacheNode_366();
+      case 27: return this.accessNode_290();
+      case 28: return this.cacheNode_172();
+      case 29: return this.cacheNode_543();
+      case 30: return this.cacheNode_527();
+      case 31: return this.accessNode_501();
+      case 32: return this.accessNode_223();
+      case 33: return this.cacheNode_499();
+      case 34: return this.cacheNode_171();
+      case 35: return this.cacheNode_343();
+      case 36: return this.accessNode_473();
+      case 37: return this.accessNode_115();
+      case 38: return this.mSet_32;
+      case 39: return this.accessNode_182();
+      case 40: return this.cacheNode_193();
+      case 41: return this.cacheNode_249();
+      case 42: return this.accessNode_534();
+      case 43: return this.accessNode_160();
+      case 44: return this.accessNode_21();
+      case 45: return this.cacheNode_415();
+      case 46: return this.cacheNode_572();
+      case 47: return this.mDependency_601.ep_48();
+      case 48: return this.mSet_0;
+      case 49: return this.accessNode_146();
+      case 50: return this.cacheNode_351();
+      case 51: return this.cacheNode_212();
+      case 52: return this.accessNode_483();
+      case 53: return this.mSet_1;
+      case 54: return this.accessNode_179();
+      case 55: return this.cacheNode_551();
+      case 56: return this.mDependency_601.ep_39();
+      case 57: return this.accessNode_390();
+      case 58: return this.accessNode_358();
+      case 59: return this.cacheNode_566();
+      case 60: return this.accessNode_135();
+      case 61: return this.cacheNode_234();
+      case 62: return this.accessNode_317();
+      case 63: return this.cacheNode_561();
+      case 64: return this.accessNode_162();
+      case 65: return this.accessNode_487();
+      case 66: return this.mDependency_601.ep_42();
+      case 67: return this.accessNode_26();
+      case 68: return this.cacheNode_508();
+      case 69: return this.accessNode_597();
+      case 70: return this.accessNode_332();
+      case 71: return this.accessNode_222();
+      case 72: return this.cacheNode_364();
+      case 73: return this.accessNode_184();
+      case 74: return this.cacheNode_53();
+      case 75: return this.mSet_3;
+      case 76: return this.cacheNode_224();
+      case 77: return Checks.checkProvisionNotNull(Module_609.Companion.provides_949());
+      case 78: return this.cacheNode_500();
+      case 79: return this.mDependency_601.ep_13();
+      case 80: return this.cacheNode_244();
+      case 81: return this.cacheNode_322();
+      case 82: return this.cacheNode_92();
+      case 83: return this.cacheNode_2();
+      case 84: return this.mDependency_601.ep_23();
+      case 85: return this.mSet_4;
+      case 86: return this.cacheNode_153();
+      case 87: return this.accessNode_42();
+      case 88: return this.mSet_5;
+      case 89: return this.mDependency_601.ep_8();
+      case 90: return this.cacheNode_44();
+      case 91: return this.cacheNode_185();
+      case 92: return this.accessNode_596();
+      case 93: return this.accessNode_510();
+      case 94: return this.accessNode_225();
+      case 95: return this.accessNode_461();
+      case 96: return this.mSet_6;
+      case 97: return this.accessNode_330();
+      case 98: return this.accessNode_186();
+      case 99: return this.cacheNode_307();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$1(int slot) {
+    switch(slot) {
+      case 0: return this.cacheNode_230();
+      case 1: return this.cacheNode_197();
+      case 2: return Checks.checkProvisionNotNull(Module_609.Companion.provides_960());
+      case 3: return this.accessNode_564();
+      case 4: return this.accessNode_268();
+      case 5: return this.cacheNode_422();
+      case 6: return this.accessNode_381();
+      case 7: return this.mSet_7;
+      case 8: return this.accessNode_391();
+      case 9: return this.cacheNode_513();
+      case 10: return this.cacheNode_27();
+      case 11: return this.cacheNode_581();
+      case 12: return this.mDependency_601.ep_24();
+      case 13: return this.accessNode_93();
+      case 14: return this.accessNode_199();
+      case 15: return this.cacheNode_261();
+      case 16: return this.cacheNode_450();
+      case 17: return this.cacheNode_7();
+      case 18: return this.accessNode_518();
+      case 19: return this.accessNode_482();
+      case 20: return this.accessNode_379();
+      case 21: return this.accessNode_377();
+      case 22: return this.mSet_10;
+      case 23: return this.cacheNode_243();
+      case 24: return this.accessNode_514();
+      case 25: return this.cacheNode_120();
+      case 26: return this.mSet_8;
+      case 27: return this.mDependency_601.ep_21();
+      case 28: return this.cacheNode_141();
+      case 29: return this.accessNode_590();
+      case 30: return this.mSet_9;
+      case 31: return this.cacheNode_359();
+      case 32: return this.cacheNode_241();
+      case 33: return this.cacheNode_577();
+      case 34: return this.cacheNode_420();
+      case 35: return this.accessNode_585();
+      case 36: return this.cacheNode_87();
+      case 37: return this.cacheNode_167();
+      case 38: return this.cacheNode_466();
+      case 39: return this.cacheNode_285();
+      case 40: return this.mDependency_601.ep_28();
+      case 41: return Checks.checkProvisionNotNull(Module_609.Companion.provides_975());
+      case 42: return this.accessNode_507();
+      case 43: return this.accessNode_89();
+      case 44: return this.cacheNode_150();
+      case 45: return this.accessNode_314();
+      case 46: return this.accessNode_427();
+      case 47: return this.accessNode_74();
+      case 48: return this.cacheNode_318();
+      case 49: return this.mDependency_601.ep_54();
+      case 50: return this.cacheNode_441();
+      case 51: return this.accessNode_515();
+      case 52: return this.cacheNode_306();
+      case 53: return this.mDependency_601.ep_3();
+      case 54: return this.accessNode_139();
+      case 55: return this.mDependency_601.ep_0();
+      case 56: return this.accessNode_23();
+      case 57: return this.cacheNode_547();
+      case 58: return this.accessNode_340();
+      case 59: return this.accessNode_552();
+      case 60: return this.accessNode_301();
+      case 61: return this.cacheNode_328();
+      case 62: return this.accessNode_449();
+      case 63: return this.accessNode_458();
+      case 64: return this.accessNode_339();
+      case 65: return this.mSet_11;
+      case 66: return this.accessNode_175();
+      case 67: return this.mDependency_601.ep_36();
+      case 68: return this.accessNode_248();
+      case 69: return this.accessNode_166();
+      case 70: return this.accessNode_263();
+      case 71: return this.accessNode_425();
+      case 72: return this.mSet_12;
+      case 73: return this.accessNode_128();
+      case 74: return this.mSet_13;
+      case 75: return this.accessNode_464();
+      case 76: return this.accessNode_399();
+      case 77: return this.accessNode_178();
+      case 78: return this.accessNode_304();
+      case 79: return Checks.checkProvisionNotNull(Module_609.Companion.provides_986());
+      case 80: return this.accessNode_309();
+      case 81: return this.cacheNode_84();
+      case 82: return this.mSet_14;
+      case 83: return this.accessNode_595();
+      case 84: return this.accessNode_45();
+      case 85: return this.accessNode_48();
+      case 86: return this.accessNode_453();
+      case 87: return this.cacheNode_349();
+      case 88: return this.accessNode_16();
+      case 89: return this.mDependency_601.ep_14();
+      case 90: return this.accessNode_492();
+      case 91: return this.accessNode_46();
+      case 92: return this.accessNode_8();
+      case 93: return this.cacheNode_531();
+      case 94: return this.cacheNode_562();
+      case 95: return this.cacheNode_250();
+      case 96: return this.accessNode_495();
+      case 97: return this.cacheNode_49();
+      case 98: return this.mDependency_601.ep_51();
+      case 99: return this.cacheNode_353();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$2(int slot) {
+    switch(slot) {
+      case 0: return this.accessNode_375();
+      case 1: return this.cacheNode_571();
+      case 2: return this.cacheNode_176();
+      case 3: return this.accessNode_337();
+      case 4: return this.cacheNode_260();
+      case 5: return this.cacheNode_426();
+      case 6: return this.mDependency_601.ep_12();
+      case 7: return this.mDependency_601.ep_44();
+      case 8: return this.mSet_15;
+      case 9: return this.cacheNode_282();
+      case 10: return this.accessNode_338();
+      case 11: return this.cacheNode_154();
+      case 12: return this.mSet_16;
+      case 13: return this.accessNode_574();
+      case 14: return this.mSet_17;
+      case 15: return this.accessNode_344();
+      case 16: return Checks.checkProvisionNotNull(Module_609.Companion.provides_997());
+      case 17: return this.accessNode_362();
+      case 18: return this.accessNode_409();
+      case 19: return this.cacheNode_530();
+      case 20: return this.accessNode_548();
+      case 21: return this.accessNode_434();
+      case 22: return this.mDependency_601.ep_53();
+      case 23: return this.cacheNode_520();
+      case 24: return this.cacheNode_468();
+      case 25: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1096());
+      case 26: return this.cacheNode_429();
+      case 27: return this.accessNode_133();
+      case 28: return this.mSet_23;
+      case 29: return this.accessNode_350();
+      case 30: return this.accessNode_180();
+      case 31: return this.accessNode_43();
+      case 32: return this.mDependency_601.ep_57();
+      case 33: return this.accessNode_118();
+      case 34: return this.accessNode_37();
+      case 35: return this.accessNode_336();
+      case 36: return this.cacheNode_273();
+      case 37: return this.cacheNode_15();
+      case 38: return this.cacheNode_440();
+      case 39: return this.mDependency_601.ep_33();
+      case 40: return this.mSet_18;
+      case 41: return this.mDependency_601.ep_1();
+      case 42: return this.accessNode_5();
+      case 43: return this.cacheNode_267();
+      case 44: return this.mDependency_601.ep_6();
+      case 45: return this.cacheNode_387();
+      case 46: return this.mSet_19;
+      case 47: return this.cacheNode_506();
+      case 48: return this.accessNode_385();
+      case 49: return this.cacheNode_22();
+      case 50: return this.mDependency_601.ep_20();
+      case 51: return this.cacheNode_599();
+      case 52: return this.cacheNode_121();
+      case 53: return this.accessNode_300();
+      case 54: return this.cacheNode_79();
+      case 55: return this.cacheNode_72();
+      case 56: return this.accessNode_410();
+      case 57: return this.cacheNode_361();
+      case 58: return this.accessNode_289();
+      case 59: return this.cacheNode_490();
+      case 60: return this.mSet_20;
+      case 61: return this.cacheNode_81();
+      case 62: return this.cacheNode_119();
+      case 63: return this.mSet_21;
+      case 64: return this.cacheNode_342();
+      case 65: return this.cacheNode_565();
+      case 66: return this.cacheNode_363();
+      case 67: return this.accessNode_54();
+      case 68: return this.accessNode_475();
+      case 69: return this.cacheNode_271();
+      case 70: return this.cacheNode_404();
+      case 71: return this.cacheNode_152();
+      case 72: return this.cacheNode_143();
+      case 73: return this.mSet_22;
+      case 74: return this.mDependency_601.ep_34();
+      case 75: return this.cacheNode_417();
+      case 76: return this.cacheNode_521();
+      case 77: return new Node_181();
+      case 78: return this.accessNode_127();
+      case 79: return this.accessNode_298();
+      case 80: return this.accessNode_18();
+      case 81: return this.accessNode_395();
+      case 82: return this.accessNode_240();
+      case 83: return this.accessNode_156();
+      case 84: return this.accessNode_439();
+      case 85: return this.accessNode_61();
+      case 86: return this.accessNode_329();
+      case 87: return this.cacheNode_13();
+      case 88: return this.cacheNode_20();
+      case 89: return this.mSet_24;
+      case 90: return this.mDependency_601.ep_40();
+      case 91: return this.cacheNode_550();
+      case 92: return this.accessNode_60();
+      case 93: return this.cacheNode_539();
+      case 94: return this.accessNode_460();
+      case 95: return this.accessNode_96();
+      case 96: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1027());
+      case 97: return this.cacheNode_389();
+      case 98: return this.cacheNode_281();
+      case 99: return this.cacheNode_388();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$3(int slot) {
+    switch(slot) {
+      case 0: return this.accessNode_311();
+      case 1: return this.cacheNode_190();
+      case 2: return this.mDependency_601.ep_2();
+      case 3: return this.cacheNode_25();
+      case 4: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1033());
+      case 5: return this.cacheNode_78();
+      case 6: return this.accessNode_367();
+      case 7: return this.accessNode_165();
+      case 8: return this.cacheNode_6();
+      case 9: return this.cacheNode_511();
+      case 10: return this.cacheNode_303();
+      case 11: return this.cacheNode_71();
+      case 12: return this.cacheNode_488();
+      case 13: return this.mSet_25;
+      case 14: return this.cacheNode_569();
+      case 15: return this.accessNode_447();
+      case 16: return this.accessNode_416();
+      case 17: return this.accessNode_56();
+      case 18: return this.accessNode_12();
+      case 19: return this.cacheNode_481();
+      case 20: return this.cacheNode_568();
+      case 21: return this.accessNode_142();
+      case 22: return this.accessNode_97();
+      case 23: return this.cacheNode_299();
+      case 24: return this.cacheNode_31();
+      case 25: return this.cacheNode_457();
+      case 26: return this.cacheNode_591();
+      case 27: return this.accessNode_438();
+      case 28: return this.accessNode_136();
+      case 29: return this.cacheNode_77();
+      case 30: return this.cacheNode_556();
+      case 31: return this.accessNode_233();
+      case 32: return this.cacheNode_524();
+      case 33: return this.mSet_38;
+      case 34: return this.cacheNode_50();
+      case 35: return this.accessNode_126();
+      case 36: return this.accessNode_66();
+      case 37: return this.cacheNode_372();
+      case 38: return this.mSet_42;
+      case 39: return this.accessNode_529();
+      case 40: return this.mSet_39;
+      case 41: return this.mSet_48;
+      case 42: return this.cacheNode_215();
+      case 43: return this.cacheNode_333();
+      case 44: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1046());
+      case 45: return this.mSet_26;
+      case 46: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1047());
+      case 47: return this.accessNode_163();
+      case 48: return this.accessNode_296();
+      case 49: return this.accessNode_541();
+      case 50: return this.mDependency_601.ep_11();
+      case 51: return this.accessNode_148();
+      case 52: return this.cacheNode_284();
+      case 53: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1049());
+      case 54: return this.accessNode_232();
+      case 55: return this.mSet_27;
+      case 56: return this.mDependency_601.ep_35();
+      case 57: return this.cacheNode_502();
+      case 58: return this.mSet_28;
+      case 59: return this.mDependency_601.ep_47();
+      case 60: return this.accessNode_405();
+      case 61: return this.cacheNode_421();
+      case 62: return this.mDependency_601.ep_15();
+      case 63: return this.accessNode_116();
+      case 64: return this.mSet_29;
+      case 65: return this.mSet_46;
+      case 66: return this.accessNode_134();
+      case 67: return this.accessNode_85();
+      case 68: return this.accessNode_105();
+      case 69: return this.cacheNode_131();
+      case 70: return this.mDependency_601.ep_17();
+      case 71: return this.accessNode_239();
+      case 72: return this.accessNode_582();
+      case 73: return this.cacheNode_593();
+      case 74: return this.cacheNode_436();
+      case 75: return this.mSet_30;
+      case 76: return this.accessNode_580();
+      case 77: return this.mSet_31;
+      case 78: return this.mDependency_601.ep_25();
+      case 79: return this.mDependency_601.ep_22();
+      case 80: return this.accessNode_107();
+      case 81: return this.cacheNode_474();
+      case 82: return this.accessNode_103();
+      case 83: return this.mDependency_601.ep_18();
+      case 84: return this.mSet_33;
+      case 85: return this.accessNode_575();
+      case 86: return this.accessNode_313();
+      case 87: return this.mSet_45;
+      case 88: return this.mDependency_601.ep_55();
+      case 89: return this.cacheNode_535();
+      case 90: return this.accessNode_463();
+      case 91: return this.mDependency_601.ep_38();
+      case 92: return this.cacheNode_231();
+      case 93: return this.cacheNode_325();
+      case 94: return this.mDependency_601.ep_45();
+      case 95: return this.cacheNode_198();
+      case 96: return this.accessNode_33();
+      case 97: return this.accessNode_553();
+      case 98: return this.accessNode_446();
+      case 99: return this.cacheNode_576();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$4(int slot) {
+    switch(slot) {
+      case 0: return this.accessNode_132();
+      case 1: return this.mDependency_601.ep_26();
+      case 2: return this.accessNode_592();
+      case 3: return this.accessNode_58();
+      case 4: return this.mDependency_601.ep_16();
+      case 5: return this.accessNode_155();
+      case 6: return this.cacheNode_559();
+      case 7: return this.accessNode_485();
+      case 8: return this.accessNode_356();
+      case 9: return this.accessNode_454();
+      case 10: return this.cacheNode_347();
+      case 11: return Checks.checkProvisionNotNull(Module_609.Companion.provides_1075());
+      case 12: return this.accessNode_149();
+      case 13: return this.accessNode_214();
+      case 14: return this.cacheNode_589();
+      case 15: return this.mDependency_601.ep_30();
+      case 16: return this.mDependency_601.ep_10();
+      case 17: return this.accessNode_100();
+      case 18: return this.cacheNode_494();
+      case 19: return this.cacheNode_64();
+      case 20: return this.cacheNode_528();
+      case 21: return this.accessNode_504();
+      case 22: return this.accessNode_432();
+      case 23: return this.accessNode_443();
+      case 24: return this.accessNode_265();
+      case 25: return this.cacheNode_137();
+      case 26: return this.cacheNode_352();
+      case 27: return this.accessNode_29();
+      case 28: return this.accessNode_264();
+      case 29: return this.cacheNode_194();
+      case 30: return this.accessNode_4();
+      case 31: return this.cacheNode_354();
+      case 32: return this.accessNode_235();
+      case 33: return this.cacheNode_560();
+      case 34: return this.accessNode_394();
+      case 35: return this.mSet_35;
+      case 36: return this.accessNode_598();
+      case 37: return this.cacheNode_407();
+      case 38: return this.cacheNode_567();
+      case 39: return this.accessNode_477();
+      case 40: return this.cacheNode_331();
+      case 41: return this.cacheNode_310();
+      case 42: return this.accessNode_219();
+      case 43: return this.cacheNode_386();
+      case 44: return this.cacheNode_459();
+      case 45: return this.mSet_36;
+      case 46: return this.cacheNode_456();
+      case 47: return this.cacheNode_316();
+      case 48: return this.mDependency_601.ep_52();
+      case 49: return this.cacheNode_469();
+      case 50: return this.cacheNode_98();
+      case 51: return this.accessNode_418();
+      case 52: return this.cacheNode_123();
+      case 53: return this.cacheNode_393();
+      case 54: return this.accessNode_189();
+      case 55: return this.accessNode_324();
+      case 56: return this.accessNode_365();
+      case 57: return this.accessNode_496();
+      case 58: return this.mDependency_601.ep_4();
+      case 59: return this.accessNode_397();
+      case 60: return this.cacheNode_157();
+      case 61: return this.accessNode_312();
+      case 62: return this.accessNode_11();
+      case 63: return this.accessNode_101();
+      case 64: return this.accessNode_414();
+      case 65: return this.accessNode_269();
+      case 66: return this.accessNode_401();
+      case 67: return this.accessNode_168();
+      case 68: return this.mSet_40;
+      case 69: return this.cacheNode_226();
+      case 70: return this.accessNode_396();
+      case 71: return this.cacheNode_586();
+      case 72: return this.cacheNode_82();
+      case 73: return this.accessNode_384();
+      case 74: return this.accessNode_109();
+      case 75: return this.accessNode_280();
+      case 76: return this.mSet_41;
+      case 77: return this.cacheNode_206();
+      case 78: return this.accessNode_86();
+      case 79: return this.cacheNode_238();
+      case 80: return this.accessNode_517();
+      case 81: return this.accessNode_293();
+      case 82: return this.cacheNode_202();
+      case 83: return this.cacheNode_360();
+      case 84: return this.mDependency_601.ep_9();
+      case 85: return this.cacheNode_348();
+      case 86: return this.cacheNode_192();
+      case 87: return this.cacheNode_102();
+      case 88: return this.cacheNode_341();
+      case 89: return this.cacheNode_201();
+      case 90: return this.accessNode_424();
+      case 91: return this.mDependency_601.ep_31();
+      case 92: return this.mSet_43;
+      case 93: return this.mDependency_601.ep_29();
+      case 94: return this.mSet_44;
+      case 95: return this.accessNode_140();
+      case 96: return this.mDependency_601.ep_41();
+      case 97: return this.accessNode_191();
+      case 98: return this.accessNode_28();
+      case 99: return this.accessNode_374();
+      default: throw new AssertionError();
+    }
+  }
+
+  private Object switch$$access$5(int slot) {
+    switch(slot) {
+      case 0: return this.accessNode_573();
+      case 1: return this.cacheNode_498();
+      case 2: return this.accessNode_558();
+      case 3: return this.accessNode_470();
+      case 4: return this.mSet_47;
+      case 5: return this.accessNode_455();
+      case 6: return this.mDependency_601.ep_32();
+      case 7: return this.accessNode_555();
+      case 8: return this.cacheNode_111();
+      case 9: return this.accessNode_242();
+      case 10: return this.mDependency_601.ep_49();
+      case 11: return this.accessNode_211();
+      case 12: return this.cacheNode_253();
+      case 13: return this.accessNode_257();
+      case 14: return this.cacheNode_445();
+      case 15: return this.cacheNode_138();
+      case 16: return this.mDependency_601.ep_37();
+      case 17: return this.cacheNode_319();
+      case 18: return this.mSet_50;
+      case 19: return this.cacheNode_229();
+      case 20: return this.cacheNode_537();
+      case 21: return this.accessNode_536();
+      case 22: return this.accessNode_334();
+      case 23: return this.accessNode_80();
+      case 24: return this.cacheNode_67();
+      case 25: return this.accessNode_292();
+      case 26: return this.accessNode_512();
+      case 27: return this.cacheNode_584();
+      case 28: return this.cacheNode_114();
+      default: throw new AssertionError();
+    }
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot / 100) {
+      case 0: return switch$$access$0(slot % 100);
+      case 1: return switch$$access$1(slot % 100);
+      case 2: return switch$$access$2(slot % 100);
+      case 3: return switch$$access$3(slot % 100);
+      case 4: return switch$$access$4(slot % 100);
+      case 5: return switch$$access$5(slot % 100);
+      default: throw new AssertionError();
+    }
+  }
+
+  Node_336 accessNode_336() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1000(new ProviderImpl(this, 438), this.accessNode_467(), new ProviderImpl(this, 287), new CachingProviderImpl(this, 73)));
+  }
+
+  Node_273 cacheNode_273() {
+    Object local = this.mNode_273Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1001());
+      this.mNode_273Instance = local;
+    }
+    return (Node_273) local;
+  }
+
+  Node_440 cacheNode_440() {
+    Object local = this.mNode_440Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1002(this.cacheNode_123(), this.cacheNode_285(), this.accessNode_5(), new ProviderImpl(this, 489), new ProviderImpl(this, 116), new CachingProviderImpl(this, 207), this.cacheNode_231(), this.accessNode_135(), this.accessNode_133(), this.cacheNode_50(), new CachingProviderImpl(this, 284)));
+      this.mNode_440Instance = local;
+    }
+    return (Node_440) local;
+  }
+
+  Node_387 cacheNode_387() {
+    Object local = this.mNode_387Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1003(new ProviderImpl(this, 81), this.cacheNode_570(), this.cacheNode_537(), new CachingProviderImpl(this, 403), this.cacheNode_153(), new CachingProviderImpl(this, 244)));
+      this.mNode_387Instance = local;
+    }
+    return (Node_387) local;
+  }
+
+  Node_22 cacheNode_22() {
+    Object local = this.mNode_22Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1004(new CachingProviderImpl(this, 120), new ProviderImpl(this, 63), new ProviderImpl(this, 115), this.mDependency_601.ep_51(), new ProviderImpl(this, 100), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 212), new ProviderImpl(this, 202), new ProviderImpl(this, 288), new ProviderImpl(this, 373), new ProviderImpl(this, 276), new ProviderImpl(this, 15)));
+      this.mNode_22Instance = local;
+    }
+    return (Node_22) local;
+  }
+
+  Node_599 cacheNode_599() {
+    Object local = this.mNode_599Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1005(this.accessNode_596(), new ProviderImpl(this, 279), new ProviderImpl(this, 197), this.mDependency_601.ep_30(), new CachingProviderImpl(this, 177), this.mSet_30, this.cacheNode_249(), new CachingProviderImpl(this, 328), this.cacheNode_154(), new ProviderImpl(this, 271), this.cacheNode_190(), new ProviderImpl(this, 57), new CachingProviderImpl(this, 221), new ProviderImpl(this, 100), new ProviderImpl(this, 199), new ProviderImpl(this, 68), new CachingProviderImpl(this, 396), new ProviderImpl(this, 70), new CachingProviderImpl(this, 282)));
+      this.mNode_599Instance = local;
+    }
+    return (Node_599) local;
+  }
+
+  Node_121 cacheNode_121() {
+    Object local = this.mNode_121Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1006(new CachingProviderImpl(this, 147), new ProviderImpl(this, 265), new ProviderImpl(this, 105), this.mDependency_601.ep_32(), this.mDependency_601.ep_13(), new CachingProviderImpl(this, 432), this.mSet_31, new ProviderImpl(this, 352), new ProviderImpl(this, 209), new CachingProviderImpl(this, 397), this.mSet_43, this.cacheNode_243(), this.mDependency_601.ep_35(), this.mDependency_601.ep_56(), new CachingProviderImpl(this, 184), new ProviderImpl(this, 406), new CachingProviderImpl(this, 396), new CachingProviderImpl(this, 11), this.accessNode_383(), new CachingProviderImpl(this, 200), this.mSet_3, this.cacheNode_98(), new ProviderImpl(this, 193), this.accessNode_134(), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 32), this.mSet_33, new CachingProviderImpl(this, 281)));
+      this.mNode_121Instance = local;
+    }
+    return (Node_121) local;
+  }
+
+  Node_300 accessNode_300() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1007(this.mDependency_601.ep_30(), new CachingProviderImpl(this, 422), this.mSet_49, this.accessNode_305(), new ProviderImpl(this, 452), this.mDependency_601.ep_10(), this.mSet_43, this.accessNode_209(), new CachingProviderImpl(this, 500), new ProviderImpl(this, 278), this.cacheNode_551()));
+  }
+
+  Node_410 accessNode_410() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1008(new ProviderImpl(this, 303), new ProviderImpl(this, 508), this.cacheNode_92(), new CachingProviderImpl(this, 70), new ProviderImpl(this, 337), new CachingProviderImpl(this, 203), new ProviderImpl(this, 287), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), this.cacheNode_393(), this.accessNode_533(), new CachingProviderImpl(this, 336), new CachingProviderImpl(this, 328), new CachingProviderImpl(this, 424), new CachingProviderImpl(this, 300), new ProviderImpl(this, 429), this.accessNode_97(), new ProviderImpl(this, 30), new CachingProviderImpl(this, 456), this.cacheNode_206()));
+  }
+
+  Node_361 cacheNode_361() {
+    Object local = this.mNode_361Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1009(new CachingProviderImpl(this, 118), this.accessNode_96(), this.cacheNode_306(), this.mDependency_601.ep_43(), new ProviderImpl(this, 199), new CachingProviderImpl(this, 44), new ProviderImpl(this, 193)));
+      this.mNode_361Instance = local;
+    }
+    return (Node_361) local;
+  }
+
+  Node_289 accessNode_289() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1010(this.mSet_50, this.cacheNode_44(), this.mDependency_601.ep_56(), this.accessNode_233(), this.mDependency_601.ep_48(), this.mDependency_601.ep_18(), new ProviderImpl(this, 102), this.accessNode_134(), this.mSet_26, this.accessNode_375(), new CachingProviderImpl(this, 370), this.cacheNode_508(), this.mSet_0, this.accessNode_51(), this.accessNode_132()));
+  }
+
+  Node_119 cacheNode_119() {
+    Object local = this.mNode_119Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1011(this.cacheNode_152(), this.cacheNode_342(), new ProviderImpl(this, 334)));
+      this.mNode_119Instance = local;
+    }
+    return (Node_119) local;
+  }
+
+  Node_342 cacheNode_342() {
+    Object local = this.mNode_342Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1012(this.cacheNode_565(), new ProviderImpl(this, 299), new CachingProviderImpl(this, 339), this.mSet_50, new ProviderImpl(this, 116), this.accessNode_427(), this.mSet_43, new CachingProviderImpl(this, 523), this.cacheNode_207(), this.accessNode_101(), this.mDependency_601.ep_13(), new CachingProviderImpl(this, 32), new CachingProviderImpl(this, 473), this.mDependency_601.ep_32(), this.accessNode_548(), this.accessNode_155(), new ProviderImpl(this, 68), this.cacheNode_40(), this.accessNode_383(), new ProviderImpl(this, 222), this.cacheNode_528(), this.accessNode_375(), new CachingProviderImpl(this, 232)));
+      this.mNode_342Instance = local;
+    }
+    return (Node_342) local;
+  }
+
+  Node_363 cacheNode_363() {
+    Object local = this.mNode_363Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1013(this.accessNode_600(), new ProviderImpl(this, 441), this.accessNode_330(), new CachingProviderImpl(this, 283), new ProviderImpl(this, 374)));
+      this.mNode_363Instance = local;
+    }
+    return (Node_363) local;
+  }
+
+  Node_475 accessNode_475() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1014(new CachingProviderImpl(this, 7), new ProviderImpl(this, 305), new ProviderImpl(this, 196), this.mDependency_601.ep_7(), new ProviderImpl(this, 202), this.accessNode_534(), this.cacheNode_589(), new ProviderImpl(this, 287), this.accessNode_133(), this.cacheNode_387(), this.mSet_50, this.cacheNode_286(), new CachingProviderImpl(this, 495), this.accessNode_222(), this.accessNode_336(), this.accessNode_390()));
+  }
+
+  Node_404 cacheNode_404() {
+    Object local = this.mNode_404Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1015(this.mSet_24, new ProviderImpl(this, 369), new CachingProviderImpl(this, 285), new CachingProviderImpl(this, 466), this.cacheNode_198(), this.cacheNode_44(), this.accessNode_101(), new CachingProviderImpl(this, 98), new ProviderImpl(this, 287), new CachingProviderImpl(this, 153), this.mDependency_601.ep_43(), new ProviderImpl(this, 255), new CachingProviderImpl(this, 335), new CachingProviderImpl(this, 135), new ProviderImpl(this, 226)));
+      this.mNode_404Instance = local;
+    }
+    return (Node_404) local;
+  }
+
+  Node_152 cacheNode_152() {
+    Object local = this.mNode_152Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1016(new ProviderImpl(this, 454), this.accessNode_424(), this.cacheNode_571(), this.cacheNode_521(), this.mSet_37, this.accessNode_140(), new ProviderImpl(this, 59), this.accessNode_126(), new ProviderImpl(this, 390), this.accessNode_507(), this.accessNode_552()));
+      this.mNode_152Instance = local;
+    }
+    return (Node_152) local;
+  }
+
+  Node_521 cacheNode_521() {
+    Object local = this.mNode_521Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1017(new CachingProviderImpl(this, 120), new ProviderImpl(this, 501), this.accessNode_134(), new CachingProviderImpl(this, 417), this.mDependency_601.ep_19(), this.accessNode_424(), new CachingProviderImpl(this, 465), new CachingProviderImpl(this, 168), new ProviderImpl(this, 238), this.mSet_43));
+      this.mNode_521Instance = local;
+    }
+    return (Node_521) local;
+  }
+
+  Node_298 accessNode_298() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1018(new CachingProviderImpl(this, 385), new ProviderImpl(this, 515), this.mDependency_601.ep_40(), new ProviderImpl(this, 45), this.cacheNode_67(), new ProviderImpl(this, 21), new ProviderImpl(this, 365), this.cacheNode_331(), new ProviderImpl(this, 229), new CachingProviderImpl(this, 196), this.cacheNode_143(), new CachingProviderImpl(this, 390), this.mDependency_601.ep_35(), this.accessNode_296(), this.accessNode_113(), new CachingProviderImpl(this, 409), this.cacheNode_267()));
+  }
+
+  Node_18 accessNode_18() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1019(this.mSet_14));
+  }
+
+  Node_395 accessNode_395() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1020(new ProviderImpl(this, 28), new CachingProviderImpl(this, 184), new ProviderImpl(this, 29), new ProviderImpl(this, 324), new CachingProviderImpl(this, 480), this.cacheNode_282(), new ProviderImpl(this, 44), new CachingProviderImpl(this, 490), new ProviderImpl(this, 14), this.accessNode_391(), new CachingProviderImpl(this, 436)));
+  }
+
+  Node_240 accessNode_240() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1021(this.cacheNode_531(), this.mSet_31, this.cacheNode_104(), this.cacheNode_261(), this.mDependency_601.ep_9(), this.cacheNode_343(), this.mSet_18, this.accessNode_26(), this.accessNode_37(), new ProviderImpl(this, 203), this.accessNode_477(), this.mSet_41, this.cacheNode_426(), new CachingProviderImpl(this, 44), this.mSet_1, new CachingProviderImpl(this, 220), this.accessNode_179(), this.mDependency_601.ep_41(), this.accessNode_12(), this.cacheNode_364(), this.accessNode_18(), this.accessNode_182(), this.cacheNode_445()));
+  }
+
+  Node_520 cacheNode_520() {
+    Object local = this.mNode_520Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1022());
+      this.mNode_520Instance = local;
+    }
+    return (Node_520) local;
+  }
+
+  Node_156 accessNode_156() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1023(this.accessNode_301(), this.cacheNode_318(), this.mSet_51, this.cacheNode_253(), this.mSet_21, new CachingProviderImpl(this, 267)));
+  }
+
+  Node_61 accessNode_61() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1024(this.cacheNode_167(), new ProviderImpl(this, 67), this.accessNode_288(), new CachingProviderImpl(this, 177), new ProviderImpl(this, 236), new ProviderImpl(this, 427), new CachingProviderImpl(this, 36), this.accessNode_142(), new ProviderImpl(this, 330), new ProviderImpl(this, 490), new ProviderImpl(this, 81), this.accessNode_311(), this.mDependency_601.ep_23()));
+  }
+
+  Node_60 accessNode_60() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1025(this.cacheNode_102(), new ProviderImpl(this, 90), new CachingProviderImpl(this, 114), new CachingProviderImpl(this, 173), new CachingProviderImpl(this, 147), this.cacheNode_249(), this.cacheNode_215(), new ProviderImpl(this, 308), this.accessNode_401(), this.cacheNode_282(), this.accessNode_580(), this.accessNode_558(), this.accessNode_219(), this.mSet_7, this.accessNode_295(), this.accessNode_574(), new ProviderImpl(this, 209), this.mSet_10, new ProviderImpl(this, 211), this.cacheNode_417()));
+  }
+
+  Node_460 accessNode_460() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1026(this.mSet_11, new ProviderImpl(this, 293), new ProviderImpl(this, 508), this.accessNode_293(), this.mSet_50, this.mDependency_601.ep_19(), new ProviderImpl(this, 194), this.cacheNode_151(), new CachingProviderImpl(this, 217), new CachingProviderImpl(this, 39)));
+  }
+
+  Node_389 cacheNode_389() {
+    Object local = this.mNode_389Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1028(new CachingProviderImpl(this, 229), this.accessNode_295(), new CachingProviderImpl(this, 398), this.accessNode_438(), this.accessNode_356()));
+      this.mNode_389Instance = local;
+    }
+    return (Node_389) local;
+  }
+
+  Node_388 cacheNode_388() {
+    Object local = this.mNode_388Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1029(this.accessNode_385(), this.cacheNode_562(), new CachingProviderImpl(this, 523)));
+      this.mNode_388Instance = local;
+    }
+    return (Node_388) local;
+  }
+
+  Node_311 accessNode_311() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1030(this.accessNode_18(), new ProviderImpl(this, 131), new ProviderImpl(this, 287), new ProviderImpl(this, 444), new ProviderImpl(this, 323), new ProviderImpl(this, 143), this.mSet_16, this.mSet_49, this.cacheNode_215(), this.mDependency_601.ep_48(), this.cacheNode_114(), new CachingProviderImpl(this, 372), this.cacheNode_551(), this.mDependency_601.ep_31(), new ProviderImpl(this, 205), this.mSet_25, this.mSet_44, this.accessNode_385(), this.accessNode_480(), this.accessNode_116(), new CachingProviderImpl(this, 284), this.mDependency_601.ep_13(), new CachingProviderImpl(this, 11), this.mSet_2, new ProviderImpl(this, 99)));
+  }
+
+  Node_190 cacheNode_190() {
+    Object local = this.mNode_190Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1031(new CachingProviderImpl(this, 104), this.mDependency_601.ep_4(), this.accessNode_93(), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 151), new ProviderImpl(this, 251), new CachingProviderImpl(this, 104), this.mDependency_601.ep_40(), new ProviderImpl(this, 257), this.accessNode_179(), new ProviderImpl(this, 136), new CachingProviderImpl(this, 143), this.mDependency_601.ep_25(), this.mDependency_601.ep_56(), this.accessNode_105(), new CachingProviderImpl(this, 203), new CachingProviderImpl(this, 149), new CachingProviderImpl(this, 283)));
+      this.mNode_190Instance = local;
+    }
+    return (Node_190) local;
+  }
+
+  Node_25 cacheNode_25() {
+    Object local = this.mNode_25Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1032(new ProviderImpl(this, 202), this.cacheNode_121(), this.mSet_14, this.accessNode_329(), new CachingProviderImpl(this, 163)));
+      this.mNode_25Instance = local;
+    }
+    return (Node_25) local;
+  }
+
+  Node_78 cacheNode_78() {
+    Object local = this.mNode_78Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1035(this.accessNode_518(), this.cacheNode_474(), this.accessNode_350(), this.accessNode_103(), new CachingProviderImpl(this, 415), this.cacheNode_441(), this.accessNode_460(), this.mDependency_601.ep_43(), this.accessNode_512(), this.cacheNode_361(), this.accessNode_534(), this.mDependency_601.ep_23(), this.cacheNode_316(), this.accessNode_240()));
+      this.mNode_78Instance = local;
+    }
+    return (Node_78) local;
+  }
+
+  Node_303 cacheNode_303() {
+    Object local = this.mNode_303Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1036(new ProviderImpl(this, 132), new CachingProviderImpl(this, 27), new ProviderImpl(this, 514), new ProviderImpl(this, 399), new ProviderImpl(this, 17), new ProviderImpl(this, 232)));
+      this.mNode_303Instance = local;
+    }
+    return (Node_303) local;
+  }
+
+  Node_71 cacheNode_71() {
+    Object local = this.mNode_71Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1037());
+      this.mNode_71Instance = local;
+    }
+    return (Node_71) local;
+  }
+
+  Node_569 cacheNode_569() {
+    Object local = this.mNode_569Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1038(new CachingProviderImpl(this, 378), new CachingProviderImpl(this, 234), this.accessNode_458(), this.cacheNode_524(), new CachingProviderImpl(this, 169), this.accessNode_304(), new ProviderImpl(this, 82)));
+      this.mNode_569Instance = local;
+    }
+    return (Node_569) local;
+  }
+
+  Node_416 accessNode_416() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1039(this.mDependency_601.ep_32(), this.accessNode_56(), this.accessNode_454(), new ProviderImpl(this, 24), new ProviderImpl(this, 299), this.accessNode_533(), this.mDependency_601.ep_29(), new CachingProviderImpl(this, 143), this.accessNode_339(), this.cacheNode_64(), this.accessNode_168(), new ProviderImpl(this, 449), new ProviderImpl(this, 219), new CachingProviderImpl(this, 496), new ProviderImpl(this, 32), this.cacheNode_224(), new ProviderImpl(this, 309)));
+  }
+
+  Node_481 cacheNode_481() {
+    Object local = this.mNode_481Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1040());
+      this.mNode_481Instance = local;
+    }
+    return (Node_481) local;
+  }
+
+  Node_568 cacheNode_568() {
+    Object local = this.mNode_568Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1041(this.cacheNode_333(), this.mDependency_601.ep_54(), this.mSet_21, this.accessNode_397(), this.mSet_17, this.mSet_25, new CachingProviderImpl(this, 217), this.cacheNode_319(), this.accessNode_340(), new ProviderImpl(this, 63), this.cacheNode_429(), new ProviderImpl(this, 508), this.cacheNode_457(), this.mDependency_601.ep_45(), this.accessNode_269(), this.cacheNode_436(), this.mSet_44, new ProviderImpl(this, 169)));
+      this.mNode_568Instance = local;
+    }
+    return (Node_568) local;
+  }
+
+  Node_299 cacheNode_299() {
+    Object local = this.mNode_299Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1042(new ProviderImpl(this, 227), this.cacheNode_422(), this.accessNode_93(), this.accessNode_458(), new CachingProviderImpl(this, 120), this.mDependency_601.ep_48(), this.mDependency_601.ep_33(), this.accessNode_301(), this.accessNode_18(), this.mDependency_601.ep_24(), this.cacheNode_543(), new ProviderImpl(this, 194), this.accessNode_501(), this.mSet_14, new CachingProviderImpl(this, 475), this.accessNode_483()));
+      this.mNode_299Instance = local;
+    }
+    return (Node_299) local;
+  }
+
+  Node_591 cacheNode_591() {
+    Object local = this.mNode_591Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1043());
+      this.mNode_591Instance = local;
+    }
+    return (Node_591) local;
+  }
+
+  Node_136 accessNode_136() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1044(new CachingProviderImpl(this, 422), this.cacheNode_44(), this.mSet_26, this.cacheNode_303(), this.cacheNode_341(), this.accessNode_492(), this.accessNode_480(), new CachingProviderImpl(this, 475), this.cacheNode_157(), this.cacheNode_426(), new CachingProviderImpl(this, 141), this.cacheNode_589(), new CachingProviderImpl(this, 339), this.cacheNode_167(), new ProviderImpl(this, 323), this.cacheNode_212(), new CachingProviderImpl(this, 143), new CachingProviderImpl(this, 176), this.mSet_37));
+  }
+
+  Node_233 accessNode_233() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1045(this.cacheNode_521(), this.cacheNode_537(), this.cacheNode_198(), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 424), new CachingProviderImpl(this, 217), Checks.checkProvisionNotNull(Module_609.Companion.provides_986()), this.mDependency_601.ep_14(), this.accessNode_295(), this.cacheNode_250(), new ProviderImpl(this, 373), this.cacheNode_586(), new CachingProviderImpl(this, 210), this.mDependency_601.ep_30()));
+  }
+
+  Node_284 cacheNode_284() {
+    Object local = this.mNode_284Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1048(new CachingProviderImpl(this, 281), this.cacheNode_157(), new ProviderImpl(this, 269), new CachingProviderImpl(this, 70), new ProviderImpl(this, 482), new ProviderImpl(this, 148), new ProviderImpl(this, 144), this.cacheNode_519(), this.mDependency_601.ep_4(), new ProviderImpl(this, 193), new ProviderImpl(this, 115), this.accessNode_518(), new ProviderImpl(this, 29), this.accessNode_600()));
+      this.mNode_284Instance = local;
+    }
+    return (Node_284) local;
+  }
+
+  Node_502 cacheNode_502() {
+    Object local = this.mNode_502Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1050(new ProviderImpl(this, 199), new ProviderImpl(this, 329), this.cacheNode_185(), new CachingProviderImpl(this, 435), this.accessNode_115(), this.mDependency_601.ep_26(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 23), this.cacheNode_310()));
+      this.mNode_502Instance = local;
+    }
+    return (Node_502) local;
+  }
+
+  Node_421 cacheNode_421() {
+    Object local = this.mNode_421Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1051(new ProviderImpl(this, 13), new ProviderImpl(this, 40), this.mDependency_601.ep_15(), new CachingProviderImpl(this, 284), new ProviderImpl(this, 293), this.mDependency_601.ep_34(), this.cacheNode_234(), new ProviderImpl(this, 111), new CachingProviderImpl(this, 120)));
+      this.mNode_421Instance = local;
+    }
+    return (Node_421) local;
+  }
+
+  Node_85 accessNode_85() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1053(new CachingProviderImpl(this, 42), this.mSet_31, new CachingProviderImpl(this, 263), new CachingProviderImpl(this, 163), new CachingProviderImpl(this, 98), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 284), new ProviderImpl(this, 125), new CachingProviderImpl(this, 217), this.mSet_51, new ProviderImpl(this, 410), new ProviderImpl(this, 314), new CachingProviderImpl(this, 94), new ProviderImpl(this, 444), this.cacheNode_71(), new CachingProviderImpl(this, 217), new ProviderImpl(this, 249), this.accessNode_533(), new CachingProviderImpl(this, 327), new CachingProviderImpl(this, 335)));
+  }
+
+  Node_436 cacheNode_436() {
+    Object local = this.mNode_436Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1054(this.accessNode_300(), new ProviderImpl(this, 103), this.cacheNode_282(), this.cacheNode_559(), this.accessNode_597(), new ProviderImpl(this, 451), new ProviderImpl(this, 401), this.cacheNode_519(), this.cacheNode_386(), this.cacheNode_506(), this.mDependency_601.ep_16(), this.accessNode_590(), this.mDependency_601.ep_44(), this.mDependency_601.ep_3(), new ProviderImpl(this, 259), this.mSet_4, new CachingProviderImpl(this, 349), new CachingProviderImpl(this, 231), new CachingProviderImpl(this, 175), this.mSet_15, this.accessNode_21(), this.cacheNode_527(), this.cacheNode_13(), this.cacheNode_141(), this.accessNode_257(), this.accessNode_338()));
+      this.mNode_436Instance = local;
+    }
+    return (Node_436) local;
+  }
+
+  Node_433 accessNode_433() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1055(new CachingProviderImpl(this, 436)));
+  }
+
+  Node_580 accessNode_580() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1056(new CachingProviderImpl(this, 184), this.mSet_6, this.accessNode_136(), this.cacheNode_450(), new ProviderImpl(this, 218), new CachingProviderImpl(this, 227), this.cacheNode_64(), this.accessNode_427(), this.cacheNode_422(), new CachingProviderImpl(this, 94), this.mDependency_601.ep_45(), this.cacheNode_303(), new ProviderImpl(this, 57), new CachingProviderImpl(this, 335), new ProviderImpl(this, 132), this.cacheNode_527(), new CachingProviderImpl(this, 462), new ProviderImpl(this, 115), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), new CachingProviderImpl(this, 339), this.cacheNode_599(), new CachingProviderImpl(this, 358), new ProviderImpl(this, 488), this.mDependency_601.ep_20(), new ProviderImpl(this, 337), this.cacheNode_157(), this.accessNode_304(), this.accessNode_582()));
+  }
+
+  Node_50 cacheNode_50() {
+    Object local = this.mNode_50Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1057(this.cacheNode_569(), this.cacheNode_229(), this.cacheNode_556(), this.cacheNode_551(), new ProviderImpl(this, 303), this.accessNode_179(), this.accessNode_425(), this.mSet_13, new CachingProviderImpl(this, 430), this.cacheNode_353(), this.accessNode_165(), this.cacheNode_44(), this.cacheNode_431(), this.cacheNode_562(), this.mSet_43, new CachingProviderImpl(this, 140), new CachingProviderImpl(this, 522), this.accessNode_463(), new ProviderImpl(this, 399), this.accessNode_118(), this.accessNode_242(), new ProviderImpl(this, 110), this.accessNode_63(), this.mDependency_601.ep_14(), this.accessNode_56(), new CachingProviderImpl(this, 147), this.accessNode_379(), this.cacheNode_120()));
+      this.mNode_50Instance = local;
+    }
+    return (Node_50) local;
+  }
+
+  Node_107 accessNode_107() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1058(new CachingProviderImpl(this, 43), new ProviderImpl(this, 324), new CachingProviderImpl(this, 156), new CachingProviderImpl(this, 70), new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 360), new ProviderImpl(this, 55), new ProviderImpl(this, 202), this.cacheNode_306(), new ProviderImpl(this, 131), this.accessNode_510(), new CachingProviderImpl(this, 248), this.cacheNode_167(), this.mDependency_601.ep_5(), new ProviderImpl(this, 68), new CachingProviderImpl(this, 121), new ProviderImpl(this, 419), this.accessNode_336()));
+  }
+
+  Node_474 cacheNode_474() {
+    Object local = this.mNode_474Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1059());
+      this.mNode_474Instance = local;
+    }
+    return (Node_474) local;
+  }
+
+  Node_66 accessNode_66() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1060(this.cacheNode_543(), this.mDependency_601.ep_40(), new ProviderImpl(this, 452), this.cacheNode_226(), new ProviderImpl(this, 284)));
+  }
+
+  Node_103 accessNode_103() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1061(this.mDependency_601.ep_14(), new CachingProviderImpl(this, 321), this.accessNode_510(), new ProviderImpl(this, 482), this.cacheNode_527(), this.cacheNode_565(), new CachingProviderImpl(this, 339), this.mDependency_601.ep_3(), new ProviderImpl(this, 13), this.cacheNode_98(), new ProviderImpl(this, 204), new ProviderImpl(this, 59), new CachingProviderImpl(this, 376), new CachingProviderImpl(this, 432), new CachingProviderImpl(this, 170), this.mDependency_601.ep_50(), this.cacheNode_154(), this.cacheNode_360(), new ProviderImpl(this, 515), this.cacheNode_286(), this.accessNode_534(), this.mSet_45, new ProviderImpl(this, 437), new CachingProviderImpl(this, 464), new CachingProviderImpl(this, 119)));
+  }
+
+  Node_134 accessNode_134() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1062(new CachingProviderImpl(this, 307), new CachingProviderImpl(this, 222), new ProviderImpl(this, 418), this.accessNode_512(), this.mDependency_601.ep_9(), this.accessNode_59(), new CachingProviderImpl(this, 402), new CachingProviderImpl(this, 459), new CachingProviderImpl(this, 353), new ProviderImpl(this, 119), new CachingProviderImpl(this, 27), this.accessNode_85(), new ProviderImpl(this, 230), new CachingProviderImpl(this, 58), new CachingProviderImpl(this, 408), new CachingProviderImpl(this, 146), new ProviderImpl(this, 395), new ProviderImpl(this, 357), new ProviderImpl(this, 444), this.mDependency_601.ep_55(), this.cacheNode_499(), this.mSet_21, new ProviderImpl(this, 335)));
+  }
+
+  Node_463 accessNode_463() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1063(this.mDependency_601.ep_39(), this.accessNode_329(), this.accessNode_350(), new CachingProviderImpl(this, 504)));
+  }
+
+  Node_33 accessNode_33() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1064(this.cacheNode_81(), this.accessNode_391(), this.cacheNode_589(), new CachingProviderImpl(this, 409), this.accessNode_507(), this.mDependency_601.ep_15(), new CachingProviderImpl(this, 267), new ProviderImpl(this, 7), this.cacheNode_198(), new ProviderImpl(this, 134), new CachingProviderImpl(this, 415), this.cacheNode_569()));
+  }
+
+  Node_553 accessNode_553() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1065(new CachingProviderImpl(this, 244), new ProviderImpl(this, 381), this.cacheNode_490(), new ProviderImpl(this, 15), this.cacheNode_441(), this.mSet_28, new ProviderImpl(this, 324), this.accessNode_350(), this.cacheNode_198(), this.accessNode_29(), this.accessNode_127(), this.cacheNode_64(), this.mSet_46, this.cacheNode_562(), this.cacheNode_137(), this.mDependency_601.ep_57(), new ProviderImpl(this, 509)));
+  }
+
+  Node_576 cacheNode_576() {
+    Object local = this.mNode_576Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1066(new CachingProviderImpl(this, 349), new CachingProviderImpl(this, 58), new ProviderImpl(this, 194), new ProviderImpl(this, 312), new CachingProviderImpl(this, 398), new CachingProviderImpl(this, 432), new CachingProviderImpl(this, 434), new ProviderImpl(this, 50)));
+      this.mNode_576Instance = local;
+    }
+    return (Node_576) local;
+  }
+
+  Node_592 accessNode_592() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1067(this.accessNode_42(), this.cacheNode_457(), this.cacheNode_206(), this.cacheNode_591(), new CachingProviderImpl(this, 404), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 434), this.mDependency_601.ep_1(), new ProviderImpl(this, 61), this.mSet_18, this.cacheNode_284(), new ProviderImpl(this, 304), this.accessNode_179(), this.accessNode_598(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), this.accessNode_424(), new ProviderImpl(this, 514), Checks.checkProvisionNotNull(Module_609.Companion.provides_949()), this.accessNode_295(), this.cacheNode_152(), this.accessNode_232(), this.accessNode_512(), this.cacheNode_562(), this.accessNode_80(), new ProviderImpl(this, 392), this.cacheNode_441(), new ProviderImpl(this, 24)));
+  }
+
+  Node_58 accessNode_58() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1068(new ProviderImpl(this, 514), this.accessNode_329(), this.cacheNode_234(), this.cacheNode_551(), this.mSet_1, this.accessNode_233(), this.mDependency_601.ep_21(), this.accessNode_397(), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), new ProviderImpl(this, 320), this.cacheNode_2(), this.cacheNode_176()));
+  }
+
+  Node_155 accessNode_155() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1069(this.cacheNode_229(), new ProviderImpl(this, 488), new CachingProviderImpl(this, 164), new ProviderImpl(this, 100), new ProviderImpl(this, 59), new CachingProviderImpl(this, 130), new ProviderImpl(this, 76), new ProviderImpl(this, 369), new ProviderImpl(this, 61), new CachingProviderImpl(this, 65), new ProviderImpl(this, 397), this.mDependency_601.ep_29()));
+  }
+
+  Node_485 accessNode_485() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1070(this.cacheNode_556(), new CachingProviderImpl(this, 316), new CachingProviderImpl(this, 112), this.cacheNode_535(), new CachingProviderImpl(this, 135), new CachingProviderImpl(this, 234), this.mDependency_601.ep_10(), this.cacheNode_524(), new CachingProviderImpl(this, 523), new CachingProviderImpl(this, 475), this.cacheNode_143(), new ProviderImpl(this, 419), new CachingProviderImpl(this, 160), new CachingProviderImpl(this, 400), new CachingProviderImpl(this, 268), new ProviderImpl(this, 324), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 168), this.accessNode_89(), new CachingProviderImpl(this, 231), new CachingProviderImpl(this, 154), this.mSet_25, this.mSet_29, this.mSet_4, new CachingProviderImpl(this, 162)));
+  }
+
+  Node_126 accessNode_126() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1071(new CachingProviderImpl(this, 451), new ProviderImpl(this, 99), new CachingProviderImpl(this, 495), this.mSet_42, new ProviderImpl(this, 259), this.mSet_10, new ProviderImpl(this, 33), this.mSet_15, new CachingProviderImpl(this, 473), new CachingProviderImpl(this, 119), this.cacheNode_556(), this.cacheNode_331(), new ProviderImpl(this, 294), this.mDependency_601.ep_57(), this.mDependency_601.ep_13(), new ProviderImpl(this, 91), new CachingProviderImpl(this, 464), new CachingProviderImpl(this, 507), this.mDependency_601.ep_35(), this.accessNode_458(), new ProviderImpl(this, 392)));
+  }
+
+  Node_356 accessNode_356() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1072(this.accessNode_467(), this.accessNode_242(), new ProviderImpl(this, 237), this.cacheNode_71(), this.mSet_10, this.cacheNode_261(), new CachingProviderImpl(this, 464), this.accessNode_496(), this.accessNode_410(), this.accessNode_296(), new ProviderImpl(this, 270), this.cacheNode_474(), this.accessNode_213(), this.cacheNode_310(), this.accessNode_529(), new ProviderImpl(this, 305), this.mSet_7, new ProviderImpl(this, 452), this.cacheNode_560(), new ProviderImpl(this, 295), this.accessNode_295(), this.cacheNode_353(), this.mSet_27, new ProviderImpl(this, 30), this.cacheNode_171(), this.cacheNode_147(), this.accessNode_93(), this.accessNode_268()));
+  }
+
+  Node_413 cacheNode_413() {
+    Object local = this.mNode_413Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1073(new ProviderImpl(this, 415), this.mSet_12, new CachingProviderImpl(this, 481), this.mDependency_601.ep_15(), new ProviderImpl(this, 236), new CachingProviderImpl(this, 156), this.accessNode_18(), this.mDependency_601.ep_7(), this.accessNode_305(), this.cacheNode_570(), this.mDependency_601.ep_23(), new ProviderImpl(this, 395), this.mSet_30, new CachingProviderImpl(this, 162), this.cacheNode_494(), this.cacheNode_215(), new CachingProviderImpl(this, 348), this.accessNode_115(), new ProviderImpl(this, 133), this.mSet_44, new CachingProviderImpl(this, 94), new ProviderImpl(this, 238), new ProviderImpl(this, 444), this.mDependency_601.ep_54(), new ProviderImpl(this, 323), this.cacheNode_530(), this.mSet_35, new CachingProviderImpl(this, 360), this.mSet_31));
+      this.mNode_413Instance = local;
+    }
+    return (Node_413) local;
+  }
+
+  Node_297 accessNode_297() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1074(new ProviderImpl(this, 131), this.accessNode_288(), new CachingProviderImpl(this, 407), new ProviderImpl(this, 527), this.cacheNode_550(), new ProviderImpl(this, 94), new ProviderImpl(this, 271), new ProviderImpl(this, 343), new CachingProviderImpl(this, 221), this.cacheNode_352(), this.cacheNode_194(), new ProviderImpl(this, 517), new CachingProviderImpl(this, 428), this.mDependency_601.ep_5(), this.accessNode_497(), this.accessNode_385(), this.mSet_11, new CachingProviderImpl(this, 391), new CachingProviderImpl(this, 169), new CachingProviderImpl(this, 316), new ProviderImpl(this, 160), new ProviderImpl(this, 324), new ProviderImpl(this, 238), this.cacheNode_6(), new ProviderImpl(this, 34), this.accessNode_23(), this.mSet_20, this.mSet_28));
+  }
+
+  Node_149 accessNode_149() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1076(this.mDependency_601.ep_22(), this.cacheNode_201(), this.accessNode_66(), new CachingProviderImpl(this, 234)));
+  }
+
+  Node_561 cacheNode_561() {
+    Object local = this.mNode_561Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1077(new ProviderImpl(this, 369), new CachingProviderImpl(this, 318), this.accessNode_391(), this.accessNode_218(), this.accessNode_432(), this.accessNode_443(), this.accessNode_56(), new CachingProviderImpl(this, 388), new CachingProviderImpl(this, 424), new ProviderImpl(this, 425), this.accessNode_148(), new CachingProviderImpl(this, 119), this.accessNode_290(), this.cacheNode_352(), new ProviderImpl(this, 115), this.cacheNode_421(), this.accessNode_305(), this.accessNode_29(), new CachingProviderImpl(this, 196), new CachingProviderImpl(this, 44), new CachingProviderImpl(this, 336)));
+      this.mNode_561Instance = local;
+    }
+    return (Node_561) local;
+  }
+
+  Node_100 accessNode_100() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1078(new ProviderImpl(this, 194), this.mSet_10, this.accessNode_180()));
+  }
+
+  Node_494 cacheNode_494() {
+    Object local = this.mNode_494Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1079(new CachingProviderImpl(this, 206), Checks.checkProvisionNotNull(Module_609.Companion.provides_986()), new ProviderImpl(this, 463), this.accessNode_162(), new CachingProviderImpl(this, 498), new CachingProviderImpl(this, 22), new ProviderImpl(this, 431), new CachingProviderImpl(this, 327), new CachingProviderImpl(this, 396), new ProviderImpl(this, 515), new ProviderImpl(this, 139), new ProviderImpl(this, 211), new CachingProviderImpl(this, 156)));
+      this.mNode_494Instance = local;
+    }
+    return (Node_494) local;
+  }
+
+  Node_64 cacheNode_64() {
+    Object local = this.mNode_64Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1080(new ProviderImpl(this, 224), this.cacheNode_121(), this.accessNode_216(), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 151), new ProviderImpl(this, 217), new CachingProviderImpl(this, 177), new CachingProviderImpl(this, 154), this.cacheNode_342(), this.mSet_31, new ProviderImpl(this, 139), new ProviderImpl(this, 115), this.accessNode_187(), new CachingProviderImpl(this, 253), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), this.cacheNode_215(), this.mSet_1, this.accessNode_148()));
+      this.mNode_64Instance = local;
+    }
+    return (Node_64) local;
+  }
+
+  Node_504 accessNode_504() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1081(new ProviderImpl(this, 471), new ProviderImpl(this, 109), this.accessNode_367(), new CachingProviderImpl(this, 503), this.mSet_10, new CachingProviderImpl(this, 502), new ProviderImpl(this, 108), new CachingProviderImpl(this, 58), this.accessNode_480(), this.mSet_4, new CachingProviderImpl(this, 37), this.accessNode_209(), this.mSet_30, new ProviderImpl(this, 514), new ProviderImpl(this, 132), new ProviderImpl(this, 142), new ProviderImpl(this, 63), this.mDependency_601.ep_52(), this.accessNode_216(), new CachingProviderImpl(this, 235), this.accessNode_496(), this.cacheNode_551(), this.mSet_37, new CachingProviderImpl(this, 87), this.accessNode_391(), new ProviderImpl(this, 86), new CachingProviderImpl(this, 44), this.accessNode_449()));
+  }
+
+  Node_350 accessNode_350() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1082(this.mSet_29, this.cacheNode_349(), this.mSet_44, new CachingProviderImpl(this, 526), this.cacheNode_307(), this.cacheNode_530(), this.accessNode_296(), this.mDependency_601.ep_38(), this.mSet_33, this.mSet_46, this.cacheNode_415(), new CachingProviderImpl(this, 465), new CachingProviderImpl(this, 94)));
+  }
+
+  Node_391 accessNode_391() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1083(new CachingProviderImpl(this, 360), new ProviderImpl(this, 452), new ProviderImpl(this, 15), this.accessNode_11()));
+  }
+
+  Node_194 cacheNode_194() {
+    Object local = this.mNode_194Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1084(new ProviderImpl(this, 431), new CachingProviderImpl(this, 434), this.accessNode_115(), this.cacheNode_243()));
+      this.mNode_194Instance = local;
+    }
+    return (Node_194) local;
+  }
+
+  Node_354 cacheNode_354() {
+    Object local = this.mNode_354Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1085(this.cacheNode_537(), this.cacheNode_81(), new CachingProviderImpl(this, 70), this.mSet_21, this.accessNode_135(), this.cacheNode_521(), new CachingProviderImpl(this, 421), new CachingProviderImpl(this, 177), new CachingProviderImpl(this, 64), this.accessNode_175(), new ProviderImpl(this, 468)));
+      this.mNode_354Instance = local;
+    }
+    return (Node_354) local;
+  }
+
+  Node_235 accessNode_235() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1086(new CachingProviderImpl(this, 509), new CachingProviderImpl(this, 400), this.accessNode_427(), this.mSet_44, new ProviderImpl(this, 202), this.mDependency_601.ep_35(), this.cacheNode_147(), new ProviderImpl(this, 516), this.cacheNode_571(), this.cacheNode_530(), this.cacheNode_40(), this.mDependency_601.ep_0(), this.mDependency_601.ep_2(), this.mDependency_601.ep_5(), this.accessNode_139(), new ProviderImpl(this, 30), new ProviderImpl(this, 408)));
+  }
+
+  Node_535 cacheNode_535() {
+    Object local = this.mNode_535Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1087(this.mDependency_601.ep_29(), new ProviderImpl(this, 488), new CachingProviderImpl(this, 52), new CachingProviderImpl(this, 49), new ProviderImpl(this, 14), this.mSet_44));
+      this.mNode_535Instance = local;
+    }
+    return (Node_535) local;
+  }
+
+  Node_598 accessNode_598() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1088(this.accessNode_434(), new CachingProviderImpl(this, 119), this.cacheNode_271(), this.cacheNode_499(), new ProviderImpl(this, 224), this.accessNode_401(), this.mDependency_601.ep_38()));
+  }
+
+  Node_477 accessNode_477() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1089(new ProviderImpl(this, 328), new CachingProviderImpl(this, 263), new ProviderImpl(this, 90), this.accessNode_390(), this.accessNode_165(), new ProviderImpl(this, 446), this.mDependency_601.ep_31(), this.cacheNode_152(), new CachingProviderImpl(this, 394), this.accessNode_595(), this.cacheNode_500(), this.accessNode_597(), this.cacheNode_341(), this.accessNode_33(), this.mDependency_601.ep_42(), this.mSet_19, this.accessNode_162(), this.cacheNode_333(), this.cacheNode_71(), this.cacheNode_581(), this.accessNode_383()));
+  }
+
+  Node_331 cacheNode_331() {
+    Object local = this.mNode_331Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1090(this.accessNode_203(), new CachingProviderImpl(this, 456), new ProviderImpl(this, 21), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 284), this.cacheNode_25(), new ProviderImpl(this, 109), new ProviderImpl(this, 115), new ProviderImpl(this, 50), this.mSet_27, this.mSet_29));
+      this.mNode_331Instance = local;
+    }
+    return (Node_331) local;
+  }
+
+  Node_310 cacheNode_310() {
+    Object local = this.mNode_310Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1091(this.accessNode_85(), this.cacheNode_393(), new ProviderImpl(this, 263), this.cacheNode_360(), this.accessNode_59(), new ProviderImpl(this, 226), this.cacheNode_431(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), this.accessNode_395(), this.mSet_9, this.accessNode_425(), this.cacheNode_303(), this.cacheNode_426(), this.accessNode_580()));
+      this.mNode_310Instance = local;
+    }
+    return (Node_310) local;
+  }
+
+  Node_386 cacheNode_386() {
+    Object local = this.mNode_386Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1092(new CachingProviderImpl(this, 177), this.mDependency_601.ep_49(), new CachingProviderImpl(this, 331), new CachingProviderImpl(this, 281), this.accessNode_242(), this.mDependency_601.ep_56(), new CachingProviderImpl(this, 368), this.mSet_0, new ProviderImpl(this, 262), this.cacheNode_92(), new CachingProviderImpl(this, 173), this.mDependency_601.ep_2(), this.accessNode_162(), new CachingProviderImpl(this, 480), new ProviderImpl(this, 309), new ProviderImpl(this, 45), this.cacheNode_351(), new CachingProviderImpl(this, 408), new ProviderImpl(this, 63), this.mSet_32));
+      this.mNode_386Instance = local;
+    }
+    return (Node_386) local;
+  }
+
+  Node_180 accessNode_180() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1093(this.mSet_26, this.cacheNode_190(), new CachingProviderImpl(this, 421), new CachingProviderImpl(this, 360), this.mSet_50, this.accessNode_381(), this.mSet_22, this.accessNode_458(), new ProviderImpl(this, 259), this.accessNode_575(), new ProviderImpl(this, 260), new CachingProviderImpl(this, 229), this.mDependency_601.ep_16()));
+  }
+
+  Node_456 cacheNode_456() {
+    Object local = this.mNode_456Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1094(new ProviderImpl(this, 238), new ProviderImpl(this, 334), new ProviderImpl(this, 63)));
+      this.mNode_456Instance = local;
+    }
+    return (Node_456) local;
+  }
+
+  Node_393 cacheNode_393() {
+    Object local = this.mNode_393Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1095(this.cacheNode_102(), this.accessNode_97(), new ProviderImpl(this, 133), new ProviderImpl(this, 205), new ProviderImpl(this, 61), this.accessNode_467(), new ProviderImpl(this, 482), new CachingProviderImpl(this, 191), new ProviderImpl(this, 468), new CachingProviderImpl(this, 151), this.mDependency_601.ep_3(), new ProviderImpl(this, 488), new CachingProviderImpl(this, 215), new CachingProviderImpl(this, 455), new ProviderImpl(this, 181), new CachingProviderImpl(this, 466), this.cacheNode_376(), new ProviderImpl(this, 410), new CachingProviderImpl(this, 147), new ProviderImpl(this, 323), this.mDependency_601.ep_27(), this.accessNode_59(), new ProviderImpl(this, 369)));
+      this.mNode_393Instance = local;
+    }
+    return (Node_393) local;
+  }
+
+  Node_383 accessNode_383() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1097(this.mSet_28, this.cacheNode_551()));
+  }
+
+  Node_215 cacheNode_215() {
+    Object local = this.mNode_215Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1098());
+      this.mNode_215Instance = local;
+    }
+    return (Node_215) local;
+  }
+
+  Node_397 accessNode_397() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1099(this.accessNode_596(), new ProviderImpl(this, 400), new ProviderImpl(this, 10), this.accessNode_595(), this.accessNode_410(), this.mSet_46, this.mDependency_601.ep_12(), new CachingProviderImpl(this, 396), this.mDependency_601.ep_9(), this.mDependency_601.ep_10(), new ProviderImpl(this, 13)));
+  }
+
+  Node_157 cacheNode_157() {
+    Object local = this.mNode_157Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1100(new ProviderImpl(this, 90), new CachingProviderImpl(this, 366)));
+      this.mNode_157Instance = local;
+    }
+    return (Node_157) local;
+  }
+
+  Node_312 accessNode_312() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1101(this.mSet_50, this.cacheNode_13(), this.mDependency_601.ep_34(), this.mSet_6, new CachingProviderImpl(this, 401), this.accessNode_575(), this.cacheNode_407(), this.accessNode_480(), this.accessNode_517(), new CachingProviderImpl(this, 500), this.cacheNode_578()));
+  }
+
+  Node_11 accessNode_11() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1102(this.mDependency_601.ep_57()));
+  }
+
+  Node_429 cacheNode_429() {
+    Object local = this.mNode_429Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1103(new CachingProviderImpl(this, 120), this.mDependency_601.ep_38(), this.accessNode_59(), new CachingProviderImpl(this, 321), new CachingProviderImpl(this, 300), new ProviderImpl(this, 259), new ProviderImpl(this, 45), this.accessNode_292(), new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 424), this.accessNode_467(), new ProviderImpl(this, 352), new ProviderImpl(this, 131), new CachingProviderImpl(this, 8), this.accessNode_135(), new ProviderImpl(this, 77), this.accessNode_334(), new CachingProviderImpl(this, 173), this.mDependency_601.ep_3(), this.accessNode_219(), new ProviderImpl(this, 447), this.accessNode_439(), this.cacheNode_303()));
+      this.mNode_429Instance = local;
+    }
+    return (Node_429) local;
+  }
+
+  Node_101 accessNode_101() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1104(Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), new ProviderImpl(this, 35), new ProviderImpl(this, 359), this.cacheNode_535(), this.cacheNode_376(), new ProviderImpl(this, 325), new CachingProviderImpl(this, 499), new ProviderImpl(this, 525), new ProviderImpl(this, 334), new CachingProviderImpl(this, 135), this.accessNode_160(), new ProviderImpl(this, 407), this.cacheNode_426(), new CachingProviderImpl(this, 455), new ProviderImpl(this, 136), this.mSet_37, this.mDependency_601.ep_28()));
+  }
+
+  Node_269 accessNode_269() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1105(this.accessNode_96(), this.accessNode_295(), this.accessNode_590(), new CachingProviderImpl(this, 279), new ProviderImpl(this, 467), new CachingProviderImpl(this, 190), this.accessNode_21()));
+  }
+
+  Node_401 accessNode_401() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1106(new CachingProviderImpl(this, 473), this.cacheNode_282(), this.cacheNode_474(), new CachingProviderImpl(this, 8), new ProviderImpl(this, 7), this.accessNode_103(), this.cacheNode_570(), this.mSet_28, this.cacheNode_577(), this.mSet_51, new CachingProviderImpl(this, 356), new ProviderImpl(this, 181), new ProviderImpl(this, 181), this.mSet_46, new CachingProviderImpl(this, 360)));
+  }
+
+  Node_43 accessNode_43() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1107(this.accessNode_399(), this.accessNode_507(), new ProviderImpl(this, 26), new CachingProviderImpl(this, 122), this.cacheNode_550(), new ProviderImpl(this, 287), this.accessNode_134(), this.accessNode_61(), new ProviderImpl(this, 512)));
+  }
+
+  Node_168 accessNode_168() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1108(this.cacheNode_376(), this.mSet_10, this.accessNode_317()));
+  }
+
+  Node_396 accessNode_396() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1109(this.accessNode_297(), new ProviderImpl(this, 381), this.accessNode_164(), this.accessNode_4(), this.accessNode_383(), this.accessNode_300(), this.cacheNode_27(), new ProviderImpl(this, 374), this.accessNode_187(), this.accessNode_439(), new ProviderImpl(this, 98), this.accessNode_507(), this.cacheNode_494(), new CachingProviderImpl(this, 173), this.cacheNode_543(), this.mDependency_601.ep_18(), Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), new CachingProviderImpl(this, 461), new ProviderImpl(this, 437), this.mSet_26, new ProviderImpl(this, 224), this.accessNode_242(), new CachingProviderImpl(this, 43), this.cacheNode_67(), new CachingProviderImpl(this, 44), this.accessNode_235(), this.cacheNode_502()));
+  }
+
+  Node_82 cacheNode_82() {
+    Object local = this.mNode_82Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1110(new ProviderImpl(this, 59), new ProviderImpl(this, 459), this.mDependency_601.ep_39(), this.accessNode_146(), new ProviderImpl(this, 320), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 169), new ProviderImpl(this, 219), this.accessNode_339(), this.accessNode_585(), this.mDependency_601.ep_43()));
+      this.mNode_82Instance = local;
+    }
+    return (Node_82) local;
+  }
+
+  Node_384 accessNode_384() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1111(this.mSet_34, new ProviderImpl(this, 508), new CachingProviderImpl(this, 229), new ProviderImpl(this, 211), this.accessNode_464(), this.mDependency_601.ep_0()));
+  }
+
+  Node_29 accessNode_29() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1112(new ProviderImpl(this, 134), this.accessNode_28(), new ProviderImpl(this, 19), this.accessNode_410(), this.cacheNode_44(), new ProviderImpl(this, 325), this.accessNode_100(), new CachingProviderImpl(this, 461)));
+  }
+
+  Node_265 accessNode_265() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1113(new CachingProviderImpl(this, 147), new CachingProviderImpl(this, 210), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), this.cacheNode_389(), new ProviderImpl(this, 201), this.mSet_9));
+  }
+
+  Node_86 accessNode_86() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1114(this.mSet_43, new CachingProviderImpl(this, 434), new CachingProviderImpl(this, 170), this.accessNode_264(), new CachingProviderImpl(this, 178), this.accessNode_5(), this.mDependency_601.ep_34(), this.accessNode_313(), this.cacheNode_27(), this.cacheNode_2(), new CachingProviderImpl(this, 336), this.mDependency_601.ep_17(), new ProviderImpl(this, 201), this.accessNode_461()));
+  }
+
+  Node_238 cacheNode_238() {
+    Object local = this.mNode_238Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1115(new ProviderImpl(this, 399), this.accessNode_336(), new CachingProviderImpl(this, 58), new ProviderImpl(this, 113), new CachingProviderImpl(this, 278), new CachingProviderImpl(this, 363), new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 32), new CachingProviderImpl(this, 64)));
+      this.mNode_238Instance = local;
+    }
+    return (Node_238) local;
+  }
+
+  Node_517 accessNode_517() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1116(new CachingProviderImpl(this, 497), new ProviderImpl(this, 172), this.cacheNode_212(), new CachingProviderImpl(this, 351), this.cacheNode_498(), new CachingProviderImpl(this, 177), this.cacheNode_151()));
+  }
+
+  Node_218 accessNode_218() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1117(this.mDependency_601.ep_7(), new ProviderImpl(this, 122), new CachingProviderImpl(this, 4), new ProviderImpl(this, 264), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 154), this.mDependency_601.ep_22(), this.mSet_11, this.mSet_46, new CachingProviderImpl(this, 502), this.cacheNode_404(), new CachingProviderImpl(this, 339), new ProviderImpl(this, 181), new CachingProviderImpl(this, 284), this.accessNode_101(), new ProviderImpl(this, 288), new ProviderImpl(this, 139), new CachingProviderImpl(this, 2), new CachingProviderImpl(this, 177), this.accessNode_216(), this.mDependency_601.ep_30(), this.mSet_6, new ProviderImpl(this, 237), new ProviderImpl(this, 110)));
+  }
+
+  Node_372 cacheNode_372() {
+    Object local = this.mNode_372Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1118(this.accessNode_296(), this.accessNode_103(), this.mDependency_601.ep_21(), this.accessNode_515(), this.accessNode_8(), this.cacheNode_333(), this.accessNode_11(), this.cacheNode_576(), new CachingProviderImpl(this, 85), this.cacheNode_325(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 44), this.accessNode_160(), this.cacheNode_450(), this.cacheNode_234(), this.cacheNode_215(), new ProviderImpl(this, 209), this.mDependency_601.ep_16(), new CachingProviderImpl(this, 505), new CachingProviderImpl(this, 159), this.mSet_24, this.accessNode_54(), this.mDependency_601.ep_27()));
+      this.mNode_372Instance = local;
+    }
+    return (Node_372) local;
+  }
+
+  Node_293 accessNode_293() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1119(new ProviderImpl(this, 90), this.accessNode_597(), new ProviderImpl(this, 237), new CachingProviderImpl(this, 328), new ProviderImpl(this, 295), new ProviderImpl(this, 264), new CachingProviderImpl(this, 360), new ProviderImpl(this, 444), new CachingProviderImpl(this, 39), this.mDependency_601.ep_52(), new ProviderImpl(this, 382), this.cacheNode_535(), this.mDependency_601.ep_55(), new CachingProviderImpl(this, 368), new ProviderImpl(this, 343), new CachingProviderImpl(this, 397), new CachingProviderImpl(this, 135), this.accessNode_385(), this.mDependency_601.ep_5(), this.mSet_33, new CachingProviderImpl(this, 4)));
+  }
+
+  Node_360 cacheNode_360() {
+    Object local = this.mNode_360Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1120(new CachingProviderImpl(this, 37), new ProviderImpl(this, 165), this.mDependency_601.ep_35(), new ProviderImpl(this, 55), this.mDependency_601.ep_22(), this.cacheNode_281(), new ProviderImpl(this, 110), this.mDependency_601.ep_45(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 177), this.accessNode_127(), this.mSet_19, new ProviderImpl(this, 161), this.mSet_46, new ProviderImpl(this, 308), new CachingProviderImpl(this, 143), this.mDependency_601.ep_36(), this.mSet_37));
+      this.mNode_360Instance = local;
+    }
+    return (Node_360) local;
+  }
+
+  Node_348 cacheNode_348() {
+    Object local = this.mNode_348Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1121(this.mDependency_601.ep_16(), this.accessNode_211(), new CachingProviderImpl(this, 439), this.cacheNode_273(), new ProviderImpl(this, 43), new ProviderImpl(this, 325), this.mSet_35, this.accessNode_480(), this.accessNode_42(), new CachingProviderImpl(this, 42), new ProviderImpl(this, 90), this.accessNode_487(), new CachingProviderImpl(this, 229), new ProviderImpl(this, 443), new CachingProviderImpl(this, 481), new CachingProviderImpl(this, 120)));
+      this.mNode_348Instance = local;
+    }
+    return (Node_348) local;
+  }
+
+  Node_192 cacheNode_192() {
+    Object local = this.mNode_192Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1122(new ProviderImpl(this, 265), new ProviderImpl(this, 501), new CachingProviderImpl(this, 158), this.mDependency_601.ep_35(), this.accessNode_533(), this.mSet_9, new CachingProviderImpl(this, 347)));
+      this.mNode_192Instance = local;
+    }
+    return (Node_192) local;
+  }
+
+  Node_439 accessNode_439() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1123(new ProviderImpl(this, 86), new ProviderImpl(this, 477), Checks.checkProvisionNotNull(Module_609.Companion.provides_1027()), this.cacheNode_520(), new CachingProviderImpl(this, 166), new CachingProviderImpl(this, 432), this.mDependency_601.ep_8(), new CachingProviderImpl(this, 360), this.accessNode_162(), this.accessNode_367(), this.accessNode_427(), this.accessNode_203(), new CachingProviderImpl(this, 42), this.cacheNode_325(), new CachingProviderImpl(this, 327), this.cacheNode_104(), new CachingProviderImpl(this, 218)));
+  }
+
+  Node_102 cacheNode_102() {
+    Object local = this.mNode_102Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1124(new ProviderImpl(this, 239), new ProviderImpl(this, 447), new ProviderImpl(this, 224), this.mDependency_601.ep_1(), this.cacheNode_599(), new CachingProviderImpl(this, 497), new ProviderImpl(this, 455), new ProviderImpl(this, 511), this.mDependency_601.ep_37(), new ProviderImpl(this, 13), new ProviderImpl(this, 148), this.mSet_23, this.accessNode_595(), this.cacheNode_249(), this.accessNode_51(), this.cacheNode_456(), new CachingProviderImpl(this, 196), new ProviderImpl(this, 456), Checks.checkProvisionNotNull(Module_609.Companion.provides_949()), new ProviderImpl(this, 414), this.cacheNode_366(), this.mDependency_601.ep_19(), new ProviderImpl(this, 118)));
+      this.mNode_102Instance = local;
+    }
+    return (Node_102) local;
+  }
+
+  Node_341 cacheNode_341() {
+    Object local = this.mNode_341Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1125(this.mSet_42, this.accessNode_160(), new ProviderImpl(this, 262), new ProviderImpl(this, 479), new ProviderImpl(this, 406), this.cacheNode_351(), this.cacheNode_457(), this.cacheNode_333(), this.cacheNode_551()));
+      this.mNode_341Instance = local;
+    }
+    return (Node_341) local;
+  }
+
+  Node_201 cacheNode_201() {
+    Object local = this.mNode_201Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1126(this.accessNode_186(), new CachingProviderImpl(this, 142), new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 120), new ProviderImpl(this, 364), this.mDependency_601.ep_50(), new ProviderImpl(this, 216), new CachingProviderImpl(this, 124)));
+      this.mNode_201Instance = local;
+    }
+    return (Node_201) local;
+  }
+
+  Node_424 accessNode_424() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1127(new ProviderImpl(this, 249), this.cacheNode_207(), new CachingProviderImpl(this, 397), this.accessNode_239()));
+  }
+
+  Node_524 cacheNode_524() {
+    Object local = this.mNode_524Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1128(new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 427), new CachingProviderImpl(this, 376), new ProviderImpl(this, 515), this.mSet_16, this.cacheNode_584(), new ProviderImpl(this, 334), this.accessNode_433(), new CachingProviderImpl(this, 231), this.cacheNode_206(), new ProviderImpl(this, 374), this.accessNode_51(), new CachingProviderImpl(this, 240), new CachingProviderImpl(this, 163), this.mDependency_601.ep_1(), new ProviderImpl(this, 200), this.cacheNode_360(), this.accessNode_533(), this.cacheNode_285(), this.mSet_48, new CachingProviderImpl(this, 409), new CachingProviderImpl(this, 368)));
+      this.mNode_524Instance = local;
+    }
+    return (Node_524) local;
+  }
+
+  Node_140 accessNode_140() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1129(this.cacheNode_147(), new ProviderImpl(this, 255), this.mDependency_601.ep_38(), new ProviderImpl(this, 68), this.cacheNode_441(), new CachingProviderImpl(this, 186), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 475), new CachingProviderImpl(this, 200), new ProviderImpl(this, 262), this.cacheNode_328(), this.cacheNode_551(), this.cacheNode_527(), new CachingProviderImpl(this, 70), this.accessNode_512(), this.cacheNode_352(), new ProviderImpl(this, 110), this.accessNode_109(), this.accessNode_334(), this.cacheNode_361(), this.accessNode_558(), new CachingProviderImpl(this, 42)));
+  }
+
+  Node_28 accessNode_28() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1130(this.accessNode_218(), new ProviderImpl(this, 200), new CachingProviderImpl(this, 225), new CachingProviderImpl(this, 333), this.mSet_46, new ProviderImpl(this, 91), new ProviderImpl(this, 417), new CachingProviderImpl(this, 22), new CachingProviderImpl(this, 65), new CachingProviderImpl(this, 363), new CachingProviderImpl(this, 248), new CachingProviderImpl(this, 60), new ProviderImpl(this, 522), new ProviderImpl(this, 426), new ProviderImpl(this, 148), new CachingProviderImpl(this, 405), this.mDependency_601.ep_3(), this.accessNode_160(), new ProviderImpl(this, 152), new CachingProviderImpl(this, 428), new ProviderImpl(this, 437), new CachingProviderImpl(this, 52), new CachingProviderImpl(this, 495), new ProviderImpl(this, 471), new ProviderImpl(this, 46), new ProviderImpl(this, 115), new CachingProviderImpl(this, 456), this.accessNode_504()));
+  }
+
+  Node_374 accessNode_374() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1131(this.mDependency_601.ep_35(), this.cacheNode_415(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 210), this.accessNode_483(), this.accessNode_409(), this.accessNode_166(), this.cacheNode_599(), this.mSet_48, new ProviderImpl(this, 90), this.accessNode_496(), this.cacheNode_420()));
+  }
+
+  Node_443 accessNode_443() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1132(this.cacheNode_543(), new CachingProviderImpl(this, 0), new CachingProviderImpl(this, 478), this.accessNode_340(), this.accessNode_329(), this.accessNode_336(), this.cacheNode_551(), new ProviderImpl(this, 13), new CachingProviderImpl(this, 413)));
+  }
+
+  Node_555 accessNode_555() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1133(this.accessNode_142()));
+  }
+
+  Node_111 cacheNode_111() {
+    Object local = this.mNode_111Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1134(new CachingProviderImpl(this, 368), new ProviderImpl(this, 312), new ProviderImpl(this, 148), this.mSet_10, this.cacheNode_260(), this.mDependency_601.ep_10(), new CachingProviderImpl(this, 360), new ProviderImpl(this, 406), new ProviderImpl(this, 262), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 210), new ProviderImpl(this, 81)));
+      this.mNode_111Instance = local;
+    }
+    return (Node_111) local;
+  }
+
+  Node_242 accessNode_242() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1135(this.mDependency_601.ep_51(), new ProviderImpl(this, 209), new ProviderImpl(this, 410), new ProviderImpl(this, 395), new CachingProviderImpl(this, 404), new CachingProviderImpl(this, 217), new ProviderImpl(this, 135), this.cacheNode_154(), this.accessNode_97(), new CachingProviderImpl(this, 526), new ProviderImpl(this, 181), this.accessNode_292(), new ProviderImpl(this, 334), new CachingProviderImpl(this, 58), new ProviderImpl(this, 438), new ProviderImpl(this, 360), this.mDependency_601.ep_42(), new ProviderImpl(this, 59)));
+  }
+
+  Node_84 cacheNode_84() {
+    Object local = this.mNode_84Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1136(this.mDependency_601.ep_25(), this.cacheNode_537(), this.cacheNode_376(), this.mSet_43, this.accessNode_233(), this.mSet_10, this.cacheNode_468(), this.cacheNode_325(), this.cacheNode_407(), new CachingProviderImpl(this, 409), new CachingProviderImpl(this, 424), new CachingProviderImpl(this, 521), this.cacheNode_535(), this.cacheNode_530(), this.mSet_24, new CachingProviderImpl(this, 70), this.accessNode_186(), this.cacheNode_141(), this.cacheNode_506(), this.accessNode_377(), this.cacheNode_303(), this.mSet_13, this.cacheNode_559(), this.mDependency_601.ep_55(), this.cacheNode_386(), this.cacheNode_494(), new ProviderImpl(this, 410), new ProviderImpl(this, 317), this.cacheNode_353()));
+      this.mNode_84Instance = local;
+    }
+    return (Node_84) local;
+  }
+
+  Node_257 accessNode_257() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1137(this.mSet_1, new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 230), this.accessNode_334(), new CachingProviderImpl(this, 347), new CachingProviderImpl(this, 42), new CachingProviderImpl(this, 500), new ProviderImpl(this, 181), this.cacheNode_238(), new ProviderImpl(this, 352), this.mDependency_601.ep_54(), this.cacheNode_481(), this.mSet_3, this.accessNode_460(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), this.mDependency_601.ep_22(), new CachingProviderImpl(this, 436), new ProviderImpl(this, 297), this.accessNode_548(), this.mDependency_601.ep_20(), this.cacheNode_303(), this.accessNode_339(), new ProviderImpl(this, 24), new ProviderImpl(this, 197), this.mDependency_601.ep_4(), new ProviderImpl(this, 76), new ProviderImpl(this, 182), new ProviderImpl(this, 452), new CachingProviderImpl(this, 180)));
+  }
+
+  Node_445 cacheNode_445() {
+    Object local = this.mNode_445Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1138(this.cacheNode_25(), this.cacheNode_2(), this.cacheNode_282(), this.mDependency_601.ep_40(), this.cacheNode_360(), this.accessNode_28(), new ProviderImpl(this, 356), this.cacheNode_285(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), this.mDependency_601.ep_8(), this.accessNode_179(), this.mSet_7, new CachingProviderImpl(this, 70), this.cacheNode_141(), this.accessNode_213(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1034()), this.mSet_13, this.cacheNode_420(), this.accessNode_573()));
+      this.mNode_445Instance = local;
+    }
+    return (Node_445) local;
+  }
+
+  Node_334 accessNode_334() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1139(new CachingProviderImpl(this, 153), new ProviderImpl(this, 367)));
+  }
+
+  Node_575 accessNode_575() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1140(new ProviderImpl(this, 320), new ProviderImpl(this, 59), new ProviderImpl(this, 485), this.accessNode_395(), this.cacheNode_537(), this.accessNode_555()));
+  }
+
+  Node_536 accessNode_536() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1141(new CachingProviderImpl(this, 147), new CachingProviderImpl(this, 499), this.accessNode_501(), this.mDependency_601.ep_1(), this.accessNode_274(), this.accessNode_419(), this.accessNode_242(), this.accessNode_394()));
+  }
+
+  Node_80 accessNode_80() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_1142(this.accessNode_533(), new ProviderImpl(this, 85), new ProviderImpl(this, 14), this.cacheNode_215(), this.mSet_2, this.accessNode_391(), new CachingProviderImpl(this, 107), this.accessNode_362(), this.accessNode_146(), this.accessNode_61(), this.cacheNode_562(), this.accessNode_162(), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), this.accessNode_274()));
+  }
+
+  Node_333 cacheNode_333() {
+    Object local = this.mNode_333Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1143(new ProviderImpl(this, 125), this.accessNode_218(), new CachingProviderImpl(this, 400), this.mSet_13, new ProviderImpl(this, 90), new ProviderImpl(this, 74), this.accessNode_344(), this.accessNode_222(), this.mSet_8, this.cacheNode_366(), this.cacheNode_67(), this.mDependency_601.ep_20(), this.mDependency_601.ep_57(), new ProviderImpl(this, 63), this.cacheNode_151(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), new ProviderImpl(this, 131), new CachingProviderImpl(this, 147), new ProviderImpl(this, 262), new ProviderImpl(this, 252), this.accessNode_146()));
+      this.mNode_333Instance = local;
+    }
+    return (Node_333) local;
+  }
+
+  Node_137 cacheNode_137() {
+    Object local = this.mNode_137Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1144(Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), this.mDependency_601.ep_24(), new ProviderImpl(this, 152), this.cacheNode_176(), this.mDependency_601.ep_7(), new ProviderImpl(this, 21), new ProviderImpl(this, 117), this.mDependency_601.ep_39(), new CachingProviderImpl(this, 461), this.cacheNode_519(), this.cacheNode_138(), new CachingProviderImpl(this, 196), this.cacheNode_354(), this.cacheNode_71(), this.accessNode_85(), new ProviderImpl(this, 318), this.cacheNode_282(), new ProviderImpl(this, 410), this.accessNode_97(), new ProviderImpl(this, 329), this.accessNode_367(), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 8), this.accessNode_482(), new CachingProviderImpl(this, 177)));
+      this.mNode_137Instance = local;
+    }
+    return (Node_137) local;
+  }
+
+  Node_114 cacheNode_114() {
+    Object local = this.mNode_114Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_1145(this.cacheNode_524(), this.cacheNode_481(), new CachingProviderImpl(this, 351), new CachingProviderImpl(this, 169)));
+      this.mNode_114Instance = local;
+    }
+    return (Node_114) local;
+  }
+
+  Node_288 accessNode_288() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_916(this.mSet_0, new CachingProviderImpl(this, 44), new CachingProviderImpl(this, 49), new ProviderImpl(this, 50), this.cacheNode_212(), new CachingProviderImpl(this, 52), this.mSet_1, new CachingProviderImpl(this, 54), this.cacheNode_551(), this.mDependency_601.ep_39(), new CachingProviderImpl(this, 57), new CachingProviderImpl(this, 58), new ProviderImpl(this, 59), new CachingProviderImpl(this, 60), new ProviderImpl(this, 61), new CachingProviderImpl(this, 62), new ProviderImpl(this, 63), new CachingProviderImpl(this, 64), new CachingProviderImpl(this, 65), this.mDependency_601.ep_42(), this.mSet_2, new CachingProviderImpl(this, 67), new ProviderImpl(this, 68)));
+  }
+
+  Node_275 cacheNode_275() {
+    Object local = this.mNode_275Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_917(new ProviderImpl(this, 144), new CachingProviderImpl(this, 145), this.accessNode_427(), new CachingProviderImpl(this, 147), new ProviderImpl(this, 101), new ProviderImpl(this, 148), this.mDependency_601.ep_54(), this.cacheNode_441(), this.accessNode_515(), this.cacheNode_306(), new ProviderImpl(this, 134), this.cacheNode_104(), new ProviderImpl(this, 125), this.mDependency_601.ep_3(), new ProviderImpl(this, 154), this.mDependency_601.ep_0(), this.accessNode_63(), this.mSet_10, new CachingProviderImpl(this, 156), new ProviderImpl(this, 157), this.accessNode_340(), new CachingProviderImpl(this, 159), new CachingProviderImpl(this, 160)));
+      this.mNode_275Instance = local;
+    }
+    return (Node_275) local;
+  }
+
+  Node_274 accessNode_274() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_918(this.accessNode_42(), this.mSet_12, new CachingProviderImpl(this, 173), new ProviderImpl(this, 169), this.mSet_13, new ProviderImpl(this, 175), this.accessNode_399(), this.cacheNode_306(), new CachingProviderImpl(this, 177), this.mDependency_601.ep_3(), this.accessNode_304(), Checks.checkProvisionNotNull(Module_609.Companion.provides_986()), new CachingProviderImpl(this, 180), new ProviderImpl(this, 76), this.cacheNode_84(), this.mSet_14));
+  }
+
+  Node_207 cacheNode_207() {
+    Object local = this.mNode_207Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_919(new ProviderImpl(this, 44), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 154), new CachingProviderImpl(this, 185), new ProviderImpl(this, 46), new ProviderImpl(this, 24), new CachingProviderImpl(this, 186), new ProviderImpl(this, 187), new CachingProviderImpl(this, 60), new ProviderImpl(this, 91)));
+      this.mNode_207Instance = local;
+    }
+    return (Node_207) local;
+  }
+
+  Node_431 cacheNode_431() {
+    Object local = this.mNode_431Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_920(this.cacheNode_571(), new ProviderImpl(this, 202), this.accessNode_337(), new CachingProviderImpl(this, 159), new ProviderImpl(this, 204), this.cacheNode_426(), this.mDependency_601.ep_12(), this.mDependency_601.ep_44(), this.mSet_15, new ProviderImpl(this, 209), new CachingProviderImpl(this, 210), new ProviderImpl(this, 67), this.mDependency_601.ep_23(), this.cacheNode_154(), this.cacheNode_40(), this.mSet_16, new ProviderImpl(this, 117), new ProviderImpl(this, 213), new ProviderImpl(this, 214), new ProviderImpl(this, 215), this.cacheNode_250(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 217), new CachingProviderImpl(this, 218), new ProviderImpl(this, 219), new CachingProviderImpl(this, 220), new CachingProviderImpl(this, 221), new CachingProviderImpl(this, 23), this.mDependency_601.ep_53()));
+      this.mNode_431Instance = local;
+    }
+    return (Node_431) local;
+  }
+
+  Node_533 accessNode_533() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_921(new ProviderImpl(this, 237), new ProviderImpl(this, 238), new ProviderImpl(this, 90), this.mDependency_601.ep_33(), this.mDependency_601.ep_21(), this.mDependency_601.ep_39(), new ProviderImpl(this, 240), new ProviderImpl(this, 241), this.mSet_32, this.mDependency_601.ep_14(), new ProviderImpl(this, 221), new ProviderImpl(this, 68), new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 242), new ProviderImpl(this, 243), new ProviderImpl(this, 46), new CachingProviderImpl(this, 7), this.mDependency_601.ep_6(), new ProviderImpl(this, 115)));
+  }
+
+  Node_40 cacheNode_40() {
+    Object local = this.mNode_40Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_922());
+      this.mNode_40Instance = local;
+    }
+    return (Node_40) local;
+  }
+
+  Node_122 accessNode_122() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_923(new ProviderImpl(this, 227), this.cacheNode_539(), new ProviderImpl(this, 194)));
+  }
+
+  Node_290 accessNode_290() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_924(this.cacheNode_212(), this.accessNode_93(), new CachingProviderImpl(this, 120), new CachingProviderImpl(this, 316), new CachingProviderImpl(this, 32), new CachingProviderImpl(this, 317), new ProviderImpl(this, 13), new CachingProviderImpl(this, 318), this.accessNode_449(), new ProviderImpl(this, 134), this.cacheNode_351(), new ProviderImpl(this, 274), this.cacheNode_481(), new ProviderImpl(this, 320), new CachingProviderImpl(this, 321), this.accessNode_97(), this.cacheNode_500()));
+  }
+
+  Node_172 cacheNode_172() {
+    Object local = this.mNode_172Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_925(this.accessNode_18(), this.cacheNode_299(), new ProviderImpl(this, 324), new ProviderImpl(this, 325), new ProviderImpl(this, 17), new ProviderImpl(this, 326), new ProviderImpl(this, 132), this.cacheNode_426(), this.cacheNode_250(), new ProviderImpl(this, 214), this.cacheNode_44(), this.accessNode_146(), new ProviderImpl(this, 311), new CachingProviderImpl(this, 196), this.accessNode_438(), this.accessNode_447(), this.cacheNode_282(), this.accessNode_118(), this.cacheNode_212(), new ProviderImpl(this, 117), this.accessNode_332(), new ProviderImpl(this, 47), this.cacheNode_343(), this.accessNode_136(), this.cacheNode_77()));
+      this.mNode_172Instance = local;
+    }
+    return (Node_172) local;
+  }
+
+  Node_543 cacheNode_543() {
+    Object local = this.mNode_543Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_926(new CachingProviderImpl(this, 66), new ProviderImpl(this, 164), this.mDependency_601.ep_54(), this.cacheNode_121(), new Node_181(), this.cacheNode_556(), this.accessNode_233()));
+      this.mNode_543Instance = local;
+    }
+    return (Node_543) local;
+  }
+
+  Node_501 accessNode_501() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_927(this.mSet_23, this.cacheNode_376(), new ProviderImpl(this, 46), new ProviderImpl(this, 344), new ProviderImpl(this, 50), new CachingProviderImpl(this, 89), this.cacheNode_490(), new ProviderImpl(this, 305), this.mSet_26, new CachingProviderImpl(this, 346)));
+  }
+
+  Node_223 accessNode_223() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_928(new ProviderImpl(this, 24), this.accessNode_163(), new ProviderImpl(this, 31), new ProviderImpl(this, 297), this.accessNode_296(), this.mDependency_601.ep_13(), this.accessNode_541(), this.mDependency_601.ep_6(), this.mDependency_601.ep_11()));
+  }
+
+  Node_499 cacheNode_499() {
+    Object local = this.mNode_499Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_929(new ProviderImpl(this, 105), this.cacheNode_273(), new CachingProviderImpl(this, 42), new CachingProviderImpl(this, 351), this.accessNode_385(), new ProviderImpl(this, 352)));
+      this.mNode_499Instance = local;
+    }
+    return (Node_499) local;
+  }
+
+  Node_171 cacheNode_171() {
+    Object local = this.mNode_171Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_930(Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), this.mSet_11, this.accessNode_232(), new CachingProviderImpl(this, 166), new CachingProviderImpl(this, 292), this.mSet_27, new ProviderImpl(this, 312), new ProviderImpl(this, 55), this.accessNode_385(), new ProviderImpl(this, 323), this.cacheNode_267(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), this.mDependency_601.ep_35(), this.accessNode_548(), this.accessNode_480(), this.cacheNode_185(), this.mDependency_601.ep_56(), new ProviderImpl(this, 357)));
+      this.mNode_171Instance = local;
+    }
+    return (Node_171) local;
+  }
+
+  Node_343 cacheNode_343() {
+    Object local = this.mNode_343Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_931(new ProviderImpl(this, 48), this.mSet_28, this.cacheNode_271(), this.mDependency_601.ep_47(), this.cacheNode_457(), new CachingProviderImpl(this, 360), this.cacheNode_570(), this.cacheNode_104(), this.cacheNode_441(), this.cacheNode_421(), new CachingProviderImpl(this, 3), this.accessNode_460(), this.accessNode_179(), this.accessNode_595(), this.mDependency_601.ep_15(), this.accessNode_590(), new CachingProviderImpl(this, 363), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.mSet_29, this.mSet_2, this.mDependency_601.ep_42(), this.cacheNode_565(), this.accessNode_362()));
+      this.mNode_343Instance = local;
+    }
+    return (Node_343) local;
+  }
+
+  Node_473 accessNode_473() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_932(this.mSet_46, new ProviderImpl(this, 80), this.accessNode_134(), this.accessNode_85(), new ProviderImpl(this, 368), this.mDependency_601.ep_28(), new ProviderImpl(this, 369), this.mSet_7, new CachingProviderImpl(this, 142), new CachingProviderImpl(this, 62), new ProviderImpl(this, 24), new ProviderImpl(this, 134), new CachingProviderImpl(this, 5), new CachingProviderImpl(this, 228), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 370), new ProviderImpl(this, 130), this.accessNode_239(), this.accessNode_59(), new CachingProviderImpl(this, 170), this.accessNode_590(), this.accessNode_23(), this.cacheNode_243(), new CachingProviderImpl(this, 372), new ProviderImpl(this, 125), new CachingProviderImpl(this, 47), this.cacheNode_531(), this.cacheNode_599(), new ProviderImpl(this, 23), this.cacheNode_593()));
+  }
+
+  Node_115 accessNode_115() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_933(new ProviderImpl(this, 374), this.mSet_30, this.mDependency_601.ep_14(), new ProviderImpl(this, 6), this.accessNode_433(), new CachingProviderImpl(this, 376), new CachingProviderImpl(this, 153), this.cacheNode_364(), new CachingProviderImpl(this, 119), this.mDependency_601.ep_19(), new ProviderImpl(this, 15), new ProviderImpl(this, 276), new CachingProviderImpl(this, 94), this.mSet_31, new CachingProviderImpl(this, 351), new ProviderImpl(this, 99), this.mSet_25, this.accessNode_216(), new CachingProviderImpl(this, 173), new ProviderImpl(this, 297), new CachingProviderImpl(this, 87), new ProviderImpl(this, 334), new ProviderImpl(this, 369), this.mDependency_601.ep_12(), new ProviderImpl(this, 314), new ProviderImpl(this, 110)));
+  }
+
+  Node_182 accessNode_182() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_934(this.mDependency_601.ep_25(), this.cacheNode_121(), this.mDependency_601.ep_22(), this.accessNode_425(), new CachingProviderImpl(this, 274), this.accessNode_107(), this.mDependency_601.ep_14(), this.mDependency_601.ep_20(), this.cacheNode_27(), this.accessNode_113(), this.accessNode_225(), new CachingProviderImpl(this, 103), this.mSet_21, this.mSet_1, new ProviderImpl(this, 381), new ProviderImpl(this, 299)));
+  }
+
+  Node_193 cacheNode_193() {
+    Object local = this.mNode_193Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_935(new CachingProviderImpl(this, 58), this.mSet_18, this.cacheNode_150()));
+      this.mNode_193Instance = local;
+    }
+    return (Node_193) local;
+  }
+
+  Node_249 cacheNode_249() {
+    Object local = this.mNode_249Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_936(this.accessNode_127(), new CachingProviderImpl(this, 336), new CachingProviderImpl(this, 382)));
+      this.mNode_249Instance = local;
+    }
+    return (Node_249) local;
+  }
+
+  Node_146 accessNode_146() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_937(new CachingProviderImpl(this, 400), this.accessNode_590(), new ProviderImpl(this, 264), this.accessNode_433(), this.accessNode_439(), this.accessNode_184(), new ProviderImpl(this, 320), this.cacheNode_364(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), this.cacheNode_25(), this.mDependency_601.ep_26(), new CachingProviderImpl(this, 402), new ProviderImpl(this, 393), this.cacheNode_27(), new CachingProviderImpl(this, 403), this.mDependency_601.ep_16(), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 405)));
+  }
+
+  Node_351 cacheNode_351() {
+    Object local = this.mNode_351Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_938(this.mDependency_601.ep_33(), new ProviderImpl(this, 406), new CachingProviderImpl(this, 347), new ProviderImpl(this, 194), this.mSet_6, new ProviderImpl(this, 13), new CachingProviderImpl(this, 407), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 335), this.cacheNode_286()));
+      this.mNode_351Instance = local;
+    }
+    return (Node_351) local;
+  }
+
+  Node_551 cacheNode_551() {
+    Object local = this.mNode_551Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_939());
+      this.mNode_551Instance = local;
+    }
+    return (Node_551) local;
+  }
+
+  Node_358 accessNode_358() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_940(new ProviderImpl(this, 274), this.accessNode_507(), new CachingProviderImpl(this, 71), new ProviderImpl(this, 221)));
+  }
+
+  Node_566 cacheNode_566() {
+    Object local = this.mNode_566Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_941(this.accessNode_164(), this.cacheNode_589(), new CachingProviderImpl(this, 415), new CachingProviderImpl(this, 122), this.cacheNode_13()));
+      this.mNode_566Instance = local;
+    }
+    return (Node_566) local;
+  }
+
+  Node_135 accessNode_135() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_942(new CachingProviderImpl(this, 398), this.mDependency_601.ep_10(), new ProviderImpl(this, 291), new CachingProviderImpl(this, 339), new CachingProviderImpl(this, 413), new CachingProviderImpl(this, 292), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), this.mSet_22, new CachingProviderImpl(this, 391), new ProviderImpl(this, 290), new ProviderImpl(this, 63), new ProviderImpl(this, 359), this.cacheNode_207(), new ProviderImpl(this, 276), new CachingProviderImpl(this, 360), this.cacheNode_328(), new ProviderImpl(this, 354), new ProviderImpl(this, 115), this.mSet_23, this.cacheNode_364(), new CachingProviderImpl(this, 57), new ProviderImpl(this, 38), new CachingProviderImpl(this, 87), this.cacheNode_284(), this.mSet_14, new CachingProviderImpl(this, 390), this.accessNode_329(), new CachingProviderImpl(this, 417)));
+  }
+
+  Node_162 accessNode_162() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_943(new ProviderImpl(this, 68), this.cacheNode_44(), new ProviderImpl(this, 80), new ProviderImpl(this, 1), new CachingProviderImpl(this, 206), new CachingProviderImpl(this, 382), this.cacheNode_474(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), new CachingProviderImpl(this, 428), this.accessNode_18(), this.cacheNode_570(), new CachingProviderImpl(this, 178), new ProviderImpl(this, 406), this.mDependency_601.ep_33(), this.mDependency_601.ep_48()));
+  }
+
+  Node_487 accessNode_487() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_944(new ProviderImpl(this, 429), this.mSet_2, new CachingProviderImpl(this, 114), new CachingProviderImpl(this, 94), this.cacheNode_40(), new CachingProviderImpl(this, 8), this.cacheNode_193(), this.mDependency_601.ep_36(), new ProviderImpl(this, 141), this.accessNode_4(), new ProviderImpl(this, 293), new ProviderImpl(this, 113), new ProviderImpl(this, 431), new CachingProviderImpl(this, 432), this.cacheNode_560(), new CachingProviderImpl(this, 407), new CachingProviderImpl(this, 11), new CachingProviderImpl(this, 434)));
+  }
+
+  Node_26 accessNode_26() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_945(new ProviderImpl(this, 81), this.cacheNode_44(), this.cacheNode_44(), new ProviderImpl(this, 435), this.cacheNode_104(), this.cacheNode_535(), new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 70), this.cacheNode_121(), new ProviderImpl(this, 437), new ProviderImpl(this, 357), new ProviderImpl(this, 198), new CachingProviderImpl(this, 210), new ProviderImpl(this, 271), new ProviderImpl(this, 438), new ProviderImpl(this, 257), new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 336), new CachingProviderImpl(this, 169), new CachingProviderImpl(this, 124), new ProviderImpl(this, 440), this.accessNode_136()));
+  }
+
+  Node_508 cacheNode_508() {
+    Object local = this.mNode_508Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_946(new CachingProviderImpl(this, 169), this.mDependency_601.ep_18(), this.cacheNode_481(), this.cacheNode_422(), this.mSet_13, this.cacheNode_547(), new CachingProviderImpl(this, 218), new ProviderImpl(this, 441), this.accessNode_264(), this.accessNode_219(), new ProviderImpl(this, 24), Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), this.accessNode_148(), this.accessNode_534(), new ProviderImpl(this, 130), this.cacheNode_150(), new ProviderImpl(this, 249), this.cacheNode_386(), new ProviderImpl(this, 444), this.accessNode_46()));
+      this.mNode_508Instance = local;
+    }
+    return (Node_508) local;
+  }
+
+  Node_332 accessNode_332() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_947(Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.accessNode_515(), this.accessNode_416()));
+  }
+
+  Node_364 cacheNode_364() {
+    Object local = this.mNode_364Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_948(new ProviderImpl(this, 104), new ProviderImpl(this, 27), this.mDependency_601.ep_35(), new ProviderImpl(this, 74), new CachingProviderImpl(this, 170), new ProviderImpl(this, 229), this.cacheNode_421(), new ProviderImpl(this, 172), new CachingProviderImpl(this, 454), this.cacheNode_528(), new CachingProviderImpl(this, 316), this.mDependency_601.ep_6(), new ProviderImpl(this, 225), new ProviderImpl(this, 429), new ProviderImpl(this, 272)));
+      this.mNode_364Instance = local;
+    }
+    return (Node_364) local;
+  }
+
+  Node_92 cacheNode_92() {
+    Object local = this.mNode_92Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_950(new CachingProviderImpl(this, 421)));
+      this.mNode_92Instance = local;
+    }
+    return (Node_92) local;
+  }
+
+  Node_2 cacheNode_2() {
+    Object local = this.mNode_2Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_951());
+      this.mNode_2Instance = local;
+    }
+    return (Node_2) local;
+  }
+
+  Node_153 cacheNode_153() {
+    Object local = this.mNode_153Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_952(this.cacheNode_404(), new ProviderImpl(this, 101), this.cacheNode_364(), new CachingProviderImpl(this, 339), this.mSet_39, this.cacheNode_342(), this.mDependency_601.ep_13(), new ProviderImpl(this, 202), this.cacheNode_244(), this.accessNode_590(), this.accessNode_11(), this.cacheNode_351(), new Node_181(), this.accessNode_168()));
+      this.mNode_153Instance = local;
+    }
+    return (Node_153) local;
+  }
+
+  Node_44 cacheNode_44() {
+    Object local = this.mNode_44Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_953(this.accessNode_518(), new CachingProviderImpl(this, 124), new CachingProviderImpl(this, 44), new CachingProviderImpl(this, 179), new CachingProviderImpl(this, 397), new CachingProviderImpl(this, 321), new CachingProviderImpl(this, 316), this.accessNode_309(), new ProviderImpl(this, 261), this.mSet_34));
+      this.mNode_44Instance = local;
+    }
+    return (Node_44) local;
+  }
+
+  Node_185 cacheNode_185() {
+    Object local = this.mNode_185Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_954(new ProviderImpl(this, 72), this.cacheNode_586(), new ProviderImpl(this, 125), this.cacheNode_82(), new ProviderImpl(this, 10), new CachingProviderImpl(this, 159), new ProviderImpl(this, 76), this.accessNode_160(), new CachingProviderImpl(this, 473), this.mSet_40, new ProviderImpl(this, 329), new ProviderImpl(this, 183), this.mSet_24, this.mSet_3));
+      this.mNode_185Instance = local;
+    }
+    return (Node_185) local;
+  }
+
+  Node_461 accessNode_461() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_955(this.mSet_41, this.cacheNode_325(), this.mSet_23, new CachingProviderImpl(this, 89), this.mSet_12, this.accessNode_214(), this.cacheNode_206(), this.accessNode_367(), new ProviderImpl(this, 320), this.accessNode_179(), this.accessNode_106(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), this.accessNode_510(), new CachingProviderImpl(this, 456), new ProviderImpl(this, 305), new ProviderImpl(this, 138), this.accessNode_16(), this.accessNode_186(), new CachingProviderImpl(this, 402), new CachingProviderImpl(this, 478), this.accessNode_103()));
+  }
+
+  Node_330 accessNode_330() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_956(new ProviderImpl(this, 132), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), new ProviderImpl(this, 357), this.cacheNode_72(), this.mDependency_601.ep_57()));
+  }
+
+  Node_186 accessNode_186() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_957(new ProviderImpl(this, 82), new ProviderImpl(this, 128), this.mSet_16, new ProviderImpl(this, 419), this.cacheNode_238(), new CachingProviderImpl(this, 464), new ProviderImpl(this, 453), this.accessNode_16(), this.mDependency_601.ep_17(), new CachingProviderImpl(this, 96)));
+  }
+
+  Node_307 cacheNode_307() {
+    Object local = this.mNode_307Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_958(new CachingProviderImpl(this, 177), this.mSet_4, new ProviderImpl(this, 376), this.accessNode_433(), new CachingProviderImpl(this, 407), this.cacheNode_441(), new ProviderImpl(this, 117), new ProviderImpl(this, 200), new ProviderImpl(this, 133), this.cacheNode_506(), new ProviderImpl(this, 78), new CachingProviderImpl(this, 422), this.accessNode_134(), this.mDependency_601.ep_52(), new ProviderImpl(this, 449), this.accessNode_383(), new CachingProviderImpl(this, 156), this.cacheNode_72(), new ProviderImpl(this, 392), this.accessNode_298(), new ProviderImpl(this, 9), new CachingProviderImpl(this, 316), this.cacheNode_22(), this.accessNode_146(), this.accessNode_122()));
+      this.mNode_307Instance = local;
+    }
+    return (Node_307) local;
+  }
+
+  Node_197 cacheNode_197() {
+    Object local = this.mNode_197Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_959(this.cacheNode_393(), this.mDependency_601.ep_51(), this.cacheNode_376(), new CachingProviderImpl(this, 481), this.accessNode_332()));
+      this.mNode_197Instance = local;
+    }
+    return (Node_197) local;
+  }
+
+  Node_564 accessNode_564() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_961(this.accessNode_184(), new ProviderImpl(this, 482), this.accessNode_85(), new CachingProviderImpl(this, 397), this.mDependency_601.ep_35(), this.accessNode_56(), new ProviderImpl(this, 303), this.cacheNode_360(), new ProviderImpl(this, 283), new ProviderImpl(this, 310), this.mDependency_601.ep_24(), this.accessNode_134(), this.cacheNode_44(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1033()), new CachingProviderImpl(this, 409), this.accessNode_598(), this.accessNode_233(), new ProviderImpl(this, 187), this.cacheNode_561()));
+  }
+
+  Node_422 cacheNode_422() {
+    Object local = this.mNode_422Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_962(new ProviderImpl(this, 40), this.accessNode_162(), new CachingProviderImpl(this, 210), this.mDependency_601.ep_2(), this.mDependency_601.ep_26(), new ProviderImpl(this, 286), this.cacheNode_206(), new CachingProviderImpl(this, 363), this.cacheNode_207(), new ProviderImpl(this, 90), new CachingProviderImpl(this, 8), new ProviderImpl(this, 78), this.mSet_26, new CachingProviderImpl(this, 315), new CachingProviderImpl(this, 427), new CachingProviderImpl(this, 160), this.mDependency_601.ep_9(), this.mSet_13, new ProviderImpl(this, 312), this.mSet_3, this.cacheNode_192(), new CachingProviderImpl(this, 284), new ProviderImpl(this, 238), this.accessNode_126()));
+      this.mNode_422Instance = local;
+    }
+    return (Node_422) local;
+  }
+
+  Node_27 cacheNode_27() {
+    Object local = this.mNode_27Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_963(this.mSet_33, this.accessNode_179(), new ProviderImpl(this, 433), this.cacheNode_376(), new CachingProviderImpl(this, 70), this.cacheNode_201(), new ProviderImpl(this, 490), new CachingProviderImpl(this, 409), this.mSet_2, this.mDependency_601.ep_31(), new ProviderImpl(this, 111), this.mSet_10));
+      this.mNode_27Instance = local;
+    }
+    return (Node_27) local;
+  }
+
+  Node_261 cacheNode_261() {
+    Object local = this.mNode_261Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_964(this.cacheNode_547(), new CachingProviderImpl(this, 492), this.mSet_21, this.accessNode_96(), this.accessNode_384(), new ProviderImpl(this, 487)));
+      this.mNode_261Instance = local;
+    }
+    return (Node_261) local;
+  }
+
+  Node_450 cacheNode_450() {
+    Object local = this.mNode_450Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_965(new ProviderImpl(this, 493)));
+      this.mNode_450Instance = local;
+    }
+    return (Node_450) local;
+  }
+
+  Node_518 accessNode_518() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_966(new CachingProviderImpl(this, 456), this.mSet_10, new CachingProviderImpl(this, 168), this.accessNode_5(), new ProviderImpl(this, 133), this.accessNode_97(), this.cacheNode_479(), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 113)));
+  }
+
+  Node_482 accessNode_482() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_967(new ProviderImpl(this, 332), this.accessNode_492(), this.accessNode_274(), new ProviderImpl(this, 90), new CachingProviderImpl(this, 39), this.accessNode_458(), new CachingProviderImpl(this, 313), this.accessNode_439(), this.accessNode_269(), this.accessNode_105(), this.accessNode_473(), new ProviderImpl(this, 210), new CachingProviderImpl(this, 170), this.accessNode_140(), this.cacheNode_231(), this.mSet_10));
+  }
+
+  Node_379 accessNode_379() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_968(this.cacheNode_348(), this.mSet_25, this.accessNode_375(), this.cacheNode_275(), this.mDependency_601.ep_38(), new ProviderImpl(this, 452), new CachingProviderImpl(this, 456), this.cacheNode_347(), this.mSet_45, this.accessNode_54(), this.cacheNode_457(), new CachingProviderImpl(this, 216), this.mDependency_601.ep_14(), this.accessNode_21(), this.accessNode_447(), this.accessNode_362(), new ProviderImpl(this, 12), this.accessNode_146(), this.mDependency_601.ep_55(), this.mDependency_601.ep_41(), this.cacheNode_354(), this.cacheNode_566(), this.mDependency_601.ep_33(), new ProviderImpl(this, 497), this.mSet_13, this.mDependency_601.ep_1()));
+  }
+
+  Node_376 cacheNode_376() {
+    Object local = this.mNode_376Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_969());
+      this.mNode_376Instance = local;
+    }
+    return (Node_376) local;
+  }
+
+  Node_577 cacheNode_577() {
+    Object local = this.mNode_577Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_970(this.mSet_3, this.accessNode_26(), this.accessNode_216(), this.mDependency_601.ep_47(), this.cacheNode_299()));
+      this.mNode_577Instance = local;
+    }
+    return (Node_577) local;
+  }
+
+  Node_420 cacheNode_420() {
+    Object local = this.mNode_420Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_971(this.mDependency_601.ep_53(), new ProviderImpl(this, 89), this.accessNode_339(), new ProviderImpl(this, 237), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), this.accessNode_51(), this.accessNode_529(), this.mDependency_601.ep_4(), this.accessNode_405(), new ProviderImpl(this, 417), this.accessNode_182()));
+      this.mNode_420Instance = local;
+    }
+    return (Node_420) local;
+  }
+
+  Node_87 cacheNode_87() {
+    Object local = this.mNode_87Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_972());
+      this.mNode_87Instance = local;
+    }
+    return (Node_87) local;
+  }
+
+  Node_167 cacheNode_167() {
+    Object local = this.mNode_167Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_973());
+      this.mNode_167Instance = local;
+    }
+    return (Node_167) local;
+  }
+
+  Node_466 cacheNode_466() {
+    Object local = this.mNode_466Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_974(new CachingProviderImpl(this, 27), this.cacheNode_131(), this.accessNode_485(), new ProviderImpl(this, 330), new CachingProviderImpl(this, 44), this.accessNode_461(), this.accessNode_424(), this.cacheNode_422(), this.cacheNode_421(), this.accessNode_89(), this.cacheNode_198(), this.cacheNode_260(), new ProviderImpl(this, 162), this.mDependency_601.ep_48(), this.accessNode_219(), this.cacheNode_498(), new ProviderImpl(this, 482), this.accessNode_48(), new CachingProviderImpl(this, 462)));
+      this.mNode_466Instance = local;
+    }
+    return (Node_466) local;
+  }
+
+  Node_89 accessNode_89() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_976(this.accessNode_496(), new ProviderImpl(this, 488), this.mSet_46, this.cacheNode_386(), this.accessNode_101(), this.cacheNode_456(), new ProviderImpl(this, 35), this.mSet_9, new ProviderImpl(this, 356), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), this.accessNode_515(), new CachingProviderImpl(this, 147), new ProviderImpl(this, 181), new ProviderImpl(this, 332), this.accessNode_470(), this.accessNode_418(), this.accessNode_222(), this.cacheNode_121(), new ProviderImpl(this, 10), new ProviderImpl(this, 352), new CachingProviderImpl(this, 103), this.accessNode_473(), new CachingProviderImpl(this, 149), this.mSet_30, new CachingProviderImpl(this, 221)));
+  }
+
+  Node_150 cacheNode_150() {
+    Object local = this.mNode_150Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_977(this.accessNode_497(), this.cacheNode_104(), new ProviderImpl(this, 202), this.accessNode_329(), new CachingProviderImpl(this, 97), new CachingProviderImpl(this, 430), new ProviderImpl(this, 220), new ProviderImpl(this, 238), this.cacheNode_565()));
+      this.mNode_150Instance = local;
+    }
+    return (Node_150) local;
+  }
+
+  Node_314 accessNode_314() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_978(this.cacheNode_527(), this.cacheNode_147(), new ProviderImpl(this, 213), this.cacheNode_22(), this.cacheNode_561(), new ProviderImpl(this, 131), this.cacheNode_511(), this.cacheNode_551(), this.cacheNode_372(), new CachingProviderImpl(this, 70)));
+  }
+
+  Node_306 cacheNode_306() {
+    Object local = this.mNode_306Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_979(new CachingProviderImpl(this, 503), new ProviderImpl(this, 508), new CachingProviderImpl(this, 285), new ProviderImpl(this, 110), this.accessNode_242(), new CachingProviderImpl(this, 169)));
+      this.mNode_306Instance = local;
+    }
+    return (Node_306) local;
+  }
+
+  Node_139 accessNode_139() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_980(new ProviderImpl(this, 209), new CachingProviderImpl(this, 390), this.accessNode_232(), new ProviderImpl(this, 449), new CachingProviderImpl(this, 313), new CachingProviderImpl(this, 466), new ProviderImpl(this, 33), this.cacheNode_535(), new CachingProviderImpl(this, 434), this.cacheNode_366(), new ProviderImpl(this, 490), this.mSet_5, new ProviderImpl(this, 419), this.cacheNode_591(), new ProviderImpl(this, 78), new CachingProviderImpl(this, 120), new ProviderImpl(this, 165), new ProviderImpl(this, 359), new CachingProviderImpl(this, 20), new ProviderImpl(this, 70), new ProviderImpl(this, 66), this.mDependency_601.ep_49(), this.accessNode_358()));
+  }
+
+  Node_340 accessNode_340() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_981(this.mDependency_601.ep_40(), new ProviderImpl(this, 78), this.cacheNode_450(), new ProviderImpl(this, 320), new ProviderImpl(this, 329), new ProviderImpl(this, 463), new CachingProviderImpl(this, 454), this.cacheNode_426(), new CachingProviderImpl(this, 177), new ProviderImpl(this, 110), new ProviderImpl(this, 219), new CachingProviderImpl(this, 196), this.mSet_44, new ProviderImpl(this, 288), new CachingProviderImpl(this, 120), new ProviderImpl(this, 181), this.mSet_23, new CachingProviderImpl(this, 351)));
+  }
+
+  Node_166 accessNode_166() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_982(new CachingProviderImpl(this, 465), new CachingProviderImpl(this, 70), this.accessNode_564(), this.mDependency_601.ep_52(), this.accessNode_103(), this.mDependency_601.ep_54(), this.cacheNode_123(), new CachingProviderImpl(this, 318), this.accessNode_314(), this.accessNode_534(), this.cacheNode_589(), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 119), this.cacheNode_349()));
+  }
+
+  Node_128 accessNode_128() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_983(this.accessNode_430(), this.mSet_31, this.accessNode_257(), this.accessNode_233(), this.mDependency_601.ep_43(), this.accessNode_113(), this.accessNode_29(), this.cacheNode_488()));
+  }
+
+  Node_464 accessNode_464() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_984(this.cacheNode_559(), this.accessNode_558(), this.cacheNode_282(), this.mSet_10, new CachingProviderImpl(this, 316), this.cacheNode_468(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052())));
+  }
+
+  Node_304 accessNode_304() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_985(new ProviderImpl(this, 294), this.accessNode_358(), this.mSet_7, this.accessNode_517(), this.accessNode_37(), this.mSet_46, new CachingProviderImpl(this, 218), this.accessNode_239(), this.accessNode_596(), this.mSet_50, new ProviderImpl(this, 39), new CachingProviderImpl(this, 189), this.accessNode_558(), new ProviderImpl(this, 120), this.cacheNode_318()));
+  }
+
+  Node_160 accessNode_160() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_987(this.mSet_33, this.mDependency_601.ep_48(), new CachingProviderImpl(this, 103), this.mDependency_601.ep_55(), new ProviderImpl(this, 389), this.mDependency_601.ep_7()));
+  }
+
+  Node_492 accessNode_492() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_988(this.accessNode_209(), this.accessNode_595(), new ProviderImpl(this, 268), new ProviderImpl(this, 134), this.mDependency_601.ep_37(), this.mSet_32, this.mDependency_601.ep_30(), new CachingProviderImpl(this, 1), new CachingProviderImpl(this, 523), new CachingProviderImpl(this, 231), this.cacheNode_154(), new ProviderImpl(this, 509), new ProviderImpl(this, 250), this.mSet_0, new ProviderImpl(this, 194), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 22), this.mDependency_601.ep_29(), this.cacheNode_521(), this.mDependency_601.ep_32(), new ProviderImpl(this, 50), this.accessNode_391(), this.cacheNode_167(), new CachingProviderImpl(this, 510), new ProviderImpl(this, 29), this.mSet_51, new CachingProviderImpl(this, 470), new CachingProviderImpl(this, 43), new ProviderImpl(this, 55), new CachingProviderImpl(this, 409)));
+  }
+
+  Node_8 accessNode_8() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_989(this.accessNode_101(), this.mDependency_601.ep_4(), new CachingProviderImpl(this, 189), new CachingProviderImpl(this, 142), new ProviderImpl(this, 259), new ProviderImpl(this, 90), this.cacheNode_44(), this.mSet_9, this.mSet_8, this.cacheNode_571(), new CachingProviderImpl(this, 178), new CachingProviderImpl(this, 196), new ProviderImpl(this, 169), new CachingProviderImpl(this, 412), new ProviderImpl(this, 343), new CachingProviderImpl(this, 58), this.mSet_15, this.cacheNode_413(), new ProviderImpl(this, 221), new ProviderImpl(this, 5), this.mDependency_601.ep_10()));
+  }
+
+  Node_531 cacheNode_531() {
+    Object local = this.mNode_531Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_990(new ProviderImpl(this, 450), new CachingProviderImpl(this, 385), new ProviderImpl(this, 63), new ProviderImpl(this, 181), new ProviderImpl(this, 63), new ProviderImpl(this, 299), this.mDependency_601.ep_30(), this.cacheNode_328(), this.accessNode_51()));
+      this.mNode_531Instance = local;
+    }
+    return (Node_531) local;
+  }
+
+  Node_305 accessNode_305() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_991(new ProviderImpl(this, 421), this.mSet_39));
+  }
+
+  Node_375 accessNode_375() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_992(new CachingProviderImpl(this, 351), new CachingProviderImpl(this, 57), new CachingProviderImpl(this, 170), this.mDependency_601.ep_21(), this.mSet_31, this.accessNode_211(), new ProviderImpl(this, 301), this.accessNode_239(), new CachingProviderImpl(this, 43), this.accessNode_106(), this.mSet_30, new ProviderImpl(this, 111), this.mDependency_601.ep_32(), new ProviderImpl(this, 104), new ProviderImpl(this, 337), new CachingProviderImpl(this, 384), new CachingProviderImpl(this, 65), this.cacheNode_152()));
+  }
+
+  Node_571 cacheNode_571() {
+    Object local = this.mNode_571Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_993(new ProviderImpl(this, 115), new CachingProviderImpl(this, 432), new ProviderImpl(this, 348), new ProviderImpl(this, 392), new ProviderImpl(this, 310), new ProviderImpl(this, 303), new CachingProviderImpl(this, 121), new ProviderImpl(this, 266), new CachingProviderImpl(this, 473), new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 217), new CachingProviderImpl(this, 87), new CachingProviderImpl(this, 154), this.mSet_11, this.accessNode_597(), new CachingProviderImpl(this, 347), new ProviderImpl(this, 404), new CachingProviderImpl(this, 210), new ProviderImpl(this, 314), new ProviderImpl(this, 125), new CachingProviderImpl(this, 417), new ProviderImpl(this, 159), this.cacheNode_506(), new ProviderImpl(this, 501), this.cacheNode_238(), new ProviderImpl(this, 342), new ProviderImpl(this, 100)));
+      this.mNode_571Instance = local;
+    }
+    return (Node_571) local;
+  }
+
+  Node_282 cacheNode_282() {
+    Object local = this.mNode_282Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_994(this.mDependency_601.ep_31(), this.cacheNode_316()));
+      this.mNode_282Instance = local;
+    }
+    return (Node_282) local;
+  }
+
+  Node_338 accessNode_338() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_995(new CachingProviderImpl(this, 240), this.accessNode_337(), this.accessNode_16(), this.accessNode_136(), this.accessNode_139(), this.accessNode_105(), this.cacheNode_275(), this.mSet_32, this.accessNode_93(), this.cacheNode_556(), this.mDependency_601.ep_31(), this.cacheNode_104(), this.cacheNode_429(), this.accessNode_56(), this.mDependency_601.ep_0(), this.accessNode_274(), new ProviderImpl(this, 296), new CachingProviderImpl(this, 27), this.cacheNode_131(), new CachingProviderImpl(this, 360), this.cacheNode_198(), this.cacheNode_307(), this.mSet_51, new ProviderImpl(this, 401), this.cacheNode_284(), this.cacheNode_319(), this.mDependency_601.ep_43(), this.mSet_16, this.mSet_19));
+  }
+
+  Node_154 cacheNode_154() {
+    Object local = this.mNode_154Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_609.Companion.provides_996(this.cacheNode_192(), new CachingProviderImpl(this, 360), this.mDependency_601.ep_17(), new ProviderImpl(this, 93), new ProviderImpl(this, 144)));
+      this.mNode_154Instance = local;
+    }
+    return (Node_154) local;
+  }
+
+  Node_362 accessNode_362() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_998(this.mDependency_601.ep_30(), this.accessNode_399(), this.accessNode_385(), new CachingProviderImpl(this, 103), new CachingProviderImpl(this, 39), this.cacheNode_6(), this.cacheNode_87(), new ProviderImpl(this, 74), this.accessNode_51(), this.cacheNode_121(), this.mDependency_601.ep_35(), new CachingProviderImpl(this, 427), this.cacheNode_190(), this.cacheNode_576(), new ProviderImpl(this, 439), new CachingProviderImpl(this, 322), new CachingProviderImpl(this, 435), this.cacheNode_67(), this.cacheNode_15(), this.accessNode_175(), new ProviderImpl(this, 117), this.accessNode_122(), this.accessNode_598(), new ProviderImpl(this, 91)));
+  }
+
+  Node_37 accessNode_37() {
+    return Checks.checkProvisionNotNull(Module_609.Companion.provides_999(new CachingProviderImpl(this, 44), new CachingProviderImpl(this, 368), this.cacheNode_267(), new ProviderImpl(this, 441), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 229), new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 430), this.accessNode_133(), new ProviderImpl(this, 449), this.accessNode_381(), new ProviderImpl(this, 472), new ProviderImpl(this, 482), this.cacheNode_584(), new ProviderImpl(this, 238), this.mSet_8, new ProviderImpl(this, 504), this.accessNode_297(), this.mDependency_601.ep_27(), new ProviderImpl(this, 420), new ProviderImpl(this, 299), new CachingProviderImpl(this, 386)));
+  }
+
+  Node_104 cacheNode_104() {
+    Object local = this.mNode_104Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_104(this.cacheNode_520(), new ProviderImpl(this, 224), this.mDependency_601.ep_56(), this.cacheNode_551(), new CachingProviderImpl(this, 154), this.accessNode_340(), new ProviderImpl(this, 192), this.accessNode_51(), new ProviderImpl(this, 99), new CachingProviderImpl(this, 225), new ProviderImpl(this, 226), this.accessNode_133(), this.mSet_23, new CachingProviderImpl(this, 229), this.mDependency_601.ep_50(), this.accessNode_419(), new CachingProviderImpl(this, 230), new CachingProviderImpl(this, 231), this.cacheNode_422(), new CachingProviderImpl(this, 232));
+      this.mNode_104Instance = local;
+    }
+    return (Node_104) local;
+  }
+
+  Node_105 accessNode_105() {
+    return new Node_105(new ProviderImpl(this, 514), new ProviderImpl(this, 78), new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 439), new ProviderImpl(this, 443), new CachingProviderImpl(this, 398), this.mDependency_601.ep_55(), this.mSet_15, new ProviderImpl(this, 344), new ProviderImpl(this, 528), new CachingProviderImpl(this, 8), new CachingProviderImpl(this, 461), new CachingProviderImpl(this, 71), new CachingProviderImpl(this, 495), this.mDependency_601.ep_33(), new ProviderImpl(this, 19), this.cacheNode_404(), this.cacheNode_457(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), new ProviderImpl(this, 471), this.cacheNode_426(), new ProviderImpl(this, 149), this.accessNode_497());
+  }
+
+  Node_106 accessNode_106() {
+    return new Node_106(new ProviderImpl(this, 132), new ProviderImpl(this, 161), new CachingProviderImpl(this, 162), new ProviderImpl(this, 163), new CachingProviderImpl(this, 36), new CachingProviderImpl(this, 164), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 104), this.mSet_11, this.accessNode_596(), new CachingProviderImpl(this, 166), this.mDependency_601.ep_36(), new ProviderImpl(this, 168), new ProviderImpl(this, 74), new CachingProviderImpl(this, 169), new CachingProviderImpl(this, 170), new CachingProviderImpl(this, 171), this.cacheNode_551());
+  }
+
+  Node_109 accessNode_109() {
+    return new Node_109(new CachingProviderImpl(this, 349), new ProviderImpl(this, 468), new ProviderImpl(this, 243), new ProviderImpl(this, 41), new ProviderImpl(this, 44), this.accessNode_59(), new ProviderImpl(this, 110), new CachingProviderImpl(this, 491), new ProviderImpl(this, 429), new CachingProviderImpl(this, 179), this.cacheNode_306(), this.cacheNode_250(), new CachingProviderImpl(this, 456), new ProviderImpl(this, 337), new CachingProviderImpl(this, 494), new CachingProviderImpl(this, 390), this.accessNode_232(), new ProviderImpl(this, 29), new ProviderImpl(this, 6), new CachingProviderImpl(this, 64), this.cacheNode_303());
+  }
+
+  Node_113 accessNode_113() {
+    return new Node_113(this.accessNode_597(), new CachingProviderImpl(this, 65), new CachingProviderImpl(this, 70), new CachingProviderImpl(this, 71), new ProviderImpl(this, 29), new ProviderImpl(this, 72), this.accessNode_184(), new ProviderImpl(this, 74), this.cacheNode_551(), new CachingProviderImpl(this, 75), this.cacheNode_551(), new ProviderImpl(this, 76), new CachingProviderImpl(this, 77), new ProviderImpl(this, 78), new ProviderImpl(this, 24), this.mDependency_601.ep_13(), new ProviderImpl(this, 80), new ProviderImpl(this, 81), this.cacheNode_92());
+  }
+
+  Node_116 accessNode_116() {
+    return new Node_116(this.cacheNode_6(), this.mDependency_601.ep_34(), this.accessNode_59(), new ProviderImpl(this, 442), new CachingProviderImpl(this, 382), this.mDependency_601.ep_52(), new ProviderImpl(this, 19), this.cacheNode_303(), new ProviderImpl(this, 441), new ProviderImpl(this, 497), new ProviderImpl(this, 205), Checks.checkProvisionNotNull(Module_609.Companion.provides_1033()), this.cacheNode_207(), new ProviderImpl(this, 271), this.accessNode_533(), new ProviderImpl(this, 312), this.accessNode_529());
+  }
+
+  Node_118 accessNode_118() {
+    return new Node_118(this.accessNode_418(), new CachingProviderImpl(this, 360), new ProviderImpl(this, 63), new ProviderImpl(this, 449), new ProviderImpl(this, 261), this.cacheNode_111(), new ProviderImpl(this, 78), this.mSet_42, new ProviderImpl(this, 438), this.cacheNode_6(), this.cacheNode_151(), new CachingProviderImpl(this, 23), this.accessNode_101(), this.cacheNode_2(), new ProviderImpl(this, 92), new ProviderImpl(this, 90), this.accessNode_419(), this.mDependency_601.ep_56(), this.mDependency_601.ep_42(), new ProviderImpl(this, 101), this.accessNode_133(), this.accessNode_232(), new ProviderImpl(this, 70), new ProviderImpl(this, 293), this.accessNode_45(), new ProviderImpl(this, 437));
+  }
+
+  Node_12 accessNode_12() {
+    return new Node_12(this.mSet_21, this.mSet_12, this.accessNode_517(), this.cacheNode_13(), this.accessNode_146(), this.accessNode_37(), this.accessNode_11(), this.cacheNode_212(), this.accessNode_470(), this.accessNode_339(), this.mSet_19, new ProviderImpl(this, 209), this.cacheNode_500(), this.accessNode_295(), this.cacheNode_120(), this.accessNode_379(), new CachingProviderImpl(this, 256), this.accessNode_298(), this.cacheNode_229(), this.accessNode_116(), this.cacheNode_566(), new ProviderImpl(this, 352), this.accessNode_475(), this.accessNode_149());
+  }
+
+  Node_120 cacheNode_120() {
+    Object local = this.mNode_120Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_120(this.cacheNode_102(), this.mDependency_601.ep_53(), this.accessNode_134(), this.cacheNode_502(), new CachingProviderImpl(this, 185), this.cacheNode_284(), this.accessNode_140(), this.mDependency_601.ep_4(), this.mSet_12, this.mSet_27, this.accessNode_136(), this.accessNode_596(), this.mDependency_601.ep_23(), new ProviderImpl(this, 191), this.accessNode_148(), this.cacheNode_260(), this.accessNode_107(), new CachingProviderImpl(this, 500), this.accessNode_218(), this.cacheNode_599(), this.cacheNode_342(), this.mDependency_601.ep_6(), new CachingProviderImpl(this, 71), new CachingProviderImpl(this, 445), this.accessNode_199());
+      this.mNode_120Instance = local;
+    }
+    return (Node_120) local;
+  }
+
+  Node_123 cacheNode_123() {
+    Object local = this.mNode_123Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_123(this.mDependency_601.ep_29(), this.cacheNode_457(), new CachingProviderImpl(this, 318), new ProviderImpl(this, 104), new CachingProviderImpl(this, 390), this.mSet_42, new ProviderImpl(this, 46), new ProviderImpl(this, 218), this.accessNode_164(), this.accessNode_288(), this.cacheNode_114(), new CachingProviderImpl(this, 354), new CachingProviderImpl(this, 177), new ProviderImpl(this, 230), new ProviderImpl(this, 148), new ProviderImpl(this, 149), new CachingProviderImpl(this, 143), this.accessNode_337(), this.accessNode_155(), new CachingProviderImpl(this, 507));
+      this.mNode_123Instance = local;
+    }
+    return (Node_123) local;
+  }
+
+  Node_127 accessNode_127() {
+    return new Node_127(new CachingProviderImpl(this, 480), new CachingProviderImpl(this, 510), new CachingProviderImpl(this, 405), new ProviderImpl(this, 419));
+  }
+
+  Node_13 cacheNode_13() {
+    Object local = this.mNode_13Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_13(this.accessNode_136(), this.cacheNode_64(), this.mDependency_601.ep_41(), new ProviderImpl(this, 242), new ProviderImpl(this, 254), this.accessNode_529(), new CachingProviderImpl(this, 120), new ProviderImpl(this, 136), new ProviderImpl(this, 444), new CachingProviderImpl(this, 8), this.cacheNode_310(), this.cacheNode_114(), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), this.cacheNode_104(), this.mDependency_601.ep_28(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 407), new CachingProviderImpl(this, 400), this.accessNode_405(), new ProviderImpl(this, 28), this.accessNode_598(), this.cacheNode_325(), this.cacheNode_347(), new ProviderImpl(this, 290));
+      this.mNode_13Instance = local;
+    }
+    return (Node_13) local;
+  }
+
+  Node_131 cacheNode_131() {
+    Object local = this.mNode_131Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_131(this.cacheNode_67(), this.mDependency_601.ep_49(), this.mSet_30, this.cacheNode_376(), this.accessNode_391(), this.mSet_33, this.accessNode_430(), this.accessNode_297(), new CachingProviderImpl(this, 200), new ProviderImpl(this, 111), this.mSet_8, new ProviderImpl(this, 342), new CachingProviderImpl(this, 185), this.mSet_44, new CachingProviderImpl(this, 180), new ProviderImpl(this, 314), new ProviderImpl(this, 152), new CachingProviderImpl(this, 27), this.accessNode_424(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1027()), this.accessNode_160(), this.cacheNode_387());
+      this.mNode_131Instance = local;
+    }
+    return (Node_131) local;
+  }
+
+  Node_132 accessNode_132() {
+    return new Node_132(new CachingProviderImpl(this, 356), new CachingProviderImpl(this, 208), new ProviderImpl(this, 299), this.cacheNode_431(), this.accessNode_296(), this.accessNode_424(), this.cacheNode_562(), new CachingProviderImpl(this, 213), new CachingProviderImpl(this, 56), this.accessNode_507(), this.mSet_31, this.accessNode_134(), new CachingProviderImpl(this, 173), this.cacheNode_456(), this.cacheNode_498(), new CachingProviderImpl(this, 234), this.cacheNode_2(), new ProviderImpl(this, 35), this.accessNode_339(), this.mDependency_601.ep_30(), this.cacheNode_420(), this.accessNode_430(), new ProviderImpl(this, 215), new CachingProviderImpl(this, 8), this.accessNode_61(), this.accessNode_377(), new ProviderImpl(this, 288), new ProviderImpl(this, 69), this.accessNode_12(), new ProviderImpl(this, 452));
+  }
+
+  Node_133 accessNode_133() {
+    return new Node_133(new ProviderImpl(this, 72), this.accessNode_164(), new CachingProviderImpl(this, 372), this.cacheNode_360(), new ProviderImpl(this, 512), this.cacheNode_143(), new CachingProviderImpl(this, 516), new ProviderImpl(this, 63), new ProviderImpl(this, 90), this.mSet_37, new CachingProviderImpl(this, 218), this.mDependency_601.ep_36(), new ProviderImpl(this, 347), new CachingProviderImpl(this, 234), new CachingProviderImpl(this, 495), this.cacheNode_207(), new ProviderImpl(this, 352));
+  }
+
+  Node_138 cacheNode_138() {
+    Object local = this.mNode_138Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_138(this.mDependency_601.ep_16(), this.cacheNode_393(), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), this.cacheNode_273(), this.mSet_41, this.mDependency_601.ep_35(), new CachingProviderImpl(this, 285), this.mSet_8, new ProviderImpl(this, 469), this.accessNode_33(), this.mSet_39);
+      this.mNode_138Instance = local;
+    }
+    return (Node_138) local;
+  }
+
+  Node_141 cacheNode_141() {
+    Object local = this.mNode_141Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_141(new ProviderImpl(this, 466), new ProviderImpl(this, 109), this.mSet_16, new ProviderImpl(this, 268), new CachingProviderImpl(this, 476), this.accessNode_399(), new ProviderImpl(this, 369), new ProviderImpl(this, 74), this.cacheNode_244());
+      this.mNode_141Instance = local;
+    }
+    return (Node_141) local;
+  }
+
+  Node_142 accessNode_142() {
+    return new Node_142(this.cacheNode_479(), this.mDependency_601.ep_46(), this.mDependency_601.ep_5(), new CachingProviderImpl(this, 465), this.accessNode_103(), this.mDependency_601.ep_37(), new ProviderImpl(this, 45), this.mDependency_601.ep_57(), this.accessNode_385(), this.accessNode_337(), this.cacheNode_71(), this.mDependency_601.ep_48(), this.cacheNode_325(), new ProviderImpl(this, 181), new ProviderImpl(this, 57), this.cacheNode_521(), this.accessNode_101(), this.mSet_12, new ProviderImpl(this, 199), new ProviderImpl(this, 294), new ProviderImpl(this, 86), this.accessNode_189(), this.cacheNode_333(), this.accessNode_430(), new CachingProviderImpl(this, 153), this.mSet_10, Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), this.cacheNode_281(), this.cacheNode_469());
+  }
+
+  Node_143 cacheNode_143() {
+    Object local = this.mNode_143Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_143(new ProviderImpl(this, 298), this.mSet_43, this.mDependency_601.ep_50());
+      this.mNode_143Instance = local;
+    }
+    return (Node_143) local;
+  }
+
+  Node_147 cacheNode_147() {
+    Object local = this.mNode_147Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_147(new ProviderImpl(this, 169), new CachingProviderImpl(this, 307), new CachingProviderImpl(this, 164), this.mSet_46, new CachingProviderImpl(this, 258));
+      this.mNode_147Instance = local;
+    }
+    return (Node_147) local;
+  }
+
+  Node_148 accessNode_148() {
+    return new Node_148(new CachingProviderImpl(this, 186), new ProviderImpl(this, 125), new ProviderImpl(this, 55), new CachingProviderImpl(this, 175), this.mSet_1, new ProviderImpl(this, 30), new ProviderImpl(this, 298), this.accessNode_233(), new CachingProviderImpl(this, 210), new ProviderImpl(this, 183), this.mDependency_601.ep_36(), this.accessNode_214(), this.accessNode_424(), this.cacheNode_282(), this.mSet_33, this.mDependency_601.ep_57(), this.accessNode_434(), this.cacheNode_528());
+  }
+
+  Node_15 cacheNode_15() {
+    Object local = this.mNode_15Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_15(new ProviderImpl(this, 309), this.mDependency_601.ep_21(), this.accessNode_432(), new CachingProviderImpl(this, 4), new ProviderImpl(this, 275), this.cacheNode_459(), this.cacheNode_528(), new CachingProviderImpl(this, 521), new CachingProviderImpl(this, 177), new ProviderImpl(this, 234), new CachingProviderImpl(this, 1), this.accessNode_209(), new ProviderImpl(this, 90), new ProviderImpl(this, 110), new CachingProviderImpl(this, 454), new CachingProviderImpl(this, 396));
+      this.mNode_15Instance = local;
+    }
+    return (Node_15) local;
+  }
+
+  Node_151 cacheNode_151() {
+    Object local = this.mNode_151Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_151(new ProviderImpl(this, 206));
+      this.mNode_151Instance = local;
+    }
+    return (Node_151) local;
+  }
+
+  Node_16 accessNode_16() {
+    return new Node_16(Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), new CachingProviderImpl(this, 336), new ProviderImpl(this, 195), this.mSet_50, this.mDependency_601.ep_40(), new ProviderImpl(this, 520), new CachingProviderImpl(this, 315), this.mDependency_601.ep_48(), new CachingProviderImpl(this, 177), new ProviderImpl(this, 117), new CachingProviderImpl(this, 184), new ProviderImpl(this, 417), this.mDependency_601.ep_2(), this.cacheNode_275(), this.cacheNode_273(), new CachingProviderImpl(this, 103));
+  }
+
+  Node_163 accessNode_163() {
+    return new Node_163(this.cacheNode_457(), new ProviderImpl(this, 418), new ProviderImpl(this, 34), new CachingProviderImpl(this, 398), new ProviderImpl(this, 120), new CachingProviderImpl(this, 351), new ProviderImpl(this, 7), this.accessNode_133(), new CachingProviderImpl(this, 20), this.mSet_8, new ProviderImpl(this, 132), new ProviderImpl(this, 520), this.accessNode_548(), new ProviderImpl(this, 471), this.accessNode_179(), new ProviderImpl(this, 14), new ProviderImpl(this, 111), this.cacheNode_306(), new CachingProviderImpl(this, 60), this.cacheNode_352(), this.cacheNode_192(), new ProviderImpl(this, 352), this.mDependency_601.ep_2(), this.accessNode_140(), new CachingProviderImpl(this, 196));
+  }
+
+  Node_164 accessNode_164() {
+    return new Node_164(new ProviderImpl(this, 169), new CachingProviderImpl(this, 23), new ProviderImpl(this, 245), this.mSet_19, new ProviderImpl(this, 247), new CachingProviderImpl(this, 227), new ProviderImpl(this, 123), new ProviderImpl(this, 238), new CachingProviderImpl(this, 248), new ProviderImpl(this, 249), new ProviderImpl(this, 51), new CachingProviderImpl(this, 145), this.cacheNode_87(), new CachingProviderImpl(this, 47), this.mSet_18);
+  }
+
+  Node_165 accessNode_165() {
+    return new Node_165(Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), new ProviderImpl(this, 19), new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 413), this.mDependency_601.ep_12(), this.accessNode_232(), this.accessNode_455(), this.mSet_0, new ProviderImpl(this, 524), this.mSet_14, this.cacheNode_198(), new CachingProviderImpl(this, 218), new ProviderImpl(this, 320), new ProviderImpl(this, 243), new ProviderImpl(this, 517), new ProviderImpl(this, 288), new ProviderImpl(this, 187));
+  }
+
+  Node_175 accessNode_175() {
+    return new Node_175(new CachingProviderImpl(this, 424), this.cacheNode_543(), new CachingProviderImpl(this, 7), new ProviderImpl(this, 312), this.accessNode_458(), this.accessNode_233(), this.accessNode_339(), new ProviderImpl(this, 81), this.mSet_22, new CachingProviderImpl(this, 318), this.cacheNode_569(), this.accessNode_248(), new CachingProviderImpl(this, 0), new CachingProviderImpl(this, 421), new CachingProviderImpl(this, 402), this.mDependency_601.ep_21(), new CachingProviderImpl(this, 282));
+  }
+
+  Node_176 cacheNode_176() {
+    Object local = this.mNode_176Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_176(new CachingProviderImpl(this, 230), this.accessNode_135(), new CachingProviderImpl(this, 349), new ProviderImpl(this, 329), new ProviderImpl(this, 181), this.cacheNode_576(), Checks.checkProvisionNotNull(Module_609.Companion.provides_949()), this.mSet_10, new ProviderImpl(this, 139), this.cacheNode_67(), this.mSet_4, this.mDependency_601.ep_41(), new ProviderImpl(this, 115), this.accessNode_598(), new ProviderImpl(this, 111), this.cacheNode_417(), this.accessNode_575(), this.accessNode_33(), this.cacheNode_348(), this.accessNode_166(), this.accessNode_552(), new ProviderImpl(this, 90), new ProviderImpl(this, 477), this.cacheNode_479(), this.accessNode_191(), new ProviderImpl(this, 276));
+      this.mNode_176Instance = local;
+    }
+    return (Node_176) local;
+  }
+
+  Node_178 accessNode_178() {
+    return new Node_178(this.mDependency_601.ep_1(), this.accessNode_439(), new CachingProviderImpl(this, 135), this.cacheNode_550(), new ProviderImpl(this, 42), this.accessNode_447(), this.accessNode_168(), this.cacheNode_440());
+  }
+
+  Node_179 accessNode_179() {
+    return new Node_179(new ProviderImpl(this, 386), new CachingProviderImpl(this, 347), new CachingProviderImpl(this, 350), new CachingProviderImpl(this, 37), this.mSet_13, new ProviderImpl(this, 336), new CachingProviderImpl(this, 360), new ProviderImpl(this, 38), new CachingProviderImpl(this, 412), this.accessNode_93(), this.mSet_4, this.mSet_34);
+  }
+
+  Node_184 accessNode_184() {
+    return new Node_184(new CachingProviderImpl(this, 180), new CachingProviderImpl(this, 455), new ProviderImpl(this, 293), new ProviderImpl(this, 433), new CachingProviderImpl(this, 408), new ProviderImpl(this, 456), new CachingProviderImpl(this, 159), this.accessNode_496(), this.mDependency_601.ep_4(), new ProviderImpl(this, 361), new CachingProviderImpl(this, 439), new ProviderImpl(this, 80), new CachingProviderImpl(this, 94), this.cacheNode_551(), this.accessNode_383(), new ProviderImpl(this, 134), new CachingProviderImpl(this, 382), new CachingProviderImpl(this, 366), this.mSet_37, new ProviderImpl(this, 400), new ProviderImpl(this, 342), this.mDependency_601.ep_25(), new ProviderImpl(this, 2), this.mSet_5, this.cacheNode_281(), new CachingProviderImpl(this, 169), this.accessNode_344());
+  }
+
+  Node_187 accessNode_187() {
+    return new Node_187(new ProviderImpl(this, 361), new ProviderImpl(this, 24), new ProviderImpl(this, 76), new CachingProviderImpl(this, 191), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 363), new ProviderImpl(this, 442), new ProviderImpl(this, 472), new CachingProviderImpl(this, 31), new ProviderImpl(this, 312), new CachingProviderImpl(this, 318), this.mSet_44, new CachingProviderImpl(this, 411), new CachingProviderImpl(this, 39), new CachingProviderImpl(this, 507));
+  }
+
+  Node_189 accessNode_189() {
+    return new Node_189(new CachingProviderImpl(this, 103), new CachingProviderImpl(this, 114), new ProviderImpl(this, 486), this.accessNode_455(), this.mSet_8, this.mSet_46, new ProviderImpl(this, 278), new ProviderImpl(this, 174), this.mDependency_601.ep_26(), new ProviderImpl(this, 444), new CachingProviderImpl(this, 412), new ProviderImpl(this, 200), this.accessNode_515(), this.accessNode_391(), this.accessNode_235(), new CachingProviderImpl(this, 397), new CachingProviderImpl(this, 466));
+  }
+
+  Node_191 accessNode_191() {
+    return new Node_191(this.accessNode_136(), this.mSet_23, new CachingProviderImpl(this, 475), new Node_181(), this.cacheNode_361(), new CachingProviderImpl(this, 210), this.accessNode_340(), this.mDependency_601.ep_26(), this.accessNode_385(), new ProviderImpl(this, 2), new ProviderImpl(this, 381), this.cacheNode_206(), this.cacheNode_360(), this.accessNode_288(), new ProviderImpl(this, 167), new ProviderImpl(this, 104), this.cacheNode_359(), this.mSet_31);
+  }
+
+  Node_198 cacheNode_198() {
+    Object local = this.mNode_198Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_198(this.accessNode_211(), new ProviderImpl(this, 431));
+      this.mNode_198Instance = local;
+    }
+    return (Node_198) local;
+  }
+
+  Node_199 accessNode_199() {
+    return new Node_199(this.cacheNode_364(), this.cacheNode_500(), this.accessNode_446());
+  }
+
+  Node_20 cacheNode_20() {
+    Object local = this.mNode_20Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_20(this.cacheNode_499(), this.mDependency_601.ep_44(), new ProviderImpl(this, 40), this.mDependency_601.ep_0(), new CachingProviderImpl(this, 499), new CachingProviderImpl(this, 263), new ProviderImpl(this, 125), this.accessNode_136(), new CachingProviderImpl(this, 20), new ProviderImpl(this, 325), new CachingProviderImpl(this, 200), this.accessNode_296(), this.cacheNode_351(), this.accessNode_162(), new CachingProviderImpl(this, 461), new ProviderImpl(this, 142), this.accessNode_330(), new CachingProviderImpl(this, 318), new ProviderImpl(this, 387), new CachingProviderImpl(this, 146), this.mSet_16, this.accessNode_297(), this.mDependency_601.ep_28(), new ProviderImpl(this, 148), new CachingProviderImpl(this, 360), this.cacheNode_198(), this.cacheNode_229(), new ProviderImpl(this, 123), this.cacheNode_348());
+      this.mNode_20Instance = local;
+    }
+    return (Node_20) local;
+  }
+
+  Node_202 cacheNode_202() {
+    Object local = this.mNode_202Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_202(this.accessNode_324(), this.accessNode_454(), this.accessNode_155(), this.cacheNode_481(), this.cacheNode_79(), new CachingProviderImpl(this, 407), this.mSet_21, this.accessNode_298(), new ProviderImpl(this, 155), new CachingProviderImpl(this, 295), this.mDependency_601.ep_45(), this.cacheNode_341(), this.accessNode_60(), this.cacheNode_231(), new ProviderImpl(this, 393), new CachingProviderImpl(this, 318), this.accessNode_529(), new CachingProviderImpl(this, 321), this.mDependency_601.ep_42(), this.cacheNode_299(), new ProviderImpl(this, 460), this.mSet_27, new ProviderImpl(this, 199), this.accessNode_477());
+      this.mNode_202Instance = local;
+    }
+    return (Node_202) local;
+  }
+
+  Node_203 accessNode_203() {
+    return new Node_203(this.cacheNode_238(), this.mSet_44, new CachingProviderImpl(this, 284), new CachingProviderImpl(this, 64), this.mDependency_601.ep_51(), this.mDependency_601.ep_50(), new ProviderImpl(this, 320), new CachingProviderImpl(this, 32), new ProviderImpl(this, 111), new CachingProviderImpl(this, 408), new CachingProviderImpl(this, 3), new ProviderImpl(this, 39));
+  }
+
+  Node_206 cacheNode_206() {
+    Object local = this.mNode_206Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_206(new CachingProviderImpl(this, 166), new CachingProviderImpl(this, 454), new CachingProviderImpl(this, 506), this.accessNode_533(), new CachingProviderImpl(this, 349), new ProviderImpl(this, 178), new ProviderImpl(this, 169), new CachingProviderImpl(this, 248), new CachingProviderImpl(this, 129), new CachingProviderImpl(this, 126), this.cacheNode_528(), new CachingProviderImpl(this, 424), new ProviderImpl(this, 343), new ProviderImpl(this, 438), new ProviderImpl(this, 399), new ProviderImpl(this, 107), new ProviderImpl(this, 433), this.cacheNode_325(), this.mDependency_601.ep_35(), new ProviderImpl(this, 59), this.mSet_35, new ProviderImpl(this, 373), new CachingProviderImpl(this, 495));
+      this.mNode_206Instance = local;
+    }
+    return (Node_206) local;
+  }
+
+  Node_209 accessNode_209() {
+    return new Node_209(this.cacheNode_167(), new ProviderImpl(this, 138), new ProviderImpl(this, 55), new ProviderImpl(this, 139), this.mDependency_601.ep_28(), Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), new CachingProviderImpl(this, 142), new CachingProviderImpl(this, 143));
+  }
+
+  Node_21 accessNode_21() {
+    return new Node_21(this.accessNode_134(), this.accessNode_463());
+  }
+
+  Node_211 accessNode_211() {
+    return new Node_211(new ProviderImpl(this, 219), new ProviderImpl(this, 374), this.accessNode_56(), new ProviderImpl(this, 477), new CachingProviderImpl(this, 478), new CachingProviderImpl(this, 191), new CachingProviderImpl(this, 162), this.cacheNode_584(), new ProviderImpl(this, 19), this.cacheNode_143(), new ProviderImpl(this, 419), this.cacheNode_431(), this.accessNode_5(), this.cacheNode_151(), new ProviderImpl(this, 193), new ProviderImpl(this, 472), new ProviderImpl(this, 443), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 279), new ProviderImpl(this, 99), this.mDependency_601.ep_55(), new ProviderImpl(this, 82), new ProviderImpl(this, 320), new CachingProviderImpl(this, 42), new ProviderImpl(this, 230), this.cacheNode_114(), this.mDependency_601.ep_44(), this.accessNode_337());
+  }
+
+  Node_212 cacheNode_212() {
+    Object local = this.mNode_212Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_212(new CachingProviderImpl(this, 52), this.cacheNode_273(), this.mDependency_601.ep_23(), new CachingProviderImpl(this, 32), new CachingProviderImpl(this, 408), this.mSet_19, new CachingProviderImpl(this, 409));
+      this.mNode_212Instance = local;
+    }
+    return (Node_212) local;
+  }
+
+  Node_213 accessNode_213() {
+    return new Node_213(this.accessNode_156(), new CachingProviderImpl(this, 284), this.accessNode_61(), this.accessNode_329(), new CachingProviderImpl(this, 147), new ProviderImpl(this, 287), this.mSet_23, this.cacheNode_20(), this.accessNode_597(), new CachingProviderImpl(this, 289), this.accessNode_515(), new CachingProviderImpl(this, 290), this.mDependency_601.ep_12(), this.cacheNode_550(), this.cacheNode_562(), this.accessNode_60(), this.mDependency_601.ep_5());
+  }
+
+  Node_214 accessNode_214() {
+    return new Node_214(new ProviderImpl(this, 355), this.mSet_11, this.cacheNode_404(), new CachingProviderImpl(this, 166), new ProviderImpl(this, 374), new CachingProviderImpl(this, 58), new ProviderImpl(this, 128), this.accessNode_395(), new CachingProviderImpl(this, 239));
+  }
+
+  Node_216 accessNode_216() {
+    return new Node_216(new CachingProviderImpl(this, 147), new ProviderImpl(this, 290), new ProviderImpl(this, 512), this.accessNode_160(), this.cacheNode_157(), new CachingProviderImpl(this, 464), new CachingProviderImpl(this, 267), new CachingProviderImpl(this, 0), this.mDependency_601.ep_17(), new CachingProviderImpl(this, 478), new CachingProviderImpl(this, 347), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), new ProviderImpl(this, 255), new CachingProviderImpl(this, 494), this.mSet_31, new ProviderImpl(this, 276));
+  }
+
+  Node_219 accessNode_219() {
+    return new Node_219(new ProviderImpl(this, 123), new CachingProviderImpl(this, 371), new ProviderImpl(this, 245), new ProviderImpl(this, 252), this.accessNode_133(), this.mDependency_601.ep_25(), this.mSet_44, new CachingProviderImpl(this, 372), this.mSet_10, this.mSet_3, this.mDependency_601.ep_17(), new ProviderImpl(this, 187), this.mDependency_601.ep_22(), this.mSet_41);
+  }
+
+  Node_222 accessNode_222() {
+    return new Node_222(this.cacheNode_316(), new ProviderImpl(this, 271), new CachingProviderImpl(this, 292), new ProviderImpl(this, 239), this.cacheNode_25(), new ProviderImpl(this, 365), new ProviderImpl(this, 414), new CachingProviderImpl(this, 95), new ProviderImpl(this, 254), new ProviderImpl(this, 100), new CachingProviderImpl(this, 448), this.cacheNode_570(), this.cacheNode_92(), new ProviderImpl(this, 449), new CachingProviderImpl(this, 44), this.mDependency_601.ep_5(), new ProviderImpl(this, 392), new ProviderImpl(this, 450), this.accessNode_418(), this.mSet_32, this.mDependency_601.ep_57(), this.mDependency_601.ep_6(), new ProviderImpl(this, 90), new ProviderImpl(this, 90), new CachingProviderImpl(this, 23), new ProviderImpl(this, 452), this.cacheNode_393(), this.accessNode_214(), new ProviderImpl(this, 276));
+  }
+
+  Node_224 cacheNode_224() {
+    Object local = this.mNode_224Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_224(new ProviderImpl(this, 139), this.accessNode_507(), new CachingProviderImpl(this, 154), this.cacheNode_15(), this.accessNode_397(), this.accessNode_314(), new ProviderImpl(this, 406), this.accessNode_126(), this.mSet_16, Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.cacheNode_157(), this.cacheNode_185(), new ProviderImpl(this, 450), new ProviderImpl(this, 45), this.mDependency_601.ep_14(), this.accessNode_496(), this.accessNode_453());
+      this.mNode_224Instance = local;
+    }
+    return (Node_224) local;
+  }
+
+  Node_225 accessNode_225() {
+    return new Node_225(this.mDependency_601.ep_3(), this.accessNode_356(), new ProviderImpl(this, 109), this.accessNode_109(), this.accessNode_332(), this.cacheNode_349(), this.cacheNode_104(), this.cacheNode_185(), new CachingProviderImpl(this, 210), this.accessNode_427(), this.cacheNode_281(), this.mDependency_601.ep_54(), this.mDependency_601.ep_27(), new ProviderImpl(this, 143), this.accessNode_21(), this.accessNode_430(), this.accessNode_467(), new CachingProviderImpl(this, 336), this.accessNode_280(), this.accessNode_93(), this.accessNode_495(), new CachingProviderImpl(this, 282), this.mSet_38, new ProviderImpl(this, 256), Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), new ProviderImpl(this, 395), new CachingProviderImpl(this, 397));
+  }
+
+  Node_226 cacheNode_226() {
+    Object local = this.mNode_226Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_226(this.cacheNode_528(), this.mSet_31, this.accessNode_592(), this.cacheNode_77(), this.accessNode_374(), this.mDependency_601.ep_13());
+      this.mNode_226Instance = local;
+    }
+    return (Node_226) local;
+  }
+
+  Node_229 cacheNode_229() {
+    Object local = this.mNode_229Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_229(new CachingProviderImpl(this, 284), new ProviderImpl(this, 181), new ProviderImpl(this, 139), this.accessNode_59(), this.accessNode_184(), new CachingProviderImpl(this, 340), new ProviderImpl(this, 45), new CachingProviderImpl(this, 349), this.cacheNode_565(), new ProviderImpl(this, 395), new CachingProviderImpl(this, 403), this.mDependency_601.ep_28(), new CachingProviderImpl(this, 351), new CachingProviderImpl(this, 513), new ProviderImpl(this, 238), new CachingProviderImpl(this, 371), this.mSet_9, Checks.checkProvisionNotNull(Module_609.Companion.provides_949()), this.mSet_43, new ProviderImpl(this, 269), this.cacheNode_363(), new CachingProviderImpl(this, 188), new CachingProviderImpl(this, 502), this.mSet_11, new ProviderImpl(this, 299));
+      this.mNode_229Instance = local;
+    }
+    return (Node_229) local;
+  }
+
+  Node_23 accessNode_23() {
+    return new Node_23(this.cacheNode_341(), new ProviderImpl(this, 301));
+  }
+
+  Node_230 cacheNode_230() {
+    Object local = this.mNode_230Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_230(this.cacheNode_519(), new CachingProviderImpl(this, 480), new ProviderImpl(this, 271), new ProviderImpl(this, 190), this.accessNode_218(), new ProviderImpl(this, 202), new ProviderImpl(this, 337), new ProviderImpl(this, 150), this.cacheNode_92(), this.mSet_28, this.accessNode_118(), this.mDependency_601.ep_42(), new ProviderImpl(this, 433));
+      this.mNode_230Instance = local;
+    }
+    return (Node_230) local;
+  }
+
+  Node_231 cacheNode_231() {
+    Object local = this.mNode_231Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_231(this.accessNode_432(), new ProviderImpl(this, 74), this.accessNode_268(), this.cacheNode_530(), this.cacheNode_20(), this.cacheNode_306(), new ProviderImpl(this, 96), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), this.mSet_33, this.accessNode_515(), this.mDependency_601.ep_37(), this.cacheNode_527(), new CachingProviderImpl(this, 507), this.accessNode_536(), this.accessNode_381(), this.mDependency_601.ep_14(), new ProviderImpl(this, 247), this.cacheNode_260(), this.accessNode_21(), this.accessNode_58(), new ProviderImpl(this, 351));
+      this.mNode_231Instance = local;
+    }
+    return (Node_231) local;
+  }
+
+  Node_232 accessNode_232() {
+    return new Node_232(new CachingProviderImpl(this, 372), this.cacheNode_441(), this.mSet_35, new ProviderImpl(this, 374), this.mDependency_601.ep_0(), new ProviderImpl(this, 225), new ProviderImpl(this, 133), new ProviderImpl(this, 259));
+  }
+
+  Node_234 cacheNode_234() {
+    Object local = this.mNode_234Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_234(new ProviderImpl(this, 418), this.mDependency_601.ep_7(), new CachingProviderImpl(this, 27), new ProviderImpl(this, 419), this.cacheNode_547(), this.cacheNode_531(), new ProviderImpl(this, 181));
+      this.mNode_234Instance = local;
+    }
+    return (Node_234) local;
+  }
+
+  Node_239 accessNode_239() {
+    return new Node_239(this.mSet_18, this.mSet_7, new CachingProviderImpl(this, 32), new ProviderImpl(this, 245), new ProviderImpl(this, 109), new CachingProviderImpl(this, 190), new CachingProviderImpl(this, 339), this.cacheNode_303(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), new CachingProviderImpl(this, 349), new ProviderImpl(this, 392), new ProviderImpl(this, 359), this.mDependency_601.ep_3(), this.cacheNode_284(), new ProviderImpl(this, 393), new CachingProviderImpl(this, 413), this.mSet_14, new ProviderImpl(this, 92), this.cacheNode_520(), new CachingProviderImpl(this, 143), this.accessNode_164(), this.accessNode_427(), this.mDependency_601.ep_37(), this.cacheNode_92(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1034()));
+  }
+
+  Node_241 cacheNode_241() {
+    Object local = this.mNode_241Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_241(this.cacheNode_429(), this.accessNode_180(), this.cacheNode_568());
+      this.mNode_241Instance = local;
+    }
+    return (Node_241) local;
+  }
+
+  Node_243 cacheNode_243() {
+    Object local = this.mNode_243Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_243(this.accessNode_28(), this.cacheNode_87(), new CachingProviderImpl(this, 474), new Node_181());
+      this.mNode_243Instance = local;
+    }
+    return (Node_243) local;
+  }
+
+  Node_244 cacheNode_244() {
+    Object local = this.mNode_244Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_244(new CachingProviderImpl(this, 282), new CachingProviderImpl(this, 169), this.accessNode_510(), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 339), this.cacheNode_150(), this.cacheNode_15(), this.accessNode_552(), this.accessNode_439(), this.cacheNode_506(), this.accessNode_37(), new ProviderImpl(this, 111), new CachingProviderImpl(this, 65), this.cacheNode_171(), new ProviderImpl(this, 177), this.cacheNode_307());
+      this.mNode_244Instance = local;
+    }
+    return (Node_244) local;
+  }
+
+  Node_248 accessNode_248() {
+    return new Node_248(new ProviderImpl(this, 90), new ProviderImpl(this, 190), new ProviderImpl(this, 239), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), this.accessNode_467(), this.accessNode_460(), new ProviderImpl(this, 461), new ProviderImpl(this, 469), new CachingProviderImpl(this, 321), new ProviderImpl(this, 339), new CachingProviderImpl(this, 127), this.cacheNode_15(), this.cacheNode_519(), new CachingProviderImpl(this, 196), new CachingProviderImpl(this, 258), new CachingProviderImpl(this, 400), new ProviderImpl(this, 433), new CachingProviderImpl(this, 470), this.accessNode_23(), this.accessNode_105(), new ProviderImpl(this, 51), this.cacheNode_364(), new CachingProviderImpl(this, 27), this.cacheNode_363(), this.mSet_42, this.mDependency_601.ep_27(), this.cacheNode_138(), new CachingProviderImpl(this, 104), new ProviderImpl(this, 276), this.mDependency_601.ep_1());
+  }
+
+  Node_250 cacheNode_250() {
+    Object local = this.mNode_250Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_250(new CachingProviderImpl(this, 62), new CachingProviderImpl(this, 480), new ProviderImpl(this, 449), this.accessNode_381(), new ProviderImpl(this, 61), new CachingProviderImpl(this, 156), new CachingProviderImpl(this, 23), this.mDependency_601.ep_19(), new ProviderImpl(this, 453), new CachingProviderImpl(this, 154), new ProviderImpl(this, 19), new ProviderImpl(this, 314), new ProviderImpl(this, 414), new CachingProviderImpl(this, 158), this.mDependency_601.ep_45(), new CachingProviderImpl(this, 169), this.cacheNode_92(), this.accessNode_288(), new CachingProviderImpl(this, 466), new CachingProviderImpl(this, 280), this.mSet_33, new ProviderImpl(this, 130));
+      this.mNode_250Instance = local;
+    }
+    return (Node_250) local;
+  }
+
+  Node_253 cacheNode_253() {
+    Object local = this.mNode_253Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_253(this.cacheNode_82(), this.cacheNode_72(), new ProviderImpl(this, 296), new CachingProviderImpl(this, 439), new ProviderImpl(this, 90), new CachingProviderImpl(this, 306), this.cacheNode_584(), new CachingProviderImpl(this, 52), this.mDependency_601.ep_56(), this.cacheNode_524(), this.cacheNode_154(), this.cacheNode_572());
+      this.mNode_253Instance = local;
+    }
+    return (Node_253) local;
+  }
+
+  Node_260 cacheNode_260() {
+    Object local = this.mNode_260Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_260(new ProviderImpl(this, 357), new ProviderImpl(this, 489), this.accessNode_107(), new ProviderImpl(this, 74), this.accessNode_51(), new CachingProviderImpl(this, 348), new CachingProviderImpl(this, 502), new CachingProviderImpl(this, 186), Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), this.cacheNode_519(), new CachingProviderImpl(this, 200), new CachingProviderImpl(this, 335), new CachingProviderImpl(this, 341), new CachingProviderImpl(this, 386), this.cacheNode_588(), new ProviderImpl(this, 514), this.mSet_40, new CachingProviderImpl(this, 8), this.cacheNode_547(), new ProviderImpl(this, 366), this.mSet_2, new ProviderImpl(this, 425), this.accessNode_397(), this.mSet_46);
+      this.mNode_260Instance = local;
+    }
+    return (Node_260) local;
+  }
+
+  Node_263 accessNode_263() {
+    return new Node_263(this.cacheNode_393(), new CachingProviderImpl(this, 84), new CachingProviderImpl(this, 36), this.accessNode_340(), new CachingProviderImpl(this, 516), this.mDependency_601.ep_15(), this.accessNode_187(), this.mDependency_601.ep_20(), this.accessNode_439(), new CachingProviderImpl(this, 65), new ProviderImpl(this, 139), new CachingProviderImpl(this, 106), this.cacheNode_319(), new ProviderImpl(this, 218), this.cacheNode_171(), new ProviderImpl(this, 113), new ProviderImpl(this, 51), this.cacheNode_431(), this.accessNode_430(), new CachingProviderImpl(this, 177), this.accessNode_312(), new CachingProviderImpl(this, 11), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), this.cacheNode_151());
+  }
+
+  Node_264 accessNode_264() {
+    return new Node_264(this.mDependency_601.ep_31(), this.cacheNode_494(), new CachingProviderImpl(this, 377), this.cacheNode_586(), this.mDependency_601.ep_46(), this.accessNode_232(), new ProviderImpl(this, 161), new ProviderImpl(this, 441), this.accessNode_492(), new CachingProviderImpl(this, 382), this.mDependency_601.ep_52(), new ProviderImpl(this, 410), this.cacheNode_499(), this.mSet_16, this.cacheNode_167(), this.mSet_19, this.accessNode_381(), new ProviderImpl(this, 202), new ProviderImpl(this, 99), this.mSet_37, this.cacheNode_79(), new CachingProviderImpl(this, 403), this.mSet_34, this.accessNode_391(), this.accessNode_447(), new ProviderImpl(this, 337));
+  }
+
+  Node_267 cacheNode_267() {
+    Object local = this.mNode_267Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_267(new CachingProviderImpl(this, 210), new CachingProviderImpl(this, 39), this.mDependency_601.ep_20(), new ProviderImpl(this, 195), new CachingProviderImpl(this, 156), new ProviderImpl(this, 513), new ProviderImpl(this, 431), this.mDependency_601.ep_55(), new CachingProviderImpl(this, 94), this.accessNode_397(), new CachingProviderImpl(this, 42), new ProviderImpl(this, 419), new ProviderImpl(this, 155), new CachingProviderImpl(this, 321), this.mDependency_601.ep_14(), new CachingProviderImpl(this, 142), this.mSet_10, this.accessNode_222(), new CachingProviderImpl(this, 120), new ProviderImpl(this, 297));
+      this.mNode_267Instance = local;
+    }
+    return (Node_267) local;
+  }
+
+  Node_268 accessNode_268() {
+    return new Node_268(this.accessNode_517(), new ProviderImpl(this, 312), new CachingProviderImpl(this, 474), this.accessNode_438(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), new CachingProviderImpl(this, 206), this.cacheNode_328(), new ProviderImpl(this, 202), this.accessNode_59(), new ProviderImpl(this, 224), new CachingProviderImpl(this, 70), this.mDependency_601.ep_27(), new ProviderImpl(this, 463), this.mDependency_601.ep_9(), this.accessNode_116(), new ProviderImpl(this, 29), new ProviderImpl(this, 342), this.cacheNode_551(), new ProviderImpl(this, 319), new ProviderImpl(this, 227), new ProviderImpl(this, 251), this.accessNode_239(), new ProviderImpl(this, 369), new ProviderImpl(this, 485), new CachingProviderImpl(this, 4), this.cacheNode_393(), this.accessNode_280(), new ProviderImpl(this, 299));
+  }
+
+  Node_271 cacheNode_271() {
+    Object local = this.mNode_271Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_271(new CachingProviderImpl(this, 351), this.cacheNode_527(), this.accessNode_109(), this.mSet_44, this.accessNode_425(), new ProviderImpl(this, 78));
+      this.mNode_271Instance = local;
+    }
+    return (Node_271) local;
+  }
+
+  Node_280 accessNode_280() {
+    return new Node_280(new CachingProviderImpl(this, 400), this.accessNode_314(), new ProviderImpl(this, 514), new ProviderImpl(this, 450), new ProviderImpl(this, 510), new CachingProviderImpl(this, 339));
+  }
+
+  Node_281 cacheNode_281() {
+    Object local = this.mNode_281Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_281(this.mSet_25, new ProviderImpl(this, 293), new ProviderImpl(this, 181), new CachingProviderImpl(this, 190), new ProviderImpl(this, 251), new CachingProviderImpl(this, 400), new ProviderImpl(this, 443), new ProviderImpl(this, 243), new CachingProviderImpl(this, 500), new ProviderImpl(this, 325), new ProviderImpl(this, 95), new CachingProviderImpl(this, 327), this.mSet_27, Checks.checkProvisionNotNull(Module_609.Companion.provides_1034()), new CachingProviderImpl(this, 407), this.mDependency_601.ep_40(), new ProviderImpl(this, 59), this.mDependency_601.ep_47(), new CachingProviderImpl(this, 70), new CachingProviderImpl(this, 159), this.mSet_32);
+      this.mNode_281Instance = local;
+    }
+    return (Node_281) local;
+  }
+
+  Node_285 cacheNode_285() {
+    Object local = this.mNode_285Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_285(this.cacheNode_44());
+      this.mNode_285Instance = local;
+    }
+    return (Node_285) local;
+  }
+
+  Node_286 cacheNode_286() {
+    Object local = this.mNode_286Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_286(Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 278), new CachingProviderImpl(this, 104), this.mSet_9, this.accessNode_298(), this.accessNode_18(), new CachingProviderImpl(this, 281), new CachingProviderImpl(this, 39), new CachingProviderImpl(this, 282), new CachingProviderImpl(this, 62), new ProviderImpl(this, 223));
+      this.mNode_286Instance = local;
+    }
+    return (Node_286) local;
+  }
+
+  Node_292 accessNode_292() {
+    return new Node_292(new ProviderImpl(this, 489), this.mSet_5, new ProviderImpl(this, 517), new CachingProviderImpl(this, 284), new ProviderImpl(this, 163), new ProviderImpl(this, 255), new CachingProviderImpl(this, 44), this.mDependency_601.ep_49(), new CachingProviderImpl(this, 212), new ProviderImpl(this, 21), this.accessNode_106(), this.mSet_0, this.mDependency_601.ep_33());
+  }
+
+  Node_295 accessNode_295() {
+    return new Node_295(new CachingProviderImpl(this, 2), new ProviderImpl(this, 305), new ProviderImpl(this, 457), new ProviderImpl(this, 488), new CachingProviderImpl(this, 172), new CachingProviderImpl(this, 104), new ProviderImpl(this, 317), this.accessNode_292(), new CachingProviderImpl(this, 300), new ProviderImpl(this, 37), this.mSet_19, this.accessNode_512(), new CachingProviderImpl(this, 307));
+  }
+
+  Node_296 accessNode_296() {
+    return new Node_296(this.accessNode_106(), this.mSet_51, new ProviderImpl(this, 519), new ProviderImpl(this, 423), this.cacheNode_167(), Checks.checkProvisionNotNull(Module_609.Companion.provides_986()), this.mSet_16, new ProviderImpl(this, 68), this.accessNode_51(), new CachingProviderImpl(this, 525), new ProviderImpl(this, 142));
+  }
+
+  Node_301 accessNode_301() {
+    return new Node_301(this.mSet_22, Checks.checkProvisionNotNull(Module_609.Companion.provides_949()), new CachingProviderImpl(this, 221), new CachingProviderImpl(this, 162), this.accessNode_518(), this.cacheNode_457(), new CachingProviderImpl(this, 397), this.accessNode_203(), this.accessNode_163(), new CachingProviderImpl(this, 49), this.mSet_48, this.mDependency_601.ep_44(), new CachingProviderImpl(this, 390), this.cacheNode_271());
+  }
+
+  Node_309 accessNode_309() {
+    return new Node_309(new CachingProviderImpl(this, 37), new ProviderImpl(this, 100), new ProviderImpl(this, 262), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 23), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 67), new CachingProviderImpl(this, 339), new CachingProviderImpl(this, 382), new CachingProviderImpl(this, 407), new ProviderImpl(this, 42), new ProviderImpl(this, 420), new ProviderImpl(this, 453), this.cacheNode_249(), this.accessNode_336(), new ProviderImpl(this, 513), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), this.mDependency_601.ep_7(), this.accessNode_467(), new ProviderImpl(this, 131), this.mSet_39, new ProviderImpl(this, 519), new CachingProviderImpl(this, 177), new ProviderImpl(this, 199), this.cacheNode_7());
+  }
+
+  Node_31 cacheNode_31() {
+    Object local = this.mNode_31Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_31(new ProviderImpl(this, 55), this.cacheNode_366(), new CachingProviderImpl(this, 349), this.cacheNode_562(), this.accessNode_397(), this.accessNode_115(), this.accessNode_454(), this.accessNode_74(), new ProviderImpl(this, 357));
+      this.mNode_31Instance = local;
+    }
+    return (Node_31) local;
+  }
+
+  Node_313 accessNode_313() {
+    return new Node_313(new ProviderImpl(this, 86), this.mSet_19, new CachingProviderImpl(this, 190), new CachingProviderImpl(this, 396), this.mSet_12, this.accessNode_418(), this.cacheNode_360(), new ProviderImpl(this, 287), this.cacheNode_511(), this.mSet_17, this.cacheNode_151(), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 168), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.mSet_27, new CachingProviderImpl(this, 160), new CachingProviderImpl(this, 405), new CachingProviderImpl(this, 146), this.mSet_44, new Node_181());
+  }
+
+  Node_316 cacheNode_316() {
+    Object local = this.mNode_316Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_316(new ProviderImpl(this, 238), new CachingProviderImpl(this, 464), this.accessNode_163(), this.cacheNode_481(), new ProviderImpl(this, 34));
+      this.mNode_316Instance = local;
+    }
+    return (Node_316) local;
+  }
+
+  Node_317 accessNode_317() {
+    return new Node_317(new ProviderImpl(this, 21), this.accessNode_329(), new ProviderImpl(this, 305), this.accessNode_209(), new CachingProviderImpl(this, 396), this.accessNode_100(), new ProviderImpl(this, 420), this.mDependency_601.ep_8(), this.mDependency_601.ep_5(), new ProviderImpl(this, 421), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 229), new CachingProviderImpl(this, 258), new ProviderImpl(this, 392), new ProviderImpl(this, 367), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 108), new CachingProviderImpl(this, 339), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 39), this.accessNode_126(), this.accessNode_564());
+  }
+
+  Node_318 cacheNode_318() {
+    Object local = this.mNode_318Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_318(this.accessNode_458(), this.cacheNode_81(), this.mSet_9, this.cacheNode_98(), new CachingProviderImpl(this, 185), new ProviderImpl(this, 109), this.cacheNode_64());
+      this.mNode_318Instance = local;
+    }
+    return (Node_318) local;
+  }
+
+  Node_319 cacheNode_319() {
+    Object local = this.mNode_319Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_319(new ProviderImpl(this, 491), this.mSet_49, this.accessNode_127(), this.accessNode_216(), this.accessNode_305(), this.accessNode_26(), this.cacheNode_376(), new ProviderImpl(this, 468), this.cacheNode_459(), this.cacheNode_82(), this.cacheNode_415(), this.accessNode_289(), new ProviderImpl(this, 144), this.mDependency_601.ep_3());
+      this.mNode_319Instance = local;
+    }
+    return (Node_319) local;
+  }
+
+  Node_320 accessNode_320() {
+    return new Node_320(this.accessNode_178(), this.accessNode_495(), this.mDependency_601.ep_34(), this.cacheNode_417(), new ProviderImpl(this, 83), this.accessNode_332(), this.cacheNode_521(), this.mDependency_601.ep_53(), new Node_181(), this.mSet_7, this.cacheNode_185(), this.cacheNode_241());
+  }
+
+  Node_322 cacheNode_322() {
+    Object local = this.mNode_322Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_322(this.accessNode_203(), this.mSet_20, this.cacheNode_316(), this.cacheNode_318(), this.accessNode_135(), this.accessNode_600(), this.accessNode_33(), this.mSet_38, this.accessNode_395(), this.mDependency_601.ep_42(), this.accessNode_232(), this.accessNode_269(), this.mSet_10, new CachingProviderImpl(this, 162), new ProviderImpl(this, 286), this.mSet_25, new CachingProviderImpl(this, 466));
+      this.mNode_322Instance = local;
+    }
+    return (Node_322) local;
+  }
+
+  Node_324 accessNode_324() {
+    return new Node_324(new ProviderImpl(this, 28), this.accessNode_460(), this.cacheNode_215(), new CachingProviderImpl(this, 281), this.accessNode_56(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), new ProviderImpl(this, 238), new CachingProviderImpl(this, 516), new CachingProviderImpl(this, 196), this.cacheNode_519(), new ProviderImpl(this, 293), new CachingProviderImpl(this, 340), new ProviderImpl(this, 431), new CachingProviderImpl(this, 464), this.mDependency_601.ep_25(), new CachingProviderImpl(this, 318), new CachingProviderImpl(this, 465), this.accessNode_107(), new ProviderImpl(this, 91), this.mSet_2, new CachingProviderImpl(this, 207), this.cacheNode_6(), this.cacheNode_111(), new CachingProviderImpl(this, 428), this.cacheNode_22());
+  }
+
+  Node_325 cacheNode_325() {
+    Object local = this.mNode_325Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_325(this.mSet_47, new ProviderImpl(this, 91), new ProviderImpl(this, 374), new CachingProviderImpl(this, 246), new CachingProviderImpl(this, 180), this.mDependency_601.ep_40(), this.mDependency_601.ep_27(), new CachingProviderImpl(this, 466), new CachingProviderImpl(this, 278));
+      this.mNode_325Instance = local;
+    }
+    return (Node_325) local;
+  }
+
+  Node_328 cacheNode_328() {
+    Object local = this.mNode_328Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_328(this.mSet_42, new CachingProviderImpl(this, 405), new ProviderImpl(this, 209), this.accessNode_510(), this.accessNode_257(), this.mDependency_601.ep_9(), this.mDependency_601.ep_51());
+      this.mNode_328Instance = local;
+    }
+    return (Node_328) local;
+  }
+
+  Node_329 accessNode_329() {
+    return new Node_329(new ProviderImpl(this, 434), this.mDependency_601.ep_24(), new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 20), new CachingProviderImpl(this, 402), new CachingProviderImpl(this, 217));
+  }
+
+  Node_337 accessNode_337() {
+    return new Node_337(new CachingProviderImpl(this, 466), this.mDependency_601.ep_30(), new ProviderImpl(this, 337), new CachingProviderImpl(this, 500), new CachingProviderImpl(this, 67), new CachingProviderImpl(this, 217), this.accessNode_134(), this.cacheNode_360(), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), this.mDependency_601.ep_27(), this.cacheNode_591());
+  }
+
+  Node_339 accessNode_339() {
+    return new Node_339(this.accessNode_324(), this.mDependency_601.ep_30(), new CachingProviderImpl(this, 466), new ProviderImpl(this, 261), this.mSet_0);
+  }
+
+  Node_344 accessNode_344() {
+    return new Node_344(new ProviderImpl(this, 242), this.mSet_20, new ProviderImpl(this, 72), new CachingProviderImpl(this, 196), this.accessNode_383(), new ProviderImpl(this, 358), this.cacheNode_479(), new CachingProviderImpl(this, 412), new ProviderImpl(this, 334), new CachingProviderImpl(this, 60), this.mDependency_601.ep_9(), new ProviderImpl(this, 494), new ProviderImpl(this, 385), new ProviderImpl(this, 431), new ProviderImpl(this, 144), this.mSet_43, this.mSet_46, new ProviderImpl(this, 402), new CachingProviderImpl(this, 283), new CachingProviderImpl(this, 229), new ProviderImpl(this, 225), new CachingProviderImpl(this, 398));
+  }
+
+  Node_347 cacheNode_347() {
+    Object local = this.mNode_347Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_347(this.cacheNode_64(), this.mDependency_601.ep_7(), new ProviderImpl(this, 90), this.accessNode_475(), this.mSet_45, new ProviderImpl(this, 233), new CachingProviderImpl(this, 198), new ProviderImpl(this, 287), new CachingProviderImpl(this, 367), this.accessNode_553(), new CachingProviderImpl(this, 350), this.mDependency_601.ep_48(), this.mDependency_601.ep_54(), new CachingProviderImpl(this, 421), new ProviderImpl(this, 223), this.mSet_24, new CachingProviderImpl(this, 210), this.mDependency_601.ep_10(), this.mSet_46);
+      this.mNode_347Instance = local;
+    }
+    return (Node_347) local;
+  }
+
+  Node_349 cacheNode_349() {
+    Object local = this.mNode_349Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_349(new ProviderImpl(this, 454), new CachingProviderImpl(this, 229), new CachingProviderImpl(this, 268), this.accessNode_575(), this.mSet_43, this.accessNode_107(), new ProviderImpl(this, 28), new CachingProviderImpl(this, 31), this.accessNode_536());
+      this.mNode_349Instance = local;
+    }
+    return (Node_349) local;
+  }
+
+  Node_352 cacheNode_352() {
+    Object local = this.mNode_352Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_352(this.cacheNode_111(), this.mSet_41, this.cacheNode_535(), new ProviderImpl(this, 297), new ProviderImpl(this, 110), new ProviderImpl(this, 101), this.mDependency_601.ep_14(), new CachingProviderImpl(this, 400), new CachingProviderImpl(this, 432), new ProviderImpl(this, 193), new CachingProviderImpl(this, 490), new CachingProviderImpl(this, 23));
+      this.mNode_352Instance = local;
+    }
+    return (Node_352) local;
+  }
+
+  Node_353 cacheNode_353() {
+    Object local = this.mNode_353Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_353(new ProviderImpl(this, 139), this.cacheNode_152(), new CachingProviderImpl(this, 1), this.accessNode_136(), new CachingProviderImpl(this, 313), new ProviderImpl(this, 514), this.cacheNode_366(), this.accessNode_43(), this.cacheNode_261());
+      this.mNode_353Instance = local;
+    }
+    return (Node_353) local;
+  }
+
+  Node_359 cacheNode_359() {
+    Object local = this.mNode_359Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_359(new CachingProviderImpl(this, 173), new ProviderImpl(this, 431), this.accessNode_430(), new ProviderImpl(this, 52), this.cacheNode_197(), this.mDependency_601.ep_15(), this.mDependency_601.ep_1(), this.mDependency_601.ep_9(), new CachingProviderImpl(this, 175), new ProviderImpl(this, 483));
+      this.mNode_359Instance = local;
+    }
+    return (Node_359) local;
+  }
+
+  Node_365 accessNode_365() {
+    return new Node_365(new ProviderImpl(this, 487), this.mDependency_601.ep_12(), this.cacheNode_206(), new CachingProviderImpl(this, 62), this.mSet_22, new CachingProviderImpl(this, 398), new ProviderImpl(this, 63), new CachingProviderImpl(this, 307), new CachingProviderImpl(this, 466), new CachingProviderImpl(this, 421), new CachingProviderImpl(this, 23), this.mDependency_601.ep_55(), new CachingProviderImpl(this, 403), new ProviderImpl(this, 286), this.mSet_5, this.mSet_32, this.mDependency_601.ep_1(), this.cacheNode_456(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), this.accessNode_186(), this.cacheNode_363(), this.cacheNode_147(), this.cacheNode_559(), new CachingProviderImpl(this, 458), new ProviderImpl(this, 444), this.mDependency_601.ep_32(), this.cacheNode_143());
+  }
+
+  Node_366 cacheNode_366() {
+    Object local = this.mNode_366Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_366(this.accessNode_367(), this.accessNode_106(), new CachingProviderImpl(this, 307), new CachingProviderImpl(this, 119), new ProviderImpl(this, 308), this.mSet_12, this.cacheNode_250(), new CachingProviderImpl(this, 121), new ProviderImpl(this, 309), new CachingProviderImpl(this, 221), new CachingProviderImpl(this, 203), this.cacheNode_303(), this.cacheNode_71(), new ProviderImpl(this, 312), new CachingProviderImpl(this, 313), new CachingProviderImpl(this, 168), new ProviderImpl(this, 79), new CachingProviderImpl(this, 3), new ProviderImpl(this, 139), this.mSet_8, new ProviderImpl(this, 314), new ProviderImpl(this, 46), new ProviderImpl(this, 315), new ProviderImpl(this, 105));
+      this.mNode_366Instance = local;
+    }
+    return (Node_366) local;
+  }
+
+  Node_367 accessNode_367() {
+    return new Node_367(new ProviderImpl(this, 226), new ProviderImpl(this, 414), new CachingProviderImpl(this, 44), new CachingProviderImpl(this, 434), this.mDependency_601.ep_56(), new ProviderImpl(this, 273), new ProviderImpl(this, 297), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), this.mSet_25, new ProviderImpl(this, 115), new ProviderImpl(this, 68), new ProviderImpl(this, 138), this.mSet_44, new ProviderImpl(this, 485), new CachingProviderImpl(this, 11), new CachingProviderImpl(this, 481), new CachingProviderImpl(this, 497), new CachingProviderImpl(this, 200), new CachingProviderImpl(this, 490), this.mSet_37, new CachingProviderImpl(this, 242), this.accessNode_160(), this.mSet_33, new ProviderImpl(this, 301));
+  }
+
+  Node_377 accessNode_377() {
+    return new Node_377(this.mSet_44, this.mDependency_601.ep_2(), this.cacheNode_490(), this.accessNode_297(), this.cacheNode_157(), new ProviderImpl(this, 447), new CachingProviderImpl(this, 218), this.mDependency_601.ep_51(), new ProviderImpl(this, 457), new CachingProviderImpl(this, 427), this.mDependency_601.ep_21(), this.cacheNode_543(), this.mDependency_601.ep_3(), this.cacheNode_570(), this.accessNode_216(), this.accessNode_51(), new CachingProviderImpl(this, 104), this.cacheNode_393(), this.accessNode_179(), this.accessNode_37(), new CachingProviderImpl(this, 177), new ProviderImpl(this, 80), this.cacheNode_20(), new CachingProviderImpl(this, 140), new CachingProviderImpl(this, 20), new ProviderImpl(this, 329), new CachingProviderImpl(this, 168), new ProviderImpl(this, 443));
+  }
+
+  Node_381 accessNode_381() {
+    return new Node_381(this.mSet_33, new ProviderImpl(this, 255), new ProviderImpl(this, 139), new ProviderImpl(this, 199), new ProviderImpl(this, 428));
+  }
+
+  Node_385 accessNode_385() {
+    return new Node_385(this.mSet_9, this.mDependency_601.ep_40(), this.mDependency_601.ep_7(), this.accessNode_419(), new CachingProviderImpl(this, 147), new ProviderImpl(this, 517), this.mDependency_601.ep_30(), this.mSet_45, new CachingProviderImpl(this, 360), this.accessNode_109(), new CachingProviderImpl(this, 210), new CachingProviderImpl(this, 31), new CachingProviderImpl(this, 20), new ProviderImpl(this, 447), new ProviderImpl(this, 281), this.accessNode_133(), new CachingProviderImpl(this, 71), new CachingProviderImpl(this, 164), new ProviderImpl(this, 494), new CachingProviderImpl(this, 403), new CachingProviderImpl(this, 413));
+  }
+
+  Node_390 accessNode_390() {
+    return new Node_390(this.mDependency_601.ep_17(), this.mDependency_601.ep_20(), new CachingProviderImpl(this, 413), this.mSet_27, this.cacheNode_185(), this.mDependency_601.ep_53(), this.cacheNode_543(), new CachingProviderImpl(this, 345), this.accessNode_300(), new CachingProviderImpl(this, 360), this.accessNode_344(), this.cacheNode_565(), this.accessNode_166(), this.mDependency_601.ep_7());
+  }
+
+  Node_394 accessNode_394() {
+    return new Node_394(new ProviderImpl(this, 287), new ProviderImpl(this, 429), this.cacheNode_316(), this.cacheNode_82(), this.accessNode_574(), this.mSet_32, this.cacheNode_303(), new CachingProviderImpl(this, 3), this.mSet_41, new ProviderImpl(this, 482), this.accessNode_33(), new CachingProviderImpl(this, 85), this.accessNode_216(), new CachingProviderImpl(this, 384), this.mSet_16, this.accessNode_600(), this.accessNode_324(), this.cacheNode_393(), this.cacheNode_351(), this.cacheNode_67(), new ProviderImpl(this, 111), this.accessNode_211(), this.accessNode_186(), new ProviderImpl(this, 275), new CachingProviderImpl(this, 244), this.mSet_42, this.accessNode_235(), this.accessNode_54(), this.accessNode_265());
+  }
+
+  Node_399 accessNode_399() {
+    return new Node_399(new CachingProviderImpl(this, 497));
+  }
+
+  Node_4 accessNode_4() {
+    return new Node_4(new CachingProviderImpl(this, 22), this.cacheNode_114(), new CachingProviderImpl(this, 166), new ProviderImpl(this, 7), new CachingProviderImpl(this, 327), new ProviderImpl(this, 265), this.cacheNode_206(), new ProviderImpl(this, 90), new CachingProviderImpl(this, 507), this.accessNode_432(), new CachingProviderImpl(this, 396), this.accessNode_455(), new ProviderImpl(this, 90), new CachingProviderImpl(this, 397), new ProviderImpl(this, 162), this.accessNode_233(), this.accessNode_443(), new CachingProviderImpl(this, 351), new ProviderImpl(this, 35), this.accessNode_391(), this.cacheNode_215());
+  }
+
+  Node_405 accessNode_405() {
+    return new Node_405(this.accessNode_59(), this.mDependency_601.ep_14(), this.cacheNode_71(), this.cacheNode_328(), new CachingProviderImpl(this, 196), new CachingProviderImpl(this, 4), this.accessNode_590(), this.cacheNode_152(), new CachingProviderImpl(this, 70), new ProviderImpl(this, 131), new ProviderImpl(this, 47), new ProviderImpl(this, 374), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.cacheNode_531(), this.mSet_49, Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), new CachingProviderImpl(this, 87), this.mDependency_601.ep_35(), this.cacheNode_417(), new ProviderImpl(this, 237), this.mDependency_601.ep_23(), this.cacheNode_393(), new CachingProviderImpl(this, 321), this.cacheNode_138(), this.accessNode_213());
+  }
+
+  Node_407 cacheNode_407() {
+    Object local = this.mNode_407Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_407(this.cacheNode_363(), new CachingProviderImpl(this, 177), new CachingProviderImpl(this, 525), new ProviderImpl(this, 218), new ProviderImpl(this, 192), new ProviderImpl(this, 91), this.accessNode_534(), new CachingProviderImpl(this, 459), new CachingProviderImpl(this, 467), new ProviderImpl(this, 410), this.mSet_25, this.accessNode_492(), this.mSet_36, new ProviderImpl(this, 115), this.mSet_42, new CachingProviderImpl(this, 230), new ProviderImpl(this, 59), this.cacheNode_361(), this.cacheNode_92(), new CachingProviderImpl(this, 360), this.cacheNode_119(), new ProviderImpl(this, 476), new CachingProviderImpl(this, 397));
+      this.mNode_407Instance = local;
+    }
+    return (Node_407) local;
+  }
+
+  Node_409 accessNode_409() {
+    return new Node_409(this.cacheNode_386(), this.cacheNode_342(), this.accessNode_574(), new CachingProviderImpl(this, 176), this.cacheNode_508(), new CachingProviderImpl(this, 461), new ProviderImpl(this, 329));
+  }
+
+  Node_414 accessNode_414() {
+    return new Node_414(new ProviderImpl(this, 1), this.mDependency_601.ep_0(), this.mSet_10, new CachingProviderImpl(this, 104), this.accessNode_162(), new CachingProviderImpl(this, 65), new ProviderImpl(this, 347), new CachingProviderImpl(this, 32), new CachingProviderImpl(this, 403), this.accessNode_264(), this.accessNode_534(), this.accessNode_136(), new CachingProviderImpl(this, 121), this.cacheNode_143(), this.cacheNode_530(), this.mDependency_601.ep_20(), this.accessNode_186(), this.mDependency_601.ep_23(), this.cacheNode_15(), new ProviderImpl(this, 305), new CachingProviderImpl(this, 495), new CachingProviderImpl(this, 348), this.cacheNode_244(), new ProviderImpl(this, 132), this.accessNode_455(), this.mSet_6, this.cacheNode_459(), this.cacheNode_343(), new CachingProviderImpl(this, 476));
+  }
+
+  Node_415 cacheNode_415() {
+    Object local = this.mNode_415Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_415(this.cacheNode_562(), this.cacheNode_404(), this.cacheNode_343(), new ProviderImpl(this, 90), this.cacheNode_500(), this.accessNode_296(), this.mSet_7, new CachingProviderImpl(this, 147), new ProviderImpl(this, 391), new ProviderImpl(this, 392), this.mSet_33, new CachingProviderImpl(this, 143), new ProviderImpl(this, 109), new CachingProviderImpl(this, 321), this.cacheNode_325(), this.cacheNode_193(), this.mDependency_601.ep_45(), this.mSet_10, this.accessNode_166(), this.cacheNode_198(), this.accessNode_475());
+      this.mNode_415Instance = local;
+    }
+    return (Node_415) local;
+  }
+
+  Node_417 cacheNode_417() {
+    Object local = this.mNode_417Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_417(new ProviderImpl(this, 392), new ProviderImpl(this, 425), new ProviderImpl(this, 253), new CachingProviderImpl(this, 20), new CachingProviderImpl(this, 180), this.accessNode_424(), new CachingProviderImpl(this, 408), new ProviderImpl(this, 76), this.accessNode_337(), this.mSet_47, this.accessNode_597(), this.accessNode_175(), this.cacheNode_87(), Checks.checkProvisionNotNull(Module_609.Companion.provides_986()), new ProviderImpl(this, 351), this.accessNode_61(), this.accessNode_592(), new ProviderImpl(this, 383), this.mDependency_601.ep_9(), this.mDependency_601.ep_6());
+      this.mNode_417Instance = local;
+    }
+    return (Node_417) local;
+  }
+
+  Node_418 accessNode_418() {
+    return new Node_418(new ProviderImpl(this, 114), Checks.checkProvisionNotNull(Module_609.Companion.provides_1034()), new CachingProviderImpl(this, 521));
+  }
+
+  Node_419 accessNode_419() {
+    return new Node_419(this.cacheNode_551(), new ProviderImpl(this, 374), new CachingProviderImpl(this, 327), new CachingProviderImpl(this, 379), this.mDependency_601.ep_35(), new CachingProviderImpl(this, 120), this.cacheNode_87(), this.mDependency_601.ep_43(), new ProviderImpl(this, 453), new ProviderImpl(this, 30), new ProviderImpl(this, 61), new ProviderImpl(this, 501), new CachingProviderImpl(this, 331), new ProviderImpl(this, 30), new ProviderImpl(this, 431), this.cacheNode_49(), this.mSet_51, new CachingProviderImpl(this, 502), new ProviderImpl(this, 357), this.cacheNode_376(), this.accessNode_510(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), new CachingProviderImpl(this, 190), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), new CachingProviderImpl(this, 146), new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 229), new CachingProviderImpl(this, 113));
+  }
+
+  Node_42 accessNode_42() {
+    return new Node_42(this.mDependency_601.ep_55(), this.cacheNode_92(), this.mSet_22, new ProviderImpl(this, 34), this.cacheNode_71(), new ProviderImpl(this, 18), new ProviderImpl(this, 105), new ProviderImpl(this, 432), new CachingProviderImpl(this, 439), this.mSet_40, this.mDependency_601.ep_3(), new CachingProviderImpl(this, 210), new ProviderImpl(this, 469), new CachingProviderImpl(this, 336), this.accessNode_396());
+  }
+
+  Node_425 accessNode_425() {
+    return new Node_425(new CachingProviderImpl(this, 470), new CachingProviderImpl(this, 268), this.accessNode_86(), this.mDependency_601.ep_45());
+  }
+
+  Node_426 cacheNode_426() {
+    Object local = this.mNode_426Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_426(new CachingProviderImpl(this, 203), this.mSet_10, new ProviderImpl(this, 59), new CachingProviderImpl(this, 366), this.cacheNode_519(), new CachingProviderImpl(this, 32), new ProviderImpl(this, 243), this.cacheNode_441(), new CachingProviderImpl(this, 44));
+      this.mNode_426Instance = local;
+    }
+    return (Node_426) local;
+  }
+
+  Node_427 accessNode_427() {
+    return new Node_427(new CachingProviderImpl(this, 428), this.cacheNode_49(), new ProviderImpl(this, 193), this.mDependency_601.ep_54(), this.mDependency_601.ep_41(), new CachingProviderImpl(this, 190), new ProviderImpl(this, 481), new CachingProviderImpl(this, 396), this.accessNode_517(), this.accessNode_329(), this.cacheNode_479(), new ProviderImpl(this, 337), this.mDependency_601.ep_43(), new CachingProviderImpl(this, 284), new CachingProviderImpl(this, 258), this.mSet_47, this.mDependency_601.ep_0(), this.mSet_28, new CachingProviderImpl(this, 169), new ProviderImpl(this, 234), new CachingProviderImpl(this, 130));
+  }
+
+  Node_430 accessNode_430() {
+    return new Node_430(new ProviderImpl(this, 99), this.accessNode_115(), new ProviderImpl(this, 100), new ProviderImpl(this, 101), this.cacheNode_234(), Checks.checkProvisionNotNull(Module_609.Companion.provides_960()), new CachingProviderImpl(this, 103), new CachingProviderImpl(this, 104), new ProviderImpl(this, 105), new ProviderImpl(this, 106), this.mSet_7, this.accessNode_391(), this.mDependency_601.ep_7(), new ProviderImpl(this, 109), new ProviderImpl(this, 4), this.cacheNode_27(), new ProviderImpl(this, 111), new CachingProviderImpl(this, 57), new CachingProviderImpl(this, 65), this.mDependency_601.ep_24());
+  }
+
+  Node_432 accessNode_432() {
+    return new Node_432(new ProviderImpl(this, 33), this.accessNode_164());
+  }
+
+  Node_434 accessNode_434() {
+    return new Node_434(new CachingProviderImpl(this, 467), this.cacheNode_576(), this.mDependency_601.ep_53(), new CachingProviderImpl(this, 465), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 127), new ProviderImpl(this, 209), this.mDependency_601.ep_35(), this.mSet_29, new ProviderImpl(this, 515), this.mDependency_601.ep_19(), this.cacheNode_171(), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 8), this.mDependency_601.ep_32(), this.cacheNode_393(), this.cacheNode_376(), new ProviderImpl(this, 190), this.mDependency_601.ep_37(), new ProviderImpl(this, 0), this.accessNode_16(), new CachingProviderImpl(this, 52), this.cacheNode_407(), this.mSet_1);
+  }
+
+  Node_438 accessNode_438() {
+    return new Node_438(this.cacheNode_530(), this.cacheNode_562(), new ProviderImpl(this, 514), this.accessNode_218(), this.accessNode_297(), this.mSet_32, new CachingProviderImpl(this, 206), this.accessNode_324(), this.accessNode_432(), this.mSet_22, this.cacheNode_535(), new ProviderImpl(this, 284), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.accessNode_175(), new ProviderImpl(this, 76), new ProviderImpl(this, 329), this.mDependency_601.ep_13(), this.cacheNode_494(), this.mDependency_601.ep_30(), this.accessNode_11(), this.accessNode_534(), new CachingProviderImpl(this, 445), this.accessNode_239(), new ProviderImpl(this, 194), new CachingProviderImpl(this, 222), Checks.checkProvisionNotNull(Module_609.Companion.provides_1027()), this.accessNode_405());
+  }
+
+  Node_441 cacheNode_441() {
+    Object local = this.mNode_441Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_441();
+      this.mNode_441Instance = local;
+    }
+    return (Node_441) local;
+  }
+
+  Node_446 accessNode_446() {
+    return new Node_446(this.accessNode_242(), this.accessNode_515(), new CachingProviderImpl(this, 466), this.cacheNode_599(), new CachingProviderImpl(this, 177), this.accessNode_334(), this.accessNode_475(), new ProviderImpl(this, 32), new ProviderImpl(this, 360), this.accessNode_512(), this.mDependency_601.ep_16(), this.accessNode_166(), this.cacheNode_202(), this.cacheNode_551(), new ProviderImpl(this, 469));
+  }
+
+  Node_447 accessNode_447() {
+    return new Node_447(this.accessNode_518(), this.accessNode_397(), this.mSet_44, this.mDependency_601.ep_24(), new CachingProviderImpl(this, 218), this.mDependency_601.ep_42(), new CachingProviderImpl(this, 64), new CachingProviderImpl(this, 229), new CachingProviderImpl(this, 130), new CachingProviderImpl(this, 461), new CachingProviderImpl(this, 500), this.mSet_25, new ProviderImpl(this, 520), new ProviderImpl(this, 31), this.accessNode_26());
+  }
+
+  Node_449 accessNode_449() {
+    return new Node_449(new ProviderImpl(this, 375), this.cacheNode_6(), new CachingProviderImpl(this, 494), new CachingProviderImpl(this, 497), new CachingProviderImpl(this, 279), this.accessNode_391(), this.cacheNode_404(), Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), Checks.checkProvisionNotNull(Module_609.Companion.provides_1033()), this.cacheNode_499(), new ProviderImpl(this, 444), new ProviderImpl(this, 181), new ProviderImpl(this, 373), this.accessNode_432(), this.accessNode_455(), new CachingProviderImpl(this, 506), new ProviderImpl(this, 40), new ProviderImpl(this, 355), this.mSet_10, new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 284), new ProviderImpl(this, 433), new ProviderImpl(this, 50), this.mSet_29, this.mDependency_601.ep_25(), new ProviderImpl(this, 202), this.cacheNode_285());
+  }
+
+  Node_45 accessNode_45() {
+    return new Node_45(new ProviderImpl(this, 61), new CachingProviderImpl(this, 396), Checks.checkProvisionNotNull(Module_609.Companion.provides_1033()), this.cacheNode_198(), new CachingProviderImpl(this, 316), this.mDependency_601.ep_11(), this.accessNode_334(), new CachingProviderImpl(this, 4), this.mSet_49, new ProviderImpl(this, 269), new ProviderImpl(this, 454), new ProviderImpl(this, 514), this.cacheNode_562(), this.mDependency_601.ep_3(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), this.cacheNode_2(), new ProviderImpl(this, 249), new CachingProviderImpl(this, 360), this.accessNode_4(), this.cacheNode_481(), new ProviderImpl(this, 352), this.mSet_50, this.accessNode_340(), this.accessNode_43());
+  }
+
+  Node_453 accessNode_453() {
+    return new Node_453(this.cacheNode_494(), this.mSet_35, this.mDependency_601.ep_3(), this.accessNode_48(), new CachingProviderImpl(this, 70), this.cacheNode_322(), this.mSet_46, new ProviderImpl(this, 392));
+  }
+
+  Node_454 accessNode_454() {
+    return new Node_454(this.accessNode_455(), new CachingProviderImpl(this, 11), this.accessNode_42());
+  }
+
+  Node_455 accessNode_455() {
+    return new Node_455(new CachingProviderImpl(this, 398), new ProviderImpl(this, 512), this.mDependency_601.ep_48(), this.mDependency_601.ep_45(), this.mDependency_601.ep_14(), new ProviderImpl(this, 194), new CachingProviderImpl(this, 372), this.accessNode_336(), this.mSet_38, new ProviderImpl(this, 418), this.accessNode_292(), new CachingProviderImpl(this, 521), this.cacheNode_366(), this.mDependency_601.ep_41(), new ProviderImpl(this, 181), new ProviderImpl(this, 35), new CachingProviderImpl(this, 407), new CachingProviderImpl(this, 143), new CachingProviderImpl(this, 177), new CachingProviderImpl(this, 42), new CachingProviderImpl(this, 290), new ProviderImpl(this, 508), new ProviderImpl(this, 334), new ProviderImpl(this, 472), this.mDependency_601.ep_34(), new ProviderImpl(this, 148));
+  }
+
+  Node_457 cacheNode_457() {
+    Object local = this.mNode_457Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_457(new CachingProviderImpl(this, 408), new ProviderImpl(this, 471), this.mDependency_601.ep_16(), new CachingProviderImpl(this, 372), this.mSet_37, this.cacheNode_570(), this.mDependency_601.ep_3(), this.cacheNode_192(), new ProviderImpl(this, 288), new CachingProviderImpl(this, 143), new CachingProviderImpl(this, 151), new CachingProviderImpl(this, 104), new ProviderImpl(this, 123), this.mSet_36, new ProviderImpl(this, 392), this.mDependency_601.ep_55(), new ProviderImpl(this, 401), this.accessNode_595(), new ProviderImpl(this, 235), new ProviderImpl(this, 356), new CachingProviderImpl(this, 166), this.accessNode_329(), this.cacheNode_494(), new CachingProviderImpl(this, 284), new CachingProviderImpl(this, 461), new ProviderImpl(this, 81), this.mSet_45, new CachingProviderImpl(this, 58));
+      this.mNode_457Instance = local;
+    }
+    return (Node_457) local;
+  }
+
+  Node_458 accessNode_458() {
+    return new Node_458(this.mDependency_601.ep_55(), this.accessNode_383(), new ProviderImpl(this, 414), this.accessNode_85(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new ProviderImpl(this, 284), new CachingProviderImpl(this, 336), new CachingProviderImpl(this, 171), new CachingProviderImpl(this, 409), new ProviderImpl(this, 453), new ProviderImpl(this, 81), new CachingProviderImpl(this, 27), this.accessNode_5(), this.accessNode_515(), new CachingProviderImpl(this, 258), this.mSet_17, this.cacheNode_212(), new CachingProviderImpl(this, 121), new ProviderImpl(this, 514), this.mDependency_601.ep_13(), this.mSet_28, this.mSet_20, this.mSet_49);
+  }
+
+  Node_459 cacheNode_459() {
+    Object local = this.mNode_459Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_459(new CachingProviderImpl(this, 67), this.mDependency_601.ep_35(), this.mSet_22, new ProviderImpl(this, 392), new ProviderImpl(this, 357), new CachingProviderImpl(this, 23), new ProviderImpl(this, 469), this.cacheNode_543(), new CachingProviderImpl(this, 119), new ProviderImpl(this, 262), new CachingProviderImpl(this, 158), new ProviderImpl(this, 101), this.mSet_34, new ProviderImpl(this, 148), new ProviderImpl(this, 266), this.mSet_6);
+      this.mNode_459Instance = local;
+    }
+    return (Node_459) local;
+  }
+
+  Node_46 accessNode_46() {
+    return new Node_46(new ProviderImpl(this, 139), new ProviderImpl(this, 74), this.cacheNode_190(), this.cacheNode_215(), this.accessNode_496(), this.cacheNode_535(), this.accessNode_548(), this.cacheNode_72(), new ProviderImpl(this, 374), this.cacheNode_273(), new CachingProviderImpl(this, 175), this.cacheNode_141());
+  }
+
+  Node_467 accessNode_467() {
+    return new Node_467(this.mSet_10, this.mSet_6, new ProviderImpl(this, 28), new ProviderImpl(this, 214));
+  }
+
+  Node_468 cacheNode_468() {
+    Object local = this.mNode_468Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_468(this.mSet_22, new ProviderImpl(this, 109), this.accessNode_377(), new ProviderImpl(this, 24));
+      this.mNode_468Instance = local;
+    }
+    return (Node_468) local;
+  }
+
+  Node_469 cacheNode_469() {
+    Object local = this.mNode_469Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_469(this.accessNode_395(), new ProviderImpl(this, 188), new CachingProviderImpl(this, 94), this.cacheNode_260(), new CachingProviderImpl(this, 339), new CachingProviderImpl(this, 22), this.accessNode_242(), new CachingProviderImpl(this, 185), this.accessNode_33(), this.accessNode_461(), this.accessNode_223());
+      this.mNode_469Instance = local;
+    }
+    return (Node_469) local;
+  }
+
+  Node_470 accessNode_470() {
+    return new Node_470(new ProviderImpl(this, 199), new CachingProviderImpl(this, 386), new ProviderImpl(this, 262), this.mSet_37, new ProviderImpl(this, 224), this.mSet_24, new CachingProviderImpl(this, 234), new ProviderImpl(this, 284), this.accessNode_135(), new ProviderImpl(this, 245));
+  }
+
+  Node_479 cacheNode_479() {
+    Object local = this.mNode_479Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_479(new ProviderImpl(this, 183), new CachingProviderImpl(this, 43));
+      this.mNode_479Instance = local;
+    }
+    return (Node_479) local;
+  }
+
+  Node_48 accessNode_48() {
+    return new Node_48(new CachingProviderImpl(this, 398), new CachingProviderImpl(this, 120), this.cacheNode_230());
+  }
+
+  Node_480 accessNode_480() {
+    return new Node_480(new ProviderImpl(this, 83), this.mDependency_601.ep_23(), new ProviderImpl(this, 13), this.mSet_4, new ProviderImpl(this, 86), new ProviderImpl(this, 87), this.mSet_5, new ProviderImpl(this, 55), this.mDependency_601.ep_8(), new ProviderImpl(this, 90), new ProviderImpl(this, 91), this.accessNode_596(), this.mDependency_601.ep_43(), this.accessNode_510(), this.mDependency_601.ep_48(), new CachingProviderImpl(this, 77), new ProviderImpl(this, 47), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 95), new ProviderImpl(this, 96), new CachingProviderImpl(this, 97), new CachingProviderImpl(this, 98));
+  }
+
+  Node_483 accessNode_483() {
+    return new Node_483(this.cacheNode_413(), this.cacheNode_556(), this.mDependency_601.ep_11(), new CachingProviderImpl(this, 120), this.cacheNode_307(), this.mDependency_601.ep_21(), new CachingProviderImpl(this, 258), this.mDependency_601.ep_20(), new ProviderImpl(this, 79), new ProviderImpl(this, 410), this.mSet_31, this.accessNode_297(), this.cacheNode_87(), this.accessNode_410(), new ProviderImpl(this, 90), this.cacheNode_81(), this.accessNode_467(), new CachingProviderImpl(this, 179), Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), this.accessNode_533(), this.accessNode_156(), new CachingProviderImpl(this, 20));
+  }
+
+  Node_488 cacheNode_488() {
+    Object local = this.mNode_488Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_488(this.accessNode_409(), new ProviderImpl(this, 205), this.mSet_41, this.accessNode_136(), this.accessNode_391(), new CachingProviderImpl(this, 481), this.accessNode_85(), this.mDependency_601.ep_6(), this.accessNode_482(), this.cacheNode_567(), this.cacheNode_31());
+      this.mNode_488Instance = local;
+    }
+    return (Node_488) local;
+  }
+
+  Node_49 cacheNode_49() {
+    Object local = this.mNode_49Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_49(this.mDependency_601.ep_14(), new ProviderImpl(this, 137), new CachingProviderImpl(this, 307), new CachingProviderImpl(this, 166));
+      this.mNode_49Instance = local;
+    }
+    return (Node_49) local;
+  }
+
+  Node_490 cacheNode_490() {
+    Object local = this.mNode_490Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_490(this.mSet_36, this.cacheNode_511(), this.accessNode_23(), new ProviderImpl(this, 235), this.cacheNode_361(), new ProviderImpl(this, 276), this.mDependency_601.ep_55(), new ProviderImpl(this, 249), new CachingProviderImpl(this, 180), this.mDependency_601.ep_50(), new ProviderImpl(this, 419), new ProviderImpl(this, 264), Checks.checkProvisionNotNull(Module_609.Companion.provides_1033()), new ProviderImpl(this, 369), new ProviderImpl(this, 337), this.mDependency_601.ep_33(), new CachingProviderImpl(this, 359), new ProviderImpl(this, 82), new CachingProviderImpl(this, 376), new ProviderImpl(this, 169), new CachingProviderImpl(this, 97), new CachingProviderImpl(this, 162), new ProviderImpl(this, 128), this.cacheNode_193(), new ProviderImpl(this, 269), new CachingProviderImpl(this, 318));
+      this.mNode_490Instance = local;
+    }
+    return (Node_490) local;
+  }
+
+  Node_495 accessNode_495() {
+    return new Node_495(this.accessNode_377(), new CachingProviderImpl(this, 67), new ProviderImpl(this, 49), this.mSet_33, new ProviderImpl(this, 187), this.accessNode_396(), new CachingProviderImpl(this, 362), this.cacheNode_415(), this.cacheNode_150(), this.accessNode_18(), new ProviderImpl(this, 150), this.accessNode_239(), new CachingProviderImpl(this, 289), this.accessNode_383(), this.cacheNode_81(), this.mSet_3, new ProviderImpl(this, 353), new CachingProviderImpl(this, 407), this.accessNode_332(), new CachingProviderImpl(this, 189), this.cacheNode_238(), this.accessNode_391(), this.mDependency_601.ep_5(), this.cacheNode_98(), new CachingProviderImpl(this, 130), this.accessNode_184(), this.cacheNode_431(), new CachingProviderImpl(this, 25), this.accessNode_178(), this.mDependency_601.ep_2());
+  }
+
+  Node_496 accessNode_496() {
+    return new Node_496(new CachingProviderImpl(this, 151), new CachingProviderImpl(this, 1), new ProviderImpl(this, 488), this.accessNode_574(), new CachingProviderImpl(this, 521), new ProviderImpl(this, 254), new CachingProviderImpl(this, 360), this.mDependency_601.ep_3(), new CachingProviderImpl(this, 8), new ProviderImpl(this, 6), this.accessNode_596(), new ProviderImpl(this, 134), new ProviderImpl(this, 29), new CachingProviderImpl(this, 233), this.mDependency_601.ep_46(), new CachingProviderImpl(this, 71), new ProviderImpl(this, 21));
+  }
+
+  Node_497 accessNode_497() {
+    return new Node_497(this.accessNode_93(), new CachingProviderImpl(this, 114), new ProviderImpl(this, 115), this.accessNode_480(), this.cacheNode_450(), new ProviderImpl(this, 35));
+  }
+
+  Node_498 cacheNode_498() {
+    Object local = this.mNode_498Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_498(this.cacheNode_206(), new CachingProviderImpl(this, 390), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), new CachingProviderImpl(this, 456), new CachingProviderImpl(this, 473), new ProviderImpl(this, 245), this.cacheNode_2(), new ProviderImpl(this, 288), new CachingProviderImpl(this, 386), new ProviderImpl(this, 299), new CachingProviderImpl(this, 360), this.mDependency_601.ep_4(), this.accessNode_18(), this.mDependency_601.ep_15(), new CachingProviderImpl(this, 416), this.mSet_27, new CachingProviderImpl(this, 349), this.accessNode_470(), this.mDependency_601.ep_57(), this.mDependency_601.ep_27(), new ProviderImpl(this, 72), new CachingProviderImpl(this, 455), new ProviderImpl(this, 128), new ProviderImpl(this, 42), this.mDependency_601.ep_53(), new ProviderImpl(this, 52));
+      this.mNode_498Instance = local;
+    }
+    return (Node_498) local;
+  }
+
+  Node_5 accessNode_5() {
+    return new Node_5(new ProviderImpl(this, 90), this.accessNode_101(), new CachingProviderImpl(this, 168), this.cacheNode_584(), this.mSet_47, new CachingProviderImpl(this, 421), this.accessNode_296(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), this.accessNode_460(), new ProviderImpl(this, 266), new ProviderImpl(this, 406), this.mSet_10, new ProviderImpl(this, 302), new CachingProviderImpl(this, 413), new CachingProviderImpl(this, 192), new ProviderImpl(this, 81), new ProviderImpl(this, 429), this.mDependency_601.ep_0(), new CachingProviderImpl(this, 366), new ProviderImpl(this, 194), new ProviderImpl(this, 134), new CachingProviderImpl(this, 108), this.mDependency_601.ep_45());
+  }
+
+  Node_500 cacheNode_500() {
+    Object local = this.mNode_500Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_500(this.accessNode_329(), new CachingProviderImpl(this, 22), this.accessNode_595(), new CachingProviderImpl(this, 461), new ProviderImpl(this, 115), this.mDependency_601.ep_47(), this.accessNode_11(), new ProviderImpl(this, 205), new ProviderImpl(this, 141), new ProviderImpl(this, 333), new CachingProviderImpl(this, 434), this.accessNode_381(), new CachingProviderImpl(this, 162), this.cacheNode_429(), this.cacheNode_576(), this.accessNode_101(), new CachingProviderImpl(this, 87), Checks.checkProvisionNotNull(Module_609.Companion.provides_1075()), this.accessNode_414());
+      this.mNode_500Instance = local;
+    }
+    return (Node_500) local;
+  }
+
+  Node_506 cacheNode_506() {
+    Object local = this.mNode_506Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_506(this.cacheNode_306(), new CachingProviderImpl(this, 31), new ProviderImpl(this, 80), new CachingProviderImpl(this, 371), new CachingProviderImpl(this, 470), this.cacheNode_2(), new ProviderImpl(this, 447), new ProviderImpl(this, 94), new ProviderImpl(this, 254), new CachingProviderImpl(this, 168), new ProviderImpl(this, 224), new CachingProviderImpl(this, 403), new CachingProviderImpl(this, 409), new CachingProviderImpl(this, 286), this.mSet_42, this.accessNode_574(), this.mSet_36);
+      this.mNode_506Instance = local;
+    }
+    return (Node_506) local;
+  }
+
+  Node_507 accessNode_507() {
+    return new Node_507(new CachingProviderImpl(this, 143), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), this.cacheNode_157(), new ProviderImpl(this, 90), this.mSet_32, this.accessNode_558(), this.mDependency_601.ep_30(), new CachingProviderImpl(this, 390), this.mSet_32, new ProviderImpl(this, 280), new ProviderImpl(this, 181), this.accessNode_443(), this.accessNode_37(), this.mSet_45, this.cacheNode_490(), new CachingProviderImpl(this, 233), new ProviderImpl(this, 76), this.accessNode_115(), new ProviderImpl(this, 380), this.mDependency_601.ep_42(), new ProviderImpl(this, 256), new ProviderImpl(this, 133), new CachingProviderImpl(this, 360), new ProviderImpl(this, 264), this.accessNode_301(), new CachingProviderImpl(this, 436), new CachingProviderImpl(this, 434), new ProviderImpl(this, 419), this.mSet_46);
+  }
+
+  Node_51 accessNode_51() {
+    return new Node_51(new ProviderImpl(this, 181));
+  }
+
+  Node_510 accessNode_510() {
+    return new Node_510(this.accessNode_106(), new CachingProviderImpl(this, 184), new CachingProviderImpl(this, 114), new ProviderImpl(this, 60), new ProviderImpl(this, 424), new ProviderImpl(this, 123), new CachingProviderImpl(this, 118), this.cacheNode_87(), new CachingProviderImpl(this, 65), new CachingProviderImpl(this, 459), this.mDependency_601.ep_23(), new CachingProviderImpl(this, 71), this.accessNode_433());
+  }
+
+  Node_511 cacheNode_511() {
+    Object local = this.mNode_511Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_511(new ProviderImpl(this, 35), new CachingProviderImpl(this, 71), new CachingProviderImpl(this, 227), new ProviderImpl(this, 259), this.mSet_18, this.cacheNode_79(), new ProviderImpl(this, 161), this.mSet_34, Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), Checks.checkProvisionNotNull(Module_609.Companion.provides_1033()), new ProviderImpl(this, 132), new ProviderImpl(this, 350), this.mSet_16, this.mSet_12, this.mSet_28, new ProviderImpl(this, 445), new CachingProviderImpl(this, 186), new CachingProviderImpl(this, 153), new CachingProviderImpl(this, 258), new CachingProviderImpl(this, 62), new ProviderImpl(this, 243), Checks.checkProvisionNotNull(Module_609.Companion.provides_1047()), new ProviderImpl(this, 343));
+      this.mNode_511Instance = local;
+    }
+    return (Node_511) local;
+  }
+
+  Node_512 accessNode_512() {
+    return new Node_512(this.cacheNode_584(), new CachingProviderImpl(this, 465), new CachingProviderImpl(this, 409), this.mDependency_601.ep_51(), new ProviderImpl(this, 161), new ProviderImpl(this, 55), new ProviderImpl(this, 325), this.accessNode_336(), new CachingProviderImpl(this, 466), new ProviderImpl(this, 92), new ProviderImpl(this, 508), new ProviderImpl(this, 19), this.mDependency_601.ep_16(), new CachingProviderImpl(this, 160), new ProviderImpl(this, 385), this.cacheNode_550(), new CachingProviderImpl(this, 8), this.cacheNode_81());
+  }
+
+  Node_513 cacheNode_513() {
+    Object local = this.mNode_513Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_513(new ProviderImpl(this, 28), this.mSet_32, this.accessNode_18(), new CachingProviderImpl(this, 154), this.accessNode_548(), this.cacheNode_481(), this.cacheNode_519(), this.mSet_17, this.cacheNode_143(), new ProviderImpl(this, 168), this.cacheNode_104(), new ProviderImpl(this, 429), this.cacheNode_102(), new ProviderImpl(this, 297), this.accessNode_430(), this.mSet_42, this.cacheNode_341(), this.cacheNode_123(), new CachingProviderImpl(this, 348));
+      this.mNode_513Instance = local;
+    }
+    return (Node_513) local;
+  }
+
+  Node_514 accessNode_514() {
+    return new Node_514(this.mSet_24, new CachingProviderImpl(this, 466), new ProviderImpl(this, 316), this.accessNode_439(), new ProviderImpl(this, 410), this.cacheNode_547(), this.accessNode_458(), new CachingProviderImpl(this, 292), this.mSet_38, new CachingProviderImpl(this, 355), new CachingProviderImpl(this, 327), this.accessNode_222(), new CachingProviderImpl(this, 499), this.accessNode_492(), this.accessNode_433(), this.cacheNode_325(), this.cacheNode_273(), new ProviderImpl(this, 78), this.mDependency_601.ep_31(), new ProviderImpl(this, 76), new ProviderImpl(this, 305), this.mDependency_601.ep_48(), new CachingProviderImpl(this, 104), this.cacheNode_513());
+  }
+
+  Node_515 accessNode_515() {
+    return new Node_515(this.accessNode_455(), this.mDependency_601.ep_32(), new ProviderImpl(this, 325), this.accessNode_160(), this.mSet_19, new ProviderImpl(this, 271), new CachingProviderImpl(this, 328), new ProviderImpl(this, 77), new ProviderImpl(this, 91), this.mDependency_601.ep_25(), new ProviderImpl(this, 269), new CachingProviderImpl(this, 368), new CachingProviderImpl(this, 507), this.cacheNode_567());
+  }
+
+  Node_519 cacheNode_519() {
+    Object local = this.mNode_519Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_519(this.mSet_26, new CachingProviderImpl(this, 362), new ProviderImpl(this, 489), new CachingProviderImpl(this, 466), new CachingProviderImpl(this, 56), this.mDependency_601.ep_4(), new CachingProviderImpl(this, 156));
+      this.mNode_519Instance = local;
+    }
+    return (Node_519) local;
+  }
+
+  Node_527 cacheNode_527() {
+    Object local = this.mNode_527Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_527(this.cacheNode_524(), new ProviderImpl(this, 324), this.mSet_38, new ProviderImpl(this, 293), new ProviderImpl(this, 334), new ProviderImpl(this, 264), new CachingProviderImpl(this, 335), new ProviderImpl(this, 336), new ProviderImpl(this, 123), new ProviderImpl(this, 337), new CachingProviderImpl(this, 154), new ProviderImpl(this, 338), new ProviderImpl(this, 262), new CachingProviderImpl(this, 94), new ProviderImpl(this, 69), new CachingProviderImpl(this, 339), new CachingProviderImpl(this, 340), this.mDependency_601.ep_50(), new ProviderImpl(this, 19), this.mSet_48, this.accessNode_518(), this.cacheNode_215(), new ProviderImpl(this, 134), new ProviderImpl(this, 343), new ProviderImpl(this, 132));
+      this.mNode_527Instance = local;
+    }
+    return (Node_527) local;
+  }
+
+  Node_528 cacheNode_528() {
+    Object local = this.mNode_528Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_528(new CachingProviderImpl(this, 218));
+      this.mNode_528Instance = local;
+    }
+    return (Node_528) local;
+  }
+
+  Node_529 accessNode_529() {
+    return new Node_529(this.cacheNode_102(), new ProviderImpl(this, 193), new CachingProviderImpl(this, 119), new CachingProviderImpl(this, 398), this.accessNode_160(), new ProviderImpl(this, 90), this.mSet_2, new CachingProviderImpl(this, 382), new CachingProviderImpl(this, 94), this.mSet_16, this.accessNode_496(), this.cacheNode_215(), this.cacheNode_333(), this.accessNode_454(), this.mDependency_601.ep_52());
+  }
+
+  Node_53 cacheNode_53() {
+    Object local = this.mNode_53Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_53(this.cacheNode_559(), this.accessNode_383(), new CachingProviderImpl(this, 451), new ProviderImpl(this, 132), this.accessNode_358(), this.accessNode_460(), this.accessNode_592(), this.accessNode_186(), this.cacheNode_436(), new ProviderImpl(this, 322), this.cacheNode_22(), this.accessNode_337(), this.accessNode_26(), new ProviderImpl(this, 375), new ProviderImpl(this, 355), this.accessNode_54(), new CachingProviderImpl(this, 171), new ProviderImpl(this, 261), this.cacheNode_481(), this.accessNode_263(), this.mDependency_601.ep_22(), this.mSet_4);
+      this.mNode_53Instance = local;
+    }
+    return (Node_53) local;
+  }
+
+  Node_530 cacheNode_530() {
+    Object local = this.mNode_530Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_530(new ProviderImpl(this, 218), this.accessNode_296(), new CachingProviderImpl(this, 258), new ProviderImpl(this, 29), new ProviderImpl(this, 343), this.mDependency_601.ep_52(), new ProviderImpl(this, 134), this.mSet_25, new CachingProviderImpl(this, 478), new ProviderImpl(this, 243), this.mDependency_601.ep_15(), this.cacheNode_520(), new ProviderImpl(this, 272), this.mSet_20, new ProviderImpl(this, 209));
+      this.mNode_530Instance = local;
+    }
+    return (Node_530) local;
+  }
+
+  Node_534 accessNode_534() {
+    return new Node_534(this.cacheNode_591(), this.mDependency_601.ep_18(), new CachingProviderImpl(this, 221), new CachingProviderImpl(this, 180), new CachingProviderImpl(this, 159), new CachingProviderImpl(this, 169), new CachingProviderImpl(this, 282), Checks.checkProvisionNotNull(Module_609.Companion.provides_1027()), this.mSet_33, new CachingProviderImpl(this, 162), new ProviderImpl(this, 325), new ProviderImpl(this, 94), new CachingProviderImpl(this, 385), new CachingProviderImpl(this, 121), new ProviderImpl(this, 324), new CachingProviderImpl(this, 339), this.cacheNode_171(), new ProviderImpl(this, 386), new ProviderImpl(this, 387));
+  }
+
+  Node_537 cacheNode_537() {
+    Object local = this.mNode_537Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_537(this.mDependency_601.ep_39(), new CachingProviderImpl(this, 439), new ProviderImpl(this, 441), new CachingProviderImpl(this, 428), new CachingProviderImpl(this, 147), this.accessNode_135(), new CachingProviderImpl(this, 173), new ProviderImpl(this, 322), new ProviderImpl(this, 101), this.accessNode_596(), new ProviderImpl(this, 194), new CachingProviderImpl(this, 382), new ProviderImpl(this, 232), this.mSet_43, new CachingProviderImpl(this, 267), this.accessNode_218(), new ProviderImpl(this, 437), this.mDependency_601.ep_28(), this.cacheNode_206(), this.accessNode_458(), new CachingProviderImpl(this, 491), this.cacheNode_331(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1096()), new CachingProviderImpl(this, 42), this.mDependency_601.ep_12(), this.cacheNode_364());
+      this.mNode_537Instance = local;
+    }
+    return (Node_537) local;
+  }
+
+  Node_539 cacheNode_539() {
+    Object local = this.mNode_539Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_539(this.cacheNode_407(), this.accessNode_518(), this.mSet_36, this.accessNode_162(), new ProviderImpl(this, 308), new CachingProviderImpl(this, 119), new ProviderImpl(this, 243), new CachingProviderImpl(this, 284), this.mSet_19, new ProviderImpl(this, 480), this.mSet_5, new CachingProviderImpl(this, 186), new ProviderImpl(this, 233), new CachingProviderImpl(this, 4), this.mSet_16, this.cacheNode_354(), this.accessNode_18());
+      this.mNode_539Instance = local;
+    }
+    return (Node_539) local;
+  }
+
+  Node_54 accessNode_54() {
+    return new Node_54(this.mSet_45, new CachingProviderImpl(this, 114), this.accessNode_438());
+  }
+
+  Node_541 accessNode_541() {
+    return new Node_541(new ProviderImpl(this, 99), this.accessNode_517(), new CachingProviderImpl(this, 407), new ProviderImpl(this, 118), this.mDependency_601.ep_27(), this.accessNode_336(), this.cacheNode_267(), new ProviderImpl(this, 435), new ProviderImpl(this, 180), new CachingProviderImpl(this, 497), this.accessNode_358(), new ProviderImpl(this, 368), this.accessNode_140(), this.cacheNode_388());
+  }
+
+  Node_547 cacheNode_547() {
+    Object local = this.mNode_547Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_547(new CachingProviderImpl(this, 509), new CachingProviderImpl(this, 372), new CachingProviderImpl(this, 277), new CachingProviderImpl(this, 424), this.mSet_47);
+      this.mNode_547Instance = local;
+    }
+    return (Node_547) local;
+  }
+
+  Node_548 accessNode_548() {
+    return new Node_548(this.cacheNode_331(), new ProviderImpl(this, 219), this.mDependency_601.ep_6());
+  }
+
+  Node_550 cacheNode_550() {
+    Object local = this.mNode_550Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_550(new CachingProviderImpl(this, 315), this.accessNode_164(), new ProviderImpl(this, 67), new ProviderImpl(this, 425), new CachingProviderImpl(this, 331), new CachingProviderImpl(this, 268), new ProviderImpl(this, 10), this.cacheNode_2(), new ProviderImpl(this, 33), this.cacheNode_92(), new ProviderImpl(this, 38), this.mDependency_601.ep_22(), new ProviderImpl(this, 68), this.mSet_13, new ProviderImpl(this, 525), this.cacheNode_506(), new ProviderImpl(this, 133), this.mDependency_601.ep_4());
+      this.mNode_550Instance = local;
+    }
+    return (Node_550) local;
+  }
+
+  Node_552 accessNode_552() {
+    return new Node_552(new ProviderImpl(this, 361), new ProviderImpl(this, 412), new ProviderImpl(this, 133), new ProviderImpl(this, 334), this.mDependency_601.ep_51(), new ProviderImpl(this, 124), new ProviderImpl(this, 511), this.accessNode_336(), this.accessNode_497(), this.accessNode_447(), new CachingProviderImpl(this, 500), new ProviderImpl(this, 238), this.cacheNode_519(), new CachingProviderImpl(this, 96), new ProviderImpl(this, 512), new CachingProviderImpl(this, 88), this.cacheNode_15(), this.mSet_44, this.mDependency_601.ep_32(), new CachingProviderImpl(this, 258), new ProviderImpl(this, 159), new CachingProviderImpl(this, 407), this.accessNode_136(), this.cacheNode_325(), this.cacheNode_494(), Checks.checkProvisionNotNull(Module_609.Companion.provides_975()), this.accessNode_189());
+  }
+
+  Node_556 cacheNode_556() {
+    Object local = this.mNode_556Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_556(this.cacheNode_584(), this.mDependency_601.ep_7(), new ProviderImpl(this, 262), new ProviderImpl(this, 21), this.cacheNode_576(), this.mDependency_601.ep_19(), new ProviderImpl(this, 374), new CachingProviderImpl(this, 38), this.mDependency_601.ep_48(), this.cacheNode_71(), new ProviderImpl(this, 462), this.accessNode_433(), new CachingProviderImpl(this, 439), this.cacheNode_87(), new CachingProviderImpl(this, 470), new CachingProviderImpl(this, 497), this.accessNode_344(), new ProviderImpl(this, 110), this.mDependency_601.ep_3());
+      this.mNode_556Instance = local;
+    }
+    return (Node_556) local;
+  }
+
+  Node_558 accessNode_558() {
+    return new Node_558(new CachingProviderImpl(this, 327), this.accessNode_497(), new ProviderImpl(this, 472), Checks.checkProvisionNotNull(Module_609.Companion.provides_1027()), new ProviderImpl(this, 452), this.accessNode_439(), new CachingProviderImpl(this, 31), this.accessNode_85(), this.cacheNode_429(), new ProviderImpl(this, 299), new ProviderImpl(this, 197), this.accessNode_418(), new CachingProviderImpl(this, 318), this.mDependency_601.ep_52(), new CachingProviderImpl(this, 135), new CachingProviderImpl(this, 60), new CachingProviderImpl(this, 462), this.mDependency_601.ep_28());
+  }
+
+  Node_559 cacheNode_559() {
+    Object local = this.mNode_559Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_559(this.accessNode_574(), new CachingProviderImpl(this, 430), new ProviderImpl(this, 373), this.mDependency_601.ep_25(), this.accessNode_460(), this.accessNode_381(), new CachingProviderImpl(this, 372), new ProviderImpl(this, 512), new CachingProviderImpl(this, 135), new CachingProviderImpl(this, 454), this.cacheNode_386(), this.cacheNode_466(), new ProviderImpl(this, 269), new CachingProviderImpl(this, 467), new CachingProviderImpl(this, 476), new CachingProviderImpl(this, 322), this.mDependency_601.ep_32(), new ProviderImpl(this, 362), this.mDependency_601.ep_35());
+      this.mNode_559Instance = local;
+    }
+    return (Node_559) local;
+  }
+
+  Node_56 accessNode_56() {
+    return new Node_56(this.mSet_10, new CachingProviderImpl(this, 328), this.cacheNode_535(), new CachingProviderImpl(this, 4), this.mSet_33, new CachingProviderImpl(this, 119), new ProviderImpl(this, 211), new ProviderImpl(this, 219));
+  }
+
+  Node_560 cacheNode_560() {
+    Object local = this.mNode_560Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_560(this.cacheNode_571(), new CachingProviderImpl(this, 221), this.accessNode_292(), new CachingProviderImpl(this, 263), this.accessNode_410(), new CachingProviderImpl(this, 121), this.cacheNode_102(), this.accessNode_146(), this.mDependency_601.ep_12(), new ProviderImpl(this, 374), this.accessNode_337(), new ProviderImpl(this, 157), new ProviderImpl(this, 125), new CachingProviderImpl(this, 336), new CachingProviderImpl(this, 439), this.accessNode_383(), this.accessNode_365(), new ProviderImpl(this, 59), this.accessNode_51(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), new CachingProviderImpl(this, 518), new ProviderImpl(this, 314), new ProviderImpl(this, 276), this.accessNode_467(), new CachingProviderImpl(this, 159), this.mSet_44, this.mSet_6, new CachingProviderImpl(this, 23));
+      this.mNode_560Instance = local;
+    }
+    return (Node_560) local;
+  }
+
+  Node_562 cacheNode_562() {
+    Object local = this.mNode_562Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_562(new ProviderImpl(this, 209), this.accessNode_596(), new ProviderImpl(this, 199), new CachingProviderImpl(this, 468), new ProviderImpl(this, 329), this.cacheNode_152(), this.cacheNode_530(), new ProviderImpl(this, 441), this.cacheNode_253(), this.accessNode_329(), this.accessNode_290(), new CachingProviderImpl(this, 294));
+      this.mNode_562Instance = local;
+    }
+    return (Node_562) local;
+  }
+
+  Node_565 cacheNode_565() {
+    Object local = this.mNode_565Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_565(this.accessNode_101(), new CachingProviderImpl(this, 171), this.mDependency_601.ep_39(), new CachingProviderImpl(this, 371), new CachingProviderImpl(this, 424), new CachingProviderImpl(this, 39), new ProviderImpl(this, 311), this.mDependency_601.ep_16(), this.cacheNode_524(), this.mDependency_601.ep_36(), new CachingProviderImpl(this, 2), this.cacheNode_102(), this.accessNode_264(), this.mDependency_601.ep_8(), new ProviderImpl(this, 231), this.mDependency_601.ep_22(), new CachingProviderImpl(this, 347), this.mDependency_601.ep_42(), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()));
+      this.mNode_565Instance = local;
+    }
+    return (Node_565) local;
+  }
+
+  Node_567 cacheNode_567() {
+    Object local = this.mNode_567Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_567(new CachingProviderImpl(this, 1), this.cacheNode_547(), this.accessNode_336(), new CachingProviderImpl(this, 318), new ProviderImpl(this, 139), this.accessNode_492(), new ProviderImpl(this, 117));
+      this.mNode_567Instance = local;
+    }
+    return (Node_567) local;
+  }
+
+  Node_570 cacheNode_570() {
+    Object local = this.mNode_570Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_570(new CachingProviderImpl(this, 233), this.accessNode_548(), this.cacheNode_527(), this.cacheNode_441(), this.cacheNode_450(), new CachingProviderImpl(this, 234), new CachingProviderImpl(this, 235), new ProviderImpl(this, 236), new ProviderImpl(this, 78));
+      this.mNode_570Instance = local;
+    }
+    return (Node_570) local;
+  }
+
+  Node_572 cacheNode_572() {
+    Object local = this.mNode_572Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_572(this.accessNode_33(), this.mSet_32, new ProviderImpl(this, 397), this.accessNode_492(), new CachingProviderImpl(this, 360), this.accessNode_85(), this.cacheNode_519(), new CachingProviderImpl(this, 398), this.accessNode_409(), new ProviderImpl(this, 399), this.mSet_27);
+      this.mNode_572Instance = local;
+    }
+    return (Node_572) local;
+  }
+
+  Node_573 accessNode_573() {
+    return new Node_573(new ProviderImpl(this, 435), this.cacheNode_306(), this.accessNode_219(), new CachingProviderImpl(this, 79), new ProviderImpl(this, 199), new ProviderImpl(this, 90), this.accessNode_512(), this.cacheNode_82(), this.accessNode_105(), this.accessNode_536(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1049()), this.cacheNode_154(), new ProviderImpl(this, 176), new CachingProviderImpl(this, 338), new CachingProviderImpl(this, 241), this.cacheNode_521(), this.accessNode_358(), new CachingProviderImpl(this, 189), this.cacheNode_319(), new ProviderImpl(this, 181), this.accessNode_416(), this.cacheNode_547(), this.cacheNode_121(), this.accessNode_191(), this.cacheNode_413(), this.accessNode_460(), this.cacheNode_359(), this.cacheNode_53(), new CachingProviderImpl(this, 349));
+  }
+
+  Node_574 accessNode_574() {
+    return new Node_574(new ProviderImpl(this, 117), this.mDependency_601.ep_18(), new ProviderImpl(this, 55), new ProviderImpl(this, 90), new ProviderImpl(this, 187), new CachingProviderImpl(this, 27), this.cacheNode_456(), new ProviderImpl(this, 209), new ProviderImpl(this, 277), this.accessNode_595(), new ProviderImpl(this, 136), this.mDependency_601.ep_41(), new ProviderImpl(this, 193), new ProviderImpl(this, 134), new CachingProviderImpl(this, 37), this.cacheNode_551(), new ProviderImpl(this, 310), new ProviderImpl(this, 90), new ProviderImpl(this, 472), new ProviderImpl(this, 145), new CachingProviderImpl(this, 380), new ProviderImpl(this, 344), this.mSet_41, new ProviderImpl(this, 516), new CachingProviderImpl(this, 159), new ProviderImpl(this, 45), new CachingProviderImpl(this, 218), new CachingProviderImpl(this, 175));
+  }
+
+  Node_578 cacheNode_578() {
+    Object local = this.mNode_578Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_578(this.accessNode_289(), this.cacheNode_490(), new ProviderImpl(this, 146), this.cacheNode_426(), this.mSet_20, new ProviderImpl(this, 199), this.cacheNode_81(), this.cacheNode_119(), this.mSet_21, new ProviderImpl(this, 264), new ProviderImpl(this, 265), this.cacheNode_363(), this.cacheNode_286(), this.accessNode_54(), this.accessNode_475(), this.cacheNode_271(), this.cacheNode_404(), new CachingProviderImpl(this, 151), new ProviderImpl(this, 53), this.cacheNode_152(), new CachingProviderImpl(this, 162), new ProviderImpl(this, 235), this.cacheNode_143(), new ProviderImpl(this, 90), this.mSet_22, this.accessNode_600(), this.cacheNode_121(), this.accessNode_128(), this.mDependency_601.ep_50());
+      this.mNode_578Instance = local;
+    }
+    return (Node_578) local;
+  }
+
+  Node_581 cacheNode_581() {
+    Object local = this.mNode_581Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_581(this.cacheNode_530(), this.accessNode_497(), this.cacheNode_172(), new ProviderImpl(this, 299));
+      this.mNode_581Instance = local;
+    }
+    return (Node_581) local;
+  }
+
+  Node_582 accessNode_582() {
+    return new Node_582(new CachingProviderImpl(this, 58), new ProviderImpl(this, 208), this.accessNode_168(), this.accessNode_418(), this.mDependency_601.ep_4(), this.accessNode_298(), new ProviderImpl(this, 266), this.mSet_38, new CachingProviderImpl(this, 191), this.accessNode_367(), new ProviderImpl(this, 143), new ProviderImpl(this, 348), this.cacheNode_131(), new ProviderImpl(this, 365));
+  }
+
+  Node_584 cacheNode_584() {
+    Object local = this.mNode_584Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_584(new CachingProviderImpl(this, 175), this.cacheNode_481(), this.cacheNode_361(), this.accessNode_419(), this.cacheNode_147(), new CachingProviderImpl(this, 159), new ProviderImpl(this, 287), new ProviderImpl(this, 482), this.mDependency_601.ep_35(), new CachingProviderImpl(this, 363), new CachingProviderImpl(this, 120), new ProviderImpl(this, 484), new ProviderImpl(this, 326), new CachingProviderImpl(this, 327), new ProviderImpl(this, 87), new ProviderImpl(this, 20), new CachingProviderImpl(this, 318));
+      this.mNode_584Instance = local;
+    }
+    return (Node_584) local;
+  }
+
+  Node_585 accessNode_585() {
+    return new Node_585(this.cacheNode_479(), this.cacheNode_102(), new CachingProviderImpl(this, 321), this.mDependency_601.ep_54(), new CachingProviderImpl(this, 351), new CachingProviderImpl(this, 434), this.mSet_36, this.accessNode_418(), this.mSet_29, new CachingProviderImpl(this, 339), this.mDependency_601.ep_24(), this.cacheNode_360(), this.mDependency_601.ep_39(), this.cacheNode_535(), new CachingProviderImpl(this, 62), new ProviderImpl(this, 265), this.accessNode_339(), new CachingProviderImpl(this, 231), this.mDependency_601.ep_2(), this.accessNode_109(), this.accessNode_485(), this.mDependency_601.ep_41(), new ProviderImpl(this, 6));
+  }
+
+  Node_586 cacheNode_586() {
+    Object local = this.mNode_586Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_586(this.cacheNode_457(), new ProviderImpl(this, 482), new ProviderImpl(this, 449), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 70), new CachingProviderImpl(this, 366), this.accessNode_292(), this.accessNode_574(), new CachingProviderImpl(this, 421), new CachingProviderImpl(this, 427), new CachingProviderImpl(this, 523), this.mDependency_601.ep_16(), this.accessNode_313(), new ProviderImpl(this, 326), new CachingProviderImpl(this, 300), new CachingProviderImpl(this, 456), new ProviderImpl(this, 237), new ProviderImpl(this, 472));
+      this.mNode_586Instance = local;
+    }
+    return (Node_586) local;
+  }
+
+  Node_588 cacheNode_588() {
+    Object local = this.mNode_588Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_588(this.mDependency_601.ep_20(), new ProviderImpl(this, 251), new ProviderImpl(this, 252), new CachingProviderImpl(this, 253), new ProviderImpl(this, 50), new ProviderImpl(this, 254), new CachingProviderImpl(this, 171), new ProviderImpl(this, 255), this.accessNode_203(), new CachingProviderImpl(this, 256), this.cacheNode_361());
+      this.mNode_588Instance = local;
+    }
+    return (Node_588) local;
+  }
+
+  Node_589 cacheNode_589() {
+    Object local = this.mNode_589Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_589(new CachingProviderImpl(this, 281), this.mSet_13, this.accessNode_96(), new ProviderImpl(this, 263), new Node_181(), new ProviderImpl(this, 323), this.mDependency_601.ep_31(), this.cacheNode_238(), this.accessNode_23(), new ProviderImpl(this, 74), new CachingProviderImpl(this, 398), new ProviderImpl(this, 16), this.mSet_28, new ProviderImpl(this, 383), new CachingProviderImpl(this, 372), new ProviderImpl(this, 271), new ProviderImpl(this, 366), new CachingProviderImpl(this, 409), this.accessNode_37(), this.cacheNode_303(), new CachingProviderImpl(this, 217));
+      this.mNode_589Instance = local;
+    }
+    return (Node_589) local;
+  }
+
+  Node_59 accessNode_59() {
+    return new Node_59(this.accessNode_300(), new ProviderImpl(this, 501), new CachingProviderImpl(this, 142), new ProviderImpl(this, 357), this.cacheNode_474(), new CachingProviderImpl(this, 73), this.mSet_21, new CachingProviderImpl(this, 407), this.mSet_50, new ProviderImpl(this, 265), new CachingProviderImpl(this, 31), new CachingProviderImpl(this, 129), this.mDependency_601.ep_57(), new ProviderImpl(this, 24), new ProviderImpl(this, 195), new ProviderImpl(this, 219), new ProviderImpl(this, 305));
+  }
+
+  Node_590 accessNode_590() {
+    return new Node_590(this.cacheNode_49(), new CachingProviderImpl(this, 439), new CachingProviderImpl(this, 231), this.cacheNode_15(), new ProviderImpl(this, 71), new CachingProviderImpl(this, 282), new ProviderImpl(this, 406), this.accessNode_432());
+  }
+
+  Node_593 cacheNode_593() {
+    Object local = this.mNode_593Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_593(this.cacheNode_325(), new CachingProviderImpl(this, 467), new ProviderImpl(this, 86), new CachingProviderImpl(this, 229), new ProviderImpl(this, 419), new ProviderImpl(this, 369), this.cacheNode_104(), new CachingProviderImpl(this, 87), new CachingProviderImpl(this, 499), new ProviderImpl(this, 527), new ProviderImpl(this, 295), this.accessNode_242(), this.mDependency_601.ep_47(), this.cacheNode_599(), this.accessNode_514(), this.mSet_51);
+      this.mNode_593Instance = local;
+    }
+    return (Node_593) local;
+  }
+
+  Node_595 accessNode_595() {
+    return new Node_595(Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), new ProviderImpl(this, 298), new CachingProviderImpl(this, 168), new CachingProviderImpl(this, 256), this.mSet_51, new CachingProviderImpl(this, 279), this.mDependency_601.ep_20(), new ProviderImpl(this, 63), new CachingProviderImpl(this, 282), new ProviderImpl(this, 403), new CachingProviderImpl(this, 97));
+  }
+
+  Node_596 accessNode_596() {
+    return new Node_596(new ProviderImpl(this, 90), new CachingProviderImpl(this, 52), new CachingProviderImpl(this, 268), this.cacheNode_215(), new ProviderImpl(this, 471), new ProviderImpl(this, 255), this.cacheNode_40(), new CachingProviderImpl(this, 427));
+  }
+
+  Node_597 accessNode_597() {
+    return new Node_597(new ProviderImpl(this, 13), new ProviderImpl(this, 24), new CachingProviderImpl(this, 403), new CachingProviderImpl(this, 366), new CachingProviderImpl(this, 154), new ProviderImpl(this, 117), new CachingProviderImpl(this, 445), new ProviderImpl(this, 81), new CachingProviderImpl(this, 230), new CachingProviderImpl(this, 184), this.cacheNode_456());
+  }
+
+  Node_6 cacheNode_6() {
+    Object local = this.mNode_6Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_6(new CachingProviderImpl(this, 454), this.accessNode_512(), new CachingProviderImpl(this, 378), new ProviderImpl(this, 457), new ProviderImpl(this, 68), new ProviderImpl(this, 271), new ProviderImpl(this, 303), this.accessNode_460(), new CachingProviderImpl(this, 0), this.mDependency_601.ep_1(), new ProviderImpl(this, 369), this.mDependency_601.ep_36(), new CachingProviderImpl(this, 218), this.mDependency_601.ep_18());
+      this.mNode_6Instance = local;
+    }
+    return (Node_6) local;
+  }
+
+  Node_600 accessNode_600() {
+    return new Node_600(this.mSet_13, this.cacheNode_527(), new ProviderImpl(this, 90), new CachingProviderImpl(this, 188), this.mDependency_601.ep_14(), new CachingProviderImpl(this, 190), new CachingProviderImpl(this, 191), this.accessNode_8(), new ProviderImpl(this, 193), new ProviderImpl(this, 194), new ProviderImpl(this, 195), new CachingProviderImpl(this, 196), this.cacheNode_49(), this.cacheNode_40(), new ProviderImpl(this, 198), this.accessNode_305(), new ProviderImpl(this, 199), new CachingProviderImpl(this, 200));
+  }
+
+  Node_63 accessNode_63() {
+    return new Node_63(new ProviderImpl(this, 46), new ProviderImpl(this, 117), this.accessNode_518(), new ProviderImpl(this, 119), new CachingProviderImpl(this, 120), new CachingProviderImpl(this, 121), new CachingProviderImpl(this, 23), new ProviderImpl(this, 111), this.mSet_10, new ProviderImpl(this, 123), new CachingProviderImpl(this, 124), new ProviderImpl(this, 125), this.mSet_8, this.mDependency_601.ep_21(), this.mSet_32, new ProviderImpl(this, 128), this.cacheNode_376(), this.accessNode_590(), this.mSet_9, new ProviderImpl(this, 131), new ProviderImpl(this, 132), new ProviderImpl(this, 133), new ProviderImpl(this, 134), new CachingProviderImpl(this, 135), this.cacheNode_87());
+  }
+
+  Node_67 cacheNode_67() {
+    Object local = this.mNode_67Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_67(this.cacheNode_431(), this.mSet_11, new CachingProviderImpl(this, 126), this.cacheNode_556(), new ProviderImpl(this, 90), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), new ProviderImpl(this, 131), new ProviderImpl(this, 443), new ProviderImpl(this, 517), this.cacheNode_456(), new CachingProviderImpl(this, 71), this.accessNode_165(), new CachingProviderImpl(this, 467), new ProviderImpl(this, 125), this.mSet_29, new CachingProviderImpl(this, 504), new CachingProviderImpl(this, 94), new ProviderImpl(this, 369), new ProviderImpl(this, 381), new CachingProviderImpl(this, 65));
+      this.mNode_67Instance = local;
+    }
+    return (Node_67) local;
+  }
+
+  Node_7 cacheNode_7() {
+    Object local = this.mNode_7Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_7(new CachingProviderImpl(this, 42), new ProviderImpl(this, 414), Checks.checkProvisionNotNull(Module_609.Companion.provides_1052()), new CachingProviderImpl(this, 94), new CachingProviderImpl(this, 171), this.accessNode_293(), new CachingProviderImpl(this, 494));
+      this.mNode_7Instance = local;
+    }
+    return (Node_7) local;
+  }
+
+  Node_72 cacheNode_72() {
+    Object local = this.mNode_72Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_72(this.cacheNode_524(), this.cacheNode_6(), this.accessNode_501(), new ProviderImpl(this, 41));
+      this.mNode_72Instance = local;
+    }
+    return (Node_72) local;
+  }
+
+  Node_74 accessNode_74() {
+    return new Node_74(this.mDependency_601.ep_41(), this.accessNode_305(), new ProviderImpl(this, 381), this.mSet_8, this.accessNode_5(), new ProviderImpl(this, 454), this.accessNode_596(), this.cacheNode_426(), this.mDependency_601.ep_40(), new CachingProviderImpl(this, 417), this.accessNode_320());
+  }
+
+  Node_77 cacheNode_77() {
+    Object local = this.mNode_77Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_77(this.accessNode_175(), new ProviderImpl(this, 453), new CachingProviderImpl(this, 222), this.mSet_33, new ProviderImpl(this, 482), this.cacheNode_466(), this.accessNode_16(), Checks.checkProvisionNotNull(Module_609.Companion.provides_1046()), new ProviderImpl(this, 272), new ProviderImpl(this, 167), new CachingProviderImpl(this, 4), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 516), this.accessNode_434(), this.accessNode_191(), this.cacheNode_589(), this.accessNode_187(), new ProviderImpl(this, 117), this.accessNode_292(), new CachingProviderImpl(this, 273), this.mDependency_601.ep_46(), new ProviderImpl(this, 42), this.accessNode_379(), new ProviderImpl(this, 452), new CachingProviderImpl(this, 162), this.cacheNode_273(), new ProviderImpl(this, 429));
+      this.mNode_77Instance = local;
+    }
+    return (Node_77) local;
+  }
+
+  Node_79 cacheNode_79() {
+    Object local = this.mNode_79Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_79(new CachingProviderImpl(this, 478), this.cacheNode_2(), this.mDependency_601.ep_26(), this.cacheNode_494(), new ProviderImpl(this, 331), this.accessNode_305(), new ProviderImpl(this, 110), new CachingProviderImpl(this, 113), this.accessNode_187(), new CachingProviderImpl(this, 360), new ProviderImpl(this, 363), new CachingProviderImpl(this, 376), this.cacheNode_386(), new ProviderImpl(this, 447), this.mSet_29, new CachingProviderImpl(this, 218), new ProviderImpl(this, 54), this.mDependency_601.ep_33(), this.cacheNode_167(), this.cacheNode_551(), new CachingProviderImpl(this, 366), new CachingProviderImpl(this, 407), new CachingProviderImpl(this, 315), this.mDependency_601.ep_56(), new CachingProviderImpl(this, 408), new ProviderImpl(this, 164), this.mSet_25);
+      this.mNode_79Instance = local;
+    }
+    return (Node_79) local;
+  }
+
+  Node_81 cacheNode_81() {
+    Object local = this.mNode_81Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_81(new CachingProviderImpl(this, 210), new ProviderImpl(this, 63), new CachingProviderImpl(this, 44), new ProviderImpl(this, 59), new ProviderImpl(this, 326), this.cacheNode_571());
+      this.mNode_81Instance = local;
+    }
+    return (Node_81) local;
+  }
+
+  Node_93 accessNode_93() {
+    return new Node_93(new CachingProviderImpl(this, 73), new CachingProviderImpl(this, 327), Checks.checkProvisionNotNull(Module_609.Companion.provides_997()), new CachingProviderImpl(this, 67), this.accessNode_127());
+  }
+
+  Node_96 accessNode_96() {
+    return new Node_96(this.mSet_32, new ProviderImpl(this, 123), this.mSet_22, this.mDependency_601.ep_54(), this.accessNode_11(), new CachingProviderImpl(this, 229), new ProviderImpl(this, 148), this.cacheNode_366(), this.cacheNode_49(), new CachingProviderImpl(this, 473), this.mDependency_601.ep_10(), new CachingProviderImpl(this, 284), new CachingProviderImpl(this, 218), this.mSet_6, new CachingProviderImpl(this, 413), new ProviderImpl(this, 134));
+  }
+
+  Node_97 accessNode_97() {
+    return new Node_97(this.mDependency_601.ep_20(), new ProviderImpl(this, 91), new CachingProviderImpl(this, 455));
+  }
+
+  Node_98 cacheNode_98() {
+    Object local = this.mNode_98Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_98(this.cacheNode_2(), new ProviderImpl(this, 24), new ProviderImpl(this, 418), new CachingProviderImpl(this, 307), this.cacheNode_206(), new ProviderImpl(this, 433), new CachingProviderImpl(this, 317));
+      this.mNode_98Instance = local;
+    }
+    return (Node_98) local;
+  }
+
+  Node_99 cacheNode_99() {
+    Object local = this.mNode_99Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_99(this.accessNode_199(), this.accessNode_518(), new ProviderImpl(this, 90), this.accessNode_460(), new CachingProviderImpl(this, 142), this.accessNode_96(), this.mDependency_601.ep_8(), this.cacheNode_349(), this.cacheNode_581(), this.accessNode_515(), new CachingProviderImpl(this, 296), this.accessNode_395(), this.accessNode_379(), new CachingProviderImpl(this, 39), this.cacheNode_389(), this.cacheNode_104(), this.accessNode_93(), this.cacheNode_281(), new ProviderImpl(this, 264), this.cacheNode_572(), new ProviderImpl(this, 299), new CachingProviderImpl(this, 300), this.cacheNode_190(), new CachingProviderImpl(this, 302), this.cacheNode_25(), new CachingProviderImpl(this, 304), Checks.checkProvisionNotNull(Module_609.Companion.provides_1034()), this.cacheNode_78());
+      this.mNode_99Instance = local;
+    }
+    return (Node_99) local;
+  }
+
+  public static Component_603.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$Component_603 mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$Component_603 delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$Component_603 mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$Component_603 factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements Component_603.Creator {
+    private Dependency_601 mSetDep_0;
+
+    private Node_183 mSet_0;
+
+    private Node_272 mSet_1;
+
+    private Node_237 mSet_10;
+
+    private Node_545 mSet_11;
+
+    private Node_471 mSet_12;
+
+    private Node_357 mSet_13;
+
+    private Node_9 mSet_14;
+
+    private Node_287 mSet_15;
+
+    private Node_255 mSet_16;
+
+    private Node_94 mSet_17;
+
+    private Node_516 mSet_18;
+
+    private Node_369 mSet_19;
+
+    private Node_125 mSet_2;
+
+    private Node_321 mSet_20;
+
+    private Node_75 mSet_21;
+
+    private Node_88 mSet_22;
+
+    private Node_412 mSet_23;
+
+    private Node_400 mSet_24;
+
+    private Node_283 mSet_25;
+
+    private Node_276 mSet_26;
+
+    private Node_525 mSet_27;
+
+    private Node_493 mSet_28;
+
+    private Node_110 mSet_29;
+
+    private Node_326 mSet_3;
+
+    private Node_526 mSet_30;
+
+    private Node_52 mSet_31;
+
+    private Node_294 mSet_32;
+
+    private Node_452 mSet_33;
+
+    private Node_17 mSet_34;
+
+    private Node_382 mSet_35;
+
+    private Node_378 mSet_36;
+
+    private Node_277 mSet_37;
+
+    private Node_554 mSet_38;
+
+    private Node_196 mSet_39;
+
+    private Node_442 mSet_4;
+
+    private Node_522 mSet_40;
+
+    private Node_35 mSet_41;
+
+    private Node_204 mSet_42;
+
+    private Node_259 mSet_43;
+
+    private Node_392 mSet_44;
+
+    private Node_39 mSet_45;
+
+    private Node_486 mSet_46;
+
+    private Node_68 mSet_47;
+
+    private Node_145 mSet_48;
+
+    private Node_370 mSet_49;
+
+    private Node_335 mSet_5;
+
+    private Node_117 mSet_50;
+
+    private Node_278 mSet_51;
+
+    private Node_24 mSet_6;
+
+    private Node_129 mSet_7;
+
+    private Node_170 mSet_8;
+
+    private Node_523 mSet_9;
+
+    @Override
+    public Component_603.Creator setDep_0(Dependency_601 i) {
+      this.mSetDep_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_0(Node_183 i) {
+      this.mSet_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_1(Node_272 i) {
+      this.mSet_1 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_10(Node_237 i) {
+      this.mSet_10 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_11(Node_545 i) {
+      this.mSet_11 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_12(Node_471 i) {
+      this.mSet_12 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_13(Node_357 i) {
+      this.mSet_13 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_14(Node_9 i) {
+      this.mSet_14 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_15(Node_287 i) {
+      this.mSet_15 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_16(Node_255 i) {
+      this.mSet_16 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_17(Node_94 i) {
+      this.mSet_17 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_18(Node_516 i) {
+      this.mSet_18 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_19(Node_369 i) {
+      this.mSet_19 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_2(Node_125 i) {
+      this.mSet_2 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_20(Node_321 i) {
+      this.mSet_20 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_21(Node_75 i) {
+      this.mSet_21 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_22(Node_88 i) {
+      this.mSet_22 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_23(Node_412 i) {
+      this.mSet_23 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_24(Node_400 i) {
+      this.mSet_24 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_25(Node_283 i) {
+      this.mSet_25 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_26(Node_276 i) {
+      this.mSet_26 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_27(Node_525 i) {
+      this.mSet_27 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_28(Node_493 i) {
+      this.mSet_28 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_29(Node_110 i) {
+      this.mSet_29 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_3(Node_326 i) {
+      this.mSet_3 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_30(Node_526 i) {
+      this.mSet_30 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_31(Node_52 i) {
+      this.mSet_31 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_32(Node_294 i) {
+      this.mSet_32 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_33(Node_452 i) {
+      this.mSet_33 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_34(Node_17 i) {
+      this.mSet_34 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_35(Node_382 i) {
+      this.mSet_35 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_36(Node_378 i) {
+      this.mSet_36 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_37(Node_277 i) {
+      this.mSet_37 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_38(Node_554 i) {
+      this.mSet_38 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_39(Node_196 i) {
+      this.mSet_39 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_4(Node_442 i) {
+      this.mSet_4 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_40(Node_522 i) {
+      this.mSet_40 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_41(Node_35 i) {
+      this.mSet_41 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_42(Node_204 i) {
+      this.mSet_42 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_43(Node_259 i) {
+      this.mSet_43 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_44(Node_392 i) {
+      this.mSet_44 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_45(Node_39 i) {
+      this.mSet_45 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_46(Node_486 i) {
+      this.mSet_46 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_47(Node_68 i) {
+      this.mSet_47 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_48(Node_145 i) {
+      this.mSet_48 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_49(Node_370 i) {
+      this.mSet_49 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_5(Node_335 i) {
+      this.mSet_5 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_50(Node_117 i) {
+      this.mSet_50 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_51(Node_278 i) {
+      this.mSet_51 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_6(Node_24 i) {
+      this.mSet_6 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_7(Node_129 i) {
+      this.mSet_7 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_8(Node_170 i) {
+      this.mSet_8 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603.Creator set_9(Node_523 i) {
+      this.mSet_9 = i;
+      return this;
+    }
+
+    @Override
+    public Component_603 create() {
+      return new Yatagan$Component_603(this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_10, this.mSet_11, this.mSet_12, this.mSet_13, this.mSet_14, this.mSet_15, this.mSet_16, this.mSet_17, this.mSet_18, this.mSet_19, this.mSet_2, this.mSet_20, this.mSet_21, this.mSet_22, this.mSet_23, this.mSet_24, this.mSet_25, this.mSet_26, this.mSet_27, this.mSet_28, this.mSet_29, this.mSet_3, this.mSet_30, this.mSet_31, this.mSet_32, this.mSet_33, this.mSet_34, this.mSet_35, this.mSet_36, this.mSet_37, this.mSet_38, this.mSet_39, this.mSet_4, this.mSet_40, this.mSet_41, this.mSet_42, this.mSet_43, this.mSet_44, this.mSet_45, this.mSet_46, this.mSet_47, this.mSet_48, this.mSet_49, this.mSet_5, this.mSet_50, this.mSet_51, this.mSet_6, this.mSet_7, this.mSet_8, this.mSet_9);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/HeavyTest/procedural-Tall-Thin.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/HeavyTest/procedural-Tall-Thin.golden-code.txt
@@ -1,0 +1,9967 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$Component_317.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$Component_317 implements Component_317 {
+  private Object mNode_17Instance;
+
+  private Object mNode_107Instance;
+
+  private Object mNode_11Instance;
+
+  private Object mNode_133Instance;
+
+  private Object mNode_172Instance;
+
+  private Object mNode_254Instance;
+
+  private Object mNode_257Instance;
+
+  private Object mNode_262Instance;
+
+  private Object mNode_281Instance;
+
+  private Object mNode_46Instance;
+
+  final Node_238 mSet_0;
+
+  final Node_130 mSet_1;
+
+  final Node_176 mSet_2;
+
+  final Node_134 mSet_3;
+
+  final Dependency_310 mDependency_310;
+
+  Yatagan$Component_317(Dependency_310 pSetDep_0, Node_238 pSet_0, Node_130 pSet_1, Node_176 pSet_2,
+      Node_134 pSet_3) {
+    this.mDependency_310 = Checks.checkInputNotNull(pSetDep_0);
+    this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+    this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+    this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+  }
+
+  @Override
+  public Node_238 getGet_0() {
+    return this.mSet_0;
+  }
+
+  @Override
+  public Node_210 getGet_1() {
+    return this.accessNode_210();
+  }
+
+  @Override
+  public Node_172 getGet_2() {
+    return this.cacheNode_172();
+  }
+
+  @Override
+  public Node_122 getGet_3() {
+    return this.mSet_1;
+  }
+
+  @Override
+  public Node_30 getGet_4() {
+    return this.accessNode_30();
+  }
+
+  @Override
+  public Node_130 getGet_5() {
+    return this.mSet_1;
+  }
+
+  @Override
+  public void inject_0(Injectee_347 i) {
+    i.setMember_0(this.mSet_1);
+    i.setMember_1(this.cacheNode_281());
+    i.setMember_2(this.cacheNode_257());
+    i.setMember_3(this.mDependency_310.ep_2());
+    i.setMember_4(this.accessNode_15());
+    i.setMember_5(this.cacheNode_17());
+    i.setMember_6(this.cacheNode_281());
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.mSet_0;
+      case 1: return this.accessNode_210();
+      case 2: return this.cacheNode_172();
+      case 3: return this.mSet_1;
+      case 4: return this.accessNode_30();
+      case 5: return this.cacheNode_281();
+      case 6: return this.cacheNode_257();
+      case 7: return this.mDependency_310.ep_2();
+      case 8: return this.accessNode_15();
+      case 9: return this.cacheNode_17();
+      case 10: return this.accessNode_83();
+      case 11: return this.cacheNode_133();
+      case 12: return this.cacheNode_46();
+      case 13: return this.accessNode_286();
+      case 14: return this.cacheNode_254();
+      case 15: return this.mSet_2;
+      case 16: return this.mDependency_310.ep_1();
+      case 17: return this.accessNode_102();
+      case 18: return this.cacheNode_262();
+      case 19: return this.mSet_3;
+      case 20: return Checks.checkProvisionNotNull(Module_391.Companion.provides_428());
+      case 21: return this.cacheNode_107();
+      case 22: return this.cacheNode_11();
+      default: throw new AssertionError();
+    }
+  }
+
+  Node_210 accessNode_210() {
+    return Checks.checkProvisionNotNull(Module_391.Companion.provides_423(this.mSet_1, this.accessNode_83(), this.mDependency_310.ep_0(), this.mSet_0, new ProviderImpl(this, 9), this.accessNode_30(), this.cacheNode_133(), this.cacheNode_46(), this.accessNode_286(), new ProviderImpl(this, 5), this.mSet_1, this.mDependency_310.ep_2(), new ProviderImpl(this, 14)));
+  }
+
+  Node_30 accessNode_30() {
+    return Checks.checkProvisionNotNull(Module_391.Companion.provides_424(new ProviderImpl(this, 11), new ProviderImpl(this, 2), this.mSet_2, new CachingProviderImpl(this, 1), this.cacheNode_257(), this.accessNode_83(), this.mDependency_310.ep_1(), this.mDependency_310.ep_0(), this.accessNode_102(), new ProviderImpl(this, 14), this.mSet_1, this.mSet_0, new CachingProviderImpl(this, 8), new ProviderImpl(this, 18), new ProviderImpl(this, 5), this.mSet_3, new ProviderImpl(this, 20), new CachingProviderImpl(this, 7)));
+  }
+
+  Node_15 accessNode_15() {
+    return Checks.checkProvisionNotNull(Module_391.Companion.provides_425(this.cacheNode_257(), this.mDependency_310.ep_2(), this.accessNode_102(), new ProviderImpl(this, 6), this.cacheNode_133(), this.accessNode_30(), new ProviderImpl(this, 3), this.mDependency_310.ep_0(), this.mDependency_310.ep_1(), Checks.checkProvisionNotNull(Module_391.Companion.provides_428()), this.accessNode_210(), this.cacheNode_46(), new ProviderImpl(this, 14)));
+  }
+
+  Node_17 cacheNode_17() {
+    Object local = this.mNode_17Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_391.Companion.provides_426());
+      this.mNode_17Instance = local;
+    }
+    return (Node_17) local;
+  }
+
+  Node_102 accessNode_102() {
+    return Checks.checkProvisionNotNull(Module_391.Companion.provides_427(this.cacheNode_46(), new CachingProviderImpl(this, 4), this.accessNode_83(), this.cacheNode_17(), new ProviderImpl(this, 2), new ProviderImpl(this, 20), this.cacheNode_257(), new ProviderImpl(this, 18), new ProviderImpl(this, 14), this.mSet_1, new CachingProviderImpl(this, 3), this.cacheNode_133(), new ProviderImpl(this, 22), this.accessNode_286()));
+  }
+
+  Node_107 cacheNode_107() {
+    Object local = this.mNode_107Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_107(this.accessNode_286(), this.mSet_2, this.cacheNode_133(), this.mDependency_310.ep_1(), new ProviderImpl(this, 5), this.accessNode_102(), this.mSet_1, this.mDependency_310.ep_0(), this.cacheNode_46(), new ProviderImpl(this, 14), new ProviderImpl(this, 19), this.mSet_1, new ProviderImpl(this, 9), this.cacheNode_257());
+      this.mNode_107Instance = local;
+    }
+    return (Node_107) local;
+  }
+
+  Node_11 cacheNode_11() {
+    Object local = this.mNode_11Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_11(this.mDependency_310.ep_2(), this.mDependency_310.ep_0(), new ProviderImpl(this, 5), new CachingProviderImpl(this, 19), new ProviderImpl(this, 21), new ProviderImpl(this, 3), new CachingProviderImpl(this, 17), new CachingProviderImpl(this, 1), new ProviderImpl(this, 16), new ProviderImpl(this, 18), this.cacheNode_17(), this.cacheNode_257(), new CachingProviderImpl(this, 8), new CachingProviderImpl(this, 10), this.mSet_1, this.cacheNode_172(), this.mSet_2);
+      this.mNode_11Instance = local;
+    }
+    return (Node_11) local;
+  }
+
+  Node_133 cacheNode_133() {
+    Object local = this.mNode_133Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_133(new ProviderImpl(this, 18), new CachingProviderImpl(this, 1), this.mSet_3, new ProviderImpl(this, 5), new CachingProviderImpl(this, 0), this.mDependency_310.ep_1(), Checks.checkProvisionNotNull(Module_391.Companion.provides_428()), new CachingProviderImpl(this, 13), this.mDependency_310.ep_0());
+      this.mNode_133Instance = local;
+    }
+    return (Node_133) local;
+  }
+
+  Node_172 cacheNode_172() {
+    Object local = this.mNode_172Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_172(new ProviderImpl(this, 9), new CachingProviderImpl(this, 8), new ProviderImpl(this, 5), new CachingProviderImpl(this, 0), this.cacheNode_257());
+      this.mNode_172Instance = local;
+    }
+    return (Node_172) local;
+  }
+
+  Node_254 cacheNode_254() {
+    Object local = this.mNode_254Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_254(this.mSet_1, this.cacheNode_17(), this.mDependency_310.ep_1(), this.cacheNode_257(), new CachingProviderImpl(this, 0), new CachingProviderImpl(this, 8), new ProviderImpl(this, 11), new CachingProviderImpl(this, 17), new ProviderImpl(this, 13), new ProviderImpl(this, 10), this.cacheNode_172(), new ProviderImpl(this, 18), new ProviderImpl(this, 5), this.mSet_2, this.cacheNode_11(), new CachingProviderImpl(this, 4));
+      this.mNode_254Instance = local;
+    }
+    return (Node_254) local;
+  }
+
+  Node_257 cacheNode_257() {
+    Object local = this.mNode_257Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_257(new ProviderImpl(this, 6), new ProviderImpl(this, 0), new ProviderImpl(this, 14), this.mSet_1, new ProviderImpl(this, 5));
+      this.mNode_257Instance = local;
+    }
+    return (Node_257) local;
+  }
+
+  Node_262 cacheNode_262() {
+    Object local = this.mNode_262Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_262(new ProviderImpl(this, 11), this.cacheNode_46(), new CachingProviderImpl(this, 4), new CachingProviderImpl(this, 17), this.cacheNode_257(), new CachingProviderImpl(this, 8), this.cacheNode_11(), new ProviderImpl(this, 5), new CachingProviderImpl(this, 20), this.accessNode_83(), this.mSet_0, this.mDependency_310.ep_2(), this.mDependency_310.ep_0(), this.cacheNode_257(), this.cacheNode_254());
+      this.mNode_262Instance = local;
+    }
+    return (Node_262) local;
+  }
+
+  Node_281 cacheNode_281() {
+    Object local = this.mNode_281Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_281(this.cacheNode_46(), new CachingProviderImpl(this, 13), this.mDependency_310.ep_2(), new CachingProviderImpl(this, 4), new ProviderImpl(this, 21), this.cacheNode_254(), new CachingProviderImpl(this, 19), new CachingProviderImpl(this, 3), this.cacheNode_262(), this.mDependency_310.ep_0(), new ProviderImpl(this, 1), this.mSet_1, this.mSet_0, new ProviderImpl(this, 10), new ProviderImpl(this, 9));
+      this.mNode_281Instance = local;
+    }
+    return (Node_281) local;
+  }
+
+  Node_286 accessNode_286() {
+    return new Node_286(new CachingProviderImpl(this, 20), this.cacheNode_17(), new ProviderImpl(this, 4), this.cacheNode_257(), this.mSet_0, new CachingProviderImpl(this, 15), new ProviderImpl(this, 12), new ProviderImpl(this, 22), new ProviderImpl(this, 14), this.cacheNode_133(), new ProviderImpl(this, 2), new ProviderImpl(this, 6));
+  }
+
+  Node_46 cacheNode_46() {
+    Object local = this.mNode_46Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_46(this.cacheNode_17(), this.mDependency_310.ep_0());
+      this.mNode_46Instance = local;
+    }
+    return (Node_46) local;
+  }
+
+  Node_83 accessNode_83() {
+    return new Node_83(this.cacheNode_257(), new ProviderImpl(this, 6), this.mSet_1, this.cacheNode_17(), new ProviderImpl(this, 3), new ProviderImpl(this, 12), new ProviderImpl(this, 14), new ProviderImpl(this, 5), new CachingProviderImpl(this, 20), this.mDependency_310.ep_1(), new CachingProviderImpl(this, 13));
+  }
+
+  public static Component_317.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$Component_317 mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$Component_317 delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$Component_317 mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$Component_317 factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements Component_317.Creator {
+    private Dependency_310 mSetDep_0;
+
+    private Node_238 mSet_0;
+
+    private Node_130 mSet_1;
+
+    private Node_176 mSet_2;
+
+    private Node_134 mSet_3;
+
+    @Override
+    public Component_317.Creator setDep_0(Dependency_310 i) {
+      this.mSetDep_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_317.Creator set_0(Node_238 i) {
+      this.mSet_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_317.Creator set_1(Node_130 i) {
+      this.mSet_1 = i;
+      return this;
+    }
+
+    @Override
+    public Component_317.Creator set_2(Node_176 i) {
+      this.mSet_2 = i;
+      return this;
+    }
+
+    @Override
+    public Component_317.Creator set_3(Node_134 i) {
+      this.mSet_3 = i;
+      return this;
+    }
+
+    @Override
+    public Component_317 create() {
+      return new Yatagan$Component_317(this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$Component_318.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$Component_318 implements Component_318 {
+  private Object mNode_30Instance;
+
+  private Object mNode_17Instance;
+
+  private Object mNode_15Instance;
+
+  private Object mNode_102Instance;
+
+  private Object mNode_106Instance;
+
+  private Object mNode_107Instance;
+
+  private Object mNode_11Instance;
+
+  private Object mNode_133Instance;
+
+  private Object mNode_172Instance;
+
+  private Object mNode_254Instance;
+
+  private Object mNode_257Instance;
+
+  private Object mNode_262Instance;
+
+  private Object mNode_281Instance;
+
+  private Object mNode_46Instance;
+
+  final Node_130 mSet_0;
+
+  final Node_176 mSet_1;
+
+  final Node_134 mSet_2;
+
+  final Node_238 mSet_3;
+
+  final Dependency_310 mDependency_310;
+
+  Yatagan$Component_318(Dependency_310 pSetDep_0, Node_130 pSet_0, Node_176 pSet_1, Node_134 pSet_2,
+      Node_238 pSet_3) {
+    this.mDependency_310 = Checks.checkInputNotNull(pSetDep_0);
+    this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+    this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+    this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+  }
+
+  @Override
+  public Component_319.Creator getChildCreator_0() {
+    return new Component_319Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Component_320.Creator getChildCreator_1() {
+    return new Component_320Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Component_321.Creator getChildCreator_2() {
+    return new Component_321Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Component_322.Creator getChildCreator_3() {
+    return new Component_322Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Lazy<Node_107> getGet_0() {
+    return new ProviderImpl(this, 17);
+  }
+
+  @Override
+  public Node_83 getGet_1() {
+    return this.accessNode_83();
+  }
+
+  @Override
+  public Node_164 getGet_2() {
+    return this.mDependency_310.ep_1();
+  }
+
+  @Override
+  public Node_133 getGet_3() {
+    return this.cacheNode_133();
+  }
+
+  @Override
+  public Node_130 getGet_4() {
+    return this.mSet_0;
+  }
+
+  @Override
+  public Node_30 getGet_5() {
+    return this.cacheNode_30();
+  }
+
+  @Override
+  public Node_257 getGet_6() {
+    return this.cacheNode_257();
+  }
+
+  @Override
+  public Node_17 getGet_7() {
+    return this.cacheNode_17();
+  }
+
+  @Override
+  public void inject_0(Injectee_348 i) {
+    i.setMember_0(this.mSet_0);
+    i.setMember_1(this.cacheNode_11());
+    i.setMember_2(this.mSet_1);
+  }
+
+  @Override
+  public void inject_1(Injectee_349 i) {
+    i.setMember_0(this.cacheNode_133());
+  }
+
+  @Override
+  public void inject_2(Injectee_350 i) {
+    i.setMember_0(this.mSet_0);
+    i.setMember_1(this.accessNode_210());
+    i.setMember_2(this.cacheNode_262());
+    i.setMember_3(this.cacheNode_15());
+    i.setMember_4(this.cacheNode_46());
+    i.setMember_5(this.accessNode_210());
+    i.setMember_6(this.mSet_0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.mSet_2;
+      case 1: return this.mSet_1;
+      case 2: return this.cacheNode_281();
+      case 3: return this.cacheNode_257();
+      case 4: return this.accessNode_210();
+      case 5: return this.mDependency_310.ep_1();
+      case 6: return this.mDependency_310.ep_2();
+      case 7: return this.cacheNode_102();
+      case 8: return this.cacheNode_11();
+      case 9: return this.cacheNode_46();
+      case 10: return this.cacheNode_172();
+      case 11: return this.cacheNode_30();
+      case 12: return this.mSet_3;
+      case 13: return this.cacheNode_15();
+      case 14: return this.cacheNode_262();
+      case 15: return this.cacheNode_17();
+      case 16: return this.cacheNode_106();
+      case 17: return this.cacheNode_107();
+      case 18: return this.mSet_0;
+      case 19: return this.cacheNode_133();
+      case 20: return this.cacheNode_254();
+      case 21: return this.accessNode_83();
+      case 22: return this.accessNode_286();
+      default: throw new AssertionError();
+    }
+  }
+
+  Node_30 cacheNode_30() {
+    Object local = this.mNode_30Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_392.Companion.provides_431(new ProviderImpl(this, 19), new ProviderImpl(this, 10), this.mSet_1, new CachingProviderImpl(this, 4), this.cacheNode_257(), this.accessNode_83(), this.mDependency_310.ep_1(), this.mDependency_310.ep_0(), this.cacheNode_102(), new ProviderImpl(this, 20), this.mSet_0, this.mSet_3, new ProviderImpl(this, 13), new ProviderImpl(this, 14), new ProviderImpl(this, 2), this.mSet_2, new ProviderImpl(this, 16), new CachingProviderImpl(this, 6)));
+      this.mNode_30Instance = local;
+    }
+    return (Node_30) local;
+  }
+
+  Node_17 cacheNode_17() {
+    Object local = this.mNode_17Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_392.Companion.provides_432());
+      this.mNode_17Instance = local;
+    }
+    return (Node_17) local;
+  }
+
+  Node_210 accessNode_210() {
+    return Checks.checkProvisionNotNull(Module_392.Companion.provides_433(this.mSet_0, this.accessNode_83(), this.mDependency_310.ep_0(), this.mSet_3, new ProviderImpl(this, 15), this.cacheNode_30(), this.cacheNode_133(), this.cacheNode_46(), this.accessNode_286(), new ProviderImpl(this, 2), this.mSet_0, this.mDependency_310.ep_2(), this.cacheNode_254()));
+  }
+
+  Node_15 cacheNode_15() {
+    Object local = this.mNode_15Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_392.Companion.provides_434(this.cacheNode_257(), this.mDependency_310.ep_2(), this.cacheNode_102(), new ProviderImpl(this, 3), this.cacheNode_133(), this.cacheNode_30(), new ProviderImpl(this, 18), this.mDependency_310.ep_0(), this.mDependency_310.ep_1(), this.cacheNode_106(), new CachingProviderImpl(this, 4), this.cacheNode_46(), new ProviderImpl(this, 20)));
+      this.mNode_15Instance = local;
+    }
+    return (Node_15) local;
+  }
+
+  Node_102 cacheNode_102() {
+    Object local = this.mNode_102Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_392.Companion.provides_435(this.cacheNode_46(), new ProviderImpl(this, 11), this.accessNode_83(), this.cacheNode_17(), new ProviderImpl(this, 10), new ProviderImpl(this, 16), this.cacheNode_257(), new ProviderImpl(this, 14), new ProviderImpl(this, 20), this.mSet_0, new CachingProviderImpl(this, 18), this.cacheNode_133(), new ProviderImpl(this, 8), this.accessNode_286()));
+      this.mNode_102Instance = local;
+    }
+    return (Node_102) local;
+  }
+
+  Node_106 cacheNode_106() {
+    Object local = this.mNode_106Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_392.Companion.provides_436());
+      this.mNode_106Instance = local;
+    }
+    return (Node_106) local;
+  }
+
+  Node_107 cacheNode_107() {
+    Object local = this.mNode_107Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_107(this.accessNode_286(), this.mSet_1, this.cacheNode_133(), this.mDependency_310.ep_1(), new ProviderImpl(this, 2), this.cacheNode_102(), this.mSet_0, this.mDependency_310.ep_0(), this.cacheNode_46(), new ProviderImpl(this, 20), new ProviderImpl(this, 0), this.mSet_0, new ProviderImpl(this, 15), this.cacheNode_257());
+      this.mNode_107Instance = local;
+    }
+    return (Node_107) local;
+  }
+
+  Node_11 cacheNode_11() {
+    Object local = this.mNode_11Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_11(this.mDependency_310.ep_2(), this.mDependency_310.ep_0(), new ProviderImpl(this, 2), new CachingProviderImpl(this, 0), new ProviderImpl(this, 17), new ProviderImpl(this, 18), new ProviderImpl(this, 7), new CachingProviderImpl(this, 4), new ProviderImpl(this, 5), new ProviderImpl(this, 14), this.cacheNode_17(), this.cacheNode_257(), new ProviderImpl(this, 13), new CachingProviderImpl(this, 21), this.mSet_0, this.cacheNode_172(), this.mSet_1);
+      this.mNode_11Instance = local;
+    }
+    return (Node_11) local;
+  }
+
+  Node_133 cacheNode_133() {
+    Object local = this.mNode_133Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_133(new ProviderImpl(this, 14), new CachingProviderImpl(this, 4), this.mSet_2, new ProviderImpl(this, 2), new CachingProviderImpl(this, 12), this.mDependency_310.ep_1(), this.cacheNode_106(), new CachingProviderImpl(this, 22), this.mDependency_310.ep_0());
+      this.mNode_133Instance = local;
+    }
+    return (Node_133) local;
+  }
+
+  Node_172 cacheNode_172() {
+    Object local = this.mNode_172Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_172(new ProviderImpl(this, 15), new ProviderImpl(this, 13), new ProviderImpl(this, 2), new CachingProviderImpl(this, 12), this.cacheNode_257());
+      this.mNode_172Instance = local;
+    }
+    return (Node_172) local;
+  }
+
+  Node_254 cacheNode_254() {
+    Object local = this.mNode_254Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_254(this.mSet_0, this.cacheNode_17(), this.mDependency_310.ep_1(), this.cacheNode_257(), new CachingProviderImpl(this, 12), new ProviderImpl(this, 13), new ProviderImpl(this, 19), new ProviderImpl(this, 7), new ProviderImpl(this, 22), new ProviderImpl(this, 21), this.cacheNode_172(), new ProviderImpl(this, 14), new ProviderImpl(this, 2), this.mSet_1, this.cacheNode_11(), new ProviderImpl(this, 11));
+      this.mNode_254Instance = local;
+    }
+    return (Node_254) local;
+  }
+
+  Node_257 cacheNode_257() {
+    Object local = this.mNode_257Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_257(new ProviderImpl(this, 3), new ProviderImpl(this, 12), new ProviderImpl(this, 20), this.mSet_0, new ProviderImpl(this, 2));
+      this.mNode_257Instance = local;
+    }
+    return (Node_257) local;
+  }
+
+  Node_262 cacheNode_262() {
+    Object local = this.mNode_262Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_262(new ProviderImpl(this, 19), this.cacheNode_46(), new ProviderImpl(this, 11), new ProviderImpl(this, 7), this.cacheNode_257(), new ProviderImpl(this, 13), this.cacheNode_11(), new ProviderImpl(this, 2), new ProviderImpl(this, 16), this.accessNode_83(), this.mSet_3, this.mDependency_310.ep_2(), this.mDependency_310.ep_0(), this.cacheNode_257(), this.cacheNode_254());
+      this.mNode_262Instance = local;
+    }
+    return (Node_262) local;
+  }
+
+  Node_281 cacheNode_281() {
+    Object local = this.mNode_281Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_281(this.cacheNode_46(), new CachingProviderImpl(this, 22), this.mDependency_310.ep_2(), new ProviderImpl(this, 11), new ProviderImpl(this, 17), this.cacheNode_254(), new CachingProviderImpl(this, 0), new CachingProviderImpl(this, 18), this.cacheNode_262(), this.mDependency_310.ep_0(), new ProviderImpl(this, 4), this.mSet_0, this.mSet_3, new ProviderImpl(this, 21), new ProviderImpl(this, 15));
+      this.mNode_281Instance = local;
+    }
+    return (Node_281) local;
+  }
+
+  Node_286 accessNode_286() {
+    return new Node_286(new ProviderImpl(this, 16), this.cacheNode_17(), new ProviderImpl(this, 11), this.cacheNode_257(), this.mSet_3, new CachingProviderImpl(this, 1), new ProviderImpl(this, 9), new ProviderImpl(this, 8), new ProviderImpl(this, 20), this.cacheNode_133(), new ProviderImpl(this, 10), new ProviderImpl(this, 3));
+  }
+
+  Node_46 cacheNode_46() {
+    Object local = this.mNode_46Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_46(this.cacheNode_17(), this.mDependency_310.ep_0());
+      this.mNode_46Instance = local;
+    }
+    return (Node_46) local;
+  }
+
+  Node_83 accessNode_83() {
+    return new Node_83(this.cacheNode_257(), new ProviderImpl(this, 3), this.mSet_0, this.cacheNode_17(), new ProviderImpl(this, 18), new ProviderImpl(this, 9), new ProviderImpl(this, 20), new ProviderImpl(this, 2), new ProviderImpl(this, 16), this.mDependency_310.ep_1(), new CachingProviderImpl(this, 22));
+  }
+
+  public static Component_318.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_319Impl implements Component_319 {
+    private Object mNode_37Instance;
+
+    private Object mNode_173Instance;
+
+    private Object mNode_36Instance;
+
+    private Object mNode_305Instance;
+
+    private Object mNode_171Instance;
+
+    private Object mNode_123Instance;
+
+    private Object mNode_229Instance;
+
+    private Object mNode_146Instance;
+
+    private Object mNode_243Instance;
+
+    private Object mNode_276Instance;
+
+    private Object mNode_261Instance;
+
+    private Object mNode_84Instance;
+
+    final Node_239 mSet_0;
+
+    final Node_265 mSet_1;
+
+    final Node_246 mSet_2;
+
+    final Node_34 mSet_3;
+
+    final Dependency_312 mDependency_312;
+
+    final Yatagan$Component_318 mComponent_318;
+
+    Component_319Impl(Yatagan$Component_318 pComponent_318, Dependency_312 pSetDep_0,
+        Node_239 pSet_0, Node_265 pSet_1, Node_246 pSet_2, Node_34 pSet_3) {
+      this.mComponent_318 = pComponent_318;
+      this.mDependency_312 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+      this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+      this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+      this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+    }
+
+    @Override
+    public Node_148 getGet_0() {
+      return this.accessNode_148();
+    }
+
+    @Override
+    public Node_267 getGet_1() {
+      return this.accessNode_267();
+    }
+
+    @Override
+    public Node_187 getGet_2() {
+      return this.mDependency_312.ep_1();
+    }
+
+    @Override
+    public Node_37 getGet_3() {
+      return this.cacheNode_37();
+    }
+
+    @Override
+    public Node_173 getGet_4() {
+      return this.cacheNode_173();
+    }
+
+    @Override
+    public Node_56 getGet_5() {
+      return this.accessNode_56();
+    }
+
+    @Override
+    public Node_36 getGet_6() {
+      return this.cacheNode_36();
+    }
+
+    @Override
+    public void inject_0(Injectee_351 i) {
+      i.setMember_0(this.mComponent_318.mSet_2);
+      i.setMember_1(this.mComponent_318.mSet_1);
+      i.setMember_2(this.cacheNode_84());
+      i.setMember_3(this.mComponent_318.cacheNode_281());
+      i.setMember_4(this.accessNode_121());
+      i.setMember_5(this.mComponent_318.cacheNode_257());
+      i.setMember_6(new Node_225());
+      i.setMember_7(this.accessNode_286());
+      i.setMember_8(this.mComponent_318.accessNode_210());
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.accessNode_148();
+        case 1: return this.accessNode_267();
+        case 2: return this.mDependency_312.ep_1();
+        case 3: return this.cacheNode_37();
+        case 4: return this.cacheNode_173();
+        case 5: return this.cacheNode_36();
+        case 6: return this.cacheNode_84();
+        case 7: return this.accessNode_121();
+        case 8: return new Node_225();
+        case 9: return this.accessNode_286();
+        case 10: return this.mSet_0;
+        case 11: return this.cacheNode_305();
+        case 12: return this.accessNode_71();
+        case 13: return this.accessNode_255();
+        case 14: return this.accessNode_182();
+        case 15: return this.accessNode_162();
+        case 16: return this.mSet_1;
+        case 17: return this.mDependency_312.ep_0();
+        case 18: return this.cacheNode_261();
+        case 19: return this.mSet_2;
+        case 20: return this.accessNode_57();
+        case 21: return this.cacheNode_171();
+        case 22: return this.mDependency_312.ep_2();
+        case 23: return this.cacheNode_123();
+        case 24: return this.accessNode_291();
+        case 25: return this.accessNode_111();
+        case 26: return this.cacheNode_146();
+        case 27: return this.accessNode_83();
+        case 28: return this.accessNode_127();
+        case 29: return this.cacheNode_276();
+        case 30: return new Node_135(this.mComponent_318.cacheNode_262(), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_15(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 12), this.cacheNode_229(), this.mDependency_312.ep_0(), this.mComponent_318.mSet_0, this.mComponent_318.mDependency_310.ep_1(), this.accessNode_83(), this.mComponent_318.cacheNode_30(), this.cacheNode_146(), this.mDependency_312.ep_2(), this.mComponent_318.cacheNode_11(), this.mSet_3, this.mComponent_318.cacheNode_281());
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_267 accessNode_267() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_440(new CachingProviderImpl(this, 14), this.cacheNode_305(), this.accessNode_138(), this.mComponent_318.mDependency_310.ep_1(), this.accessNode_162(), this.mComponent_318.mDependency_310.ep_1(), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_172(), new ProviderImpl(this, 16), this.mComponent_318.cacheNode_46(), this.accessNode_148(), this.mComponent_318.cacheNode_30()));
+    }
+
+    Node_37 cacheNode_37() {
+      Object local = this.mNode_37Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_441(new CachingProviderImpl(this, 7), this.mDependency_312.ep_0(), this.accessNode_286(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), this.mComponent_318.cacheNode_11(), this.mComponent_318.cacheNode_257(), new ProviderImpl(this, 8), this.mComponent_318.mDependency_310.ep_0(), new ProviderImpl(this, 16), this.cacheNode_261(), this.accessNode_162(), new ProviderImpl(this, 4), this.mComponent_318.cacheNode_281(), this.accessNode_138(), new CachingProviderImpl(this, 14), this.mComponent_318.mSet_3, this.mComponent_318.cacheNode_15(), this.mComponent_318.cacheNode_262(), this.mComponent_318.cacheNode_17(), this.mSet_2, new CachingProviderImpl(this, 13)));
+        this.mNode_37Instance = local;
+      }
+      return (Node_37) local;
+    }
+
+    Node_173 cacheNode_173() {
+      Object local = this.mNode_173Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_442(this.mComponent_318.cacheNode_102()));
+        this.mNode_173Instance = local;
+      }
+      return (Node_173) local;
+    }
+
+    Node_36 cacheNode_36() {
+      Object local = this.mNode_36Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_443(this.accessNode_56(), this.mComponent_318.cacheNode_46(), this.mDependency_312.ep_2(), this.mComponent_318.mDependency_310.ep_0(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 8), this.mComponent_318.cacheNode_106(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 6), new ProviderImpl(this, 11), new ProviderImpl(this, 6), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_1(), this.cacheNode_123(), this.mComponent_318.cacheNode_257(), this.mComponent_318.cacheNode_102(), this.mDependency_312.ep_0(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 18), this.accessNode_286(), this.mComponent_318.mSet_3));
+        this.mNode_36Instance = local;
+      }
+      return (Node_36) local;
+    }
+
+    Node_121 accessNode_121() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_444(this.mComponent_318.mDependency_310.ep_2(), this.cacheNode_305(), this.accessNode_71(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), this.accessNode_267(), this.mComponent_318.cacheNode_254(), this.mComponent_318.cacheNode_102(), new Node_225(), this.mComponent_318.mSet_0, this.accessNode_56(), this.cacheNode_37(), new ProviderImpl(this, 6), this.cacheNode_36(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 17), this.cacheNode_171(), this.accessNode_291(), this.accessNode_148(), this.accessNode_138(), this.accessNode_111(), this.mComponent_318.mDependency_310.ep_0(), this.mSet_1, this.mComponent_318.mSet_3));
+    }
+
+    Node_305 cacheNode_305() {
+      Object local = this.mNode_305Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_445(this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mSet_1, this.cacheNode_37(), new CachingProviderImpl(this, 24), this.mComponent_318.cacheNode_257(), this.cacheNode_229(), this.mComponent_318.mSet_0, this.cacheNode_261(), this.mComponent_318.cacheNode_254(), new CachingProviderImpl(this, 1), this.accessNode_138(), this.mComponent_318.cacheNode_102(), this.accessNode_57()));
+        this.mNode_305Instance = local;
+      }
+      return (Node_305) local;
+    }
+
+    Node_255 accessNode_255() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_446(this.mComponent_318.cacheNode_281(), this.cacheNode_36(), this.mComponent_318.mSet_1, new CachingProviderImpl(this, 7), this.mComponent_318.accessNode_210(), new Node_225(), this.mComponent_318.mDependency_310.ep_1(), this.accessNode_286(), this.mComponent_318.cacheNode_133(), this.cacheNode_37(), this.cacheNode_229(), this.accessNode_148(), new ProviderImpl(this, 23), this.accessNode_162(), this.cacheNode_243(), this.cacheNode_173(), this.accessNode_127(), this.mComponent_318.cacheNode_17(), this.accessNode_56(), this.cacheNode_146(), this.mComponent_318.cacheNode_102(), this.accessNode_182(), this.mComponent_318.cacheNode_172()));
+    }
+
+    Node_138 accessNode_138() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_447(new ProviderImpl(this, 12), this.accessNode_56(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 6), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), this.mDependency_312.ep_0(), this.mComponent_318.cacheNode_281(), this.accessNode_291(), this.mComponent_318.mSet_1, this.mComponent_318.cacheNode_262(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 17), new ProviderImpl(this, 29), new ProviderImpl(this, 23), new CachingProviderImpl(this, 0), this.accessNode_162()));
+    }
+
+    Node_162 accessNode_162() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_448(new Node_225(), this.mComponent_318.cacheNode_15(), this.mComponent_318.cacheNode_262(), new CachingProviderImpl(this, 7), this.mComponent_318.mSet_3, new ProviderImpl(this, 6), this.mComponent_318.mDependency_310.ep_2(), new ProviderImpl(this, 21), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), new ProviderImpl(this, 27)));
+    }
+
+    Node_171 cacheNode_171() {
+      Object local = this.mNode_171Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_449(this.mComponent_318.mSet_2, new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 17), this.mComponent_318.mDependency_310.ep_1(), new ProviderImpl(this, 18), this.mComponent_318.cacheNode_133(), this.mComponent_318.mSet_0, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 6), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_281(), this.mComponent_318.cacheNode_257()));
+        this.mNode_171Instance = local;
+      }
+      return (Node_171) local;
+    }
+
+    Node_123 cacheNode_123() {
+      Object local = this.mNode_123Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_450(new CachingProviderImpl(this, 0), this.accessNode_138(), this.mSet_1, this.mComponent_318.mDependency_310.ep_1(), new ProviderImpl(this, 5), this.mComponent_318.cacheNode_262(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), new CachingProviderImpl(this, 7), this.mComponent_318.accessNode_210(), this.mComponent_318.cacheNode_17(), this.mDependency_312.ep_0(), this.mComponent_318.cacheNode_254(), new CachingProviderImpl(this, 25), new ProviderImpl(this, 22), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_11(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), this.mComponent_318.cacheNode_133(), this.accessNode_286(), new CachingProviderImpl(this, 13), this.mComponent_318.cacheNode_102(), this.mSet_3));
+        this.mNode_123Instance = local;
+      }
+      return (Node_123) local;
+    }
+
+    Node_291 accessNode_291() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_451(this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_1, this.accessNode_286(), new ProviderImpl(this, 26), this.cacheNode_229()));
+    }
+
+    Node_111 accessNode_111() {
+      return Checks.checkProvisionNotNull(Module_393.Companion.provides_452(this.mComponent_318.cacheNode_15(), this.mComponent_318.cacheNode_257(), this.mComponent_318.cacheNode_254(), this.mDependency_312.ep_1(), new ProviderImpl(this, 28), this.mComponent_318.cacheNode_262(), new ProviderImpl(this, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 7), this.accessNode_255(), this.accessNode_162(), this.mComponent_318.mSet_1, new ProviderImpl(this, 29), this.mComponent_318.cacheNode_107(), this.mComponent_318.cacheNode_262(), this.mComponent_318.cacheNode_30(), this.mComponent_318.cacheNode_172()));
+    }
+
+    Node_229 cacheNode_229() {
+      Object local = this.mNode_229Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_453(this.mComponent_318.cacheNode_30(), this.mComponent_318.mSet_0, new Node_225(), this.mComponent_318.cacheNode_11(), this.mComponent_318.cacheNode_46(), this.cacheNode_146(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 19), this.mComponent_318.cacheNode_172()));
+        this.mNode_229Instance = local;
+      }
+      return (Node_229) local;
+    }
+
+    Node_146 cacheNode_146() {
+      Object local = this.mNode_146Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_454(this.mComponent_318.cacheNode_262(), this.accessNode_127(), new ProviderImpl(this, 11)));
+        this.mNode_146Instance = local;
+      }
+      return (Node_146) local;
+    }
+
+    Node_243 cacheNode_243() {
+      Object local = this.mNode_243Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_455(this.mComponent_318.cacheNode_15(), this.cacheNode_36(), this.mComponent_318.mDependency_310.ep_1(), this.mSet_2, this.mSet_0, this.mComponent_318.mSet_0));
+        this.mNode_243Instance = local;
+      }
+      return (Node_243) local;
+    }
+
+    Node_276 cacheNode_276() {
+      Object local = this.mNode_276Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_393.Companion.provides_456(this.mComponent_318.cacheNode_15(), this.accessNode_291(), this.mComponent_318.cacheNode_11(), new CachingProviderImpl(this, 0), new CachingProviderImpl(this, 14), this.mComponent_318.cacheNode_254(), this.cacheNode_37(), this.mComponent_318.cacheNode_133()));
+        this.mNode_276Instance = local;
+      }
+      return (Node_276) local;
+    }
+
+    Node_127 accessNode_127() {
+      return new Node_127(new CachingProviderImpl(this, 7), this.mSet_3, this.mDependency_312.ep_1(), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_1(), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_257(), new CachingProviderImpl(this, 14));
+    }
+
+    Node_148 accessNode_148() {
+      return new Node_148(this.mSet_0, this.mComponent_318.mDependency_310.ep_1(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 0), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_102(), new ProviderImpl(this, 6), this.cacheNode_305(), this.accessNode_71(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 8), this.mComponent_318.cacheNode_46(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), new CachingProviderImpl(this, 13));
+    }
+
+    Node_182 accessNode_182() {
+      return new Node_182(this.mComponent_318.mSet_1, this.mComponent_318.cacheNode_102(), this.mComponent_318.mSet_3, this.mComponent_318.mDependency_310.ep_1(), this.mComponent_318.cacheNode_15(), this.mDependency_312.ep_1(), this.accessNode_83(), this.mComponent_318.mSet_2, this.mComponent_318.cacheNode_257(), new ProviderImpl(this, 3), this.accessNode_127(), this.mSet_2, this.mComponent_318.cacheNode_106(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 4), this.accessNode_267(), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.cacheNode_262(), this.cacheNode_146(), this.mSet_3, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 6));
+    }
+
+    Node_261 cacheNode_261() {
+      Object local = this.mNode_261Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_261(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 13), new ProviderImpl(this, 2), this.mSet_1, this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_46(), this.mComponent_318.cacheNode_172(), this.cacheNode_171(), this.mComponent_318.cacheNode_254(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 4), this.mSet_0, this.accessNode_291(), new CachingProviderImpl(this, 7), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 20), new CachingProviderImpl(this, 13), this.mComponent_318.mSet_2, new ProviderImpl(this, 0), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 2), this.mComponent_318.mDependency_310.ep_1(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15));
+        this.mNode_261Instance = local;
+      }
+      return (Node_261) local;
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.mComponent_318.cacheNode_257(), this.mComponent_318.mSet_3, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 8), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), this.mComponent_318.cacheNode_133(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3));
+    }
+
+    Node_56 accessNode_56() {
+      return new Node_56(new CachingProviderImpl(this, 0), this.mComponent_318.cacheNode_257(), new CachingProviderImpl(this, 20), this.cacheNode_171(), this.mComponent_318.cacheNode_172(), this.cacheNode_261(), new CachingProviderImpl(this, 7), this.mComponent_318.cacheNode_106(), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_0());
+    }
+
+    Node_57 accessNode_57() {
+      return new Node_57(this.accessNode_286(), new CachingProviderImpl(this, 15), this.mComponent_318.mDependency_310.ep_1(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.cacheNode_172(), this.cacheNode_36(), new ProviderImpl(this, 29), this.mComponent_318.cacheNode_262(), this.mComponent_318.mSet_1, this.mComponent_318.accessNode_210(), this.mComponent_318.cacheNode_257(), new ProviderImpl(this, 19), this.mComponent_318.cacheNode_106(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 18), new ProviderImpl(this, 30), this.mDependency_312.ep_0(), this.accessNode_71(), new CachingProviderImpl(this, 25));
+    }
+
+    Node_71 accessNode_71() {
+      return new Node_71(this.mComponent_318.mSet_2, new ProviderImpl(this, 26), this.mComponent_318.mSet_1, new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.cacheNode_262(), this.mComponent_318.cacheNode_281(), new CachingProviderImpl(this, 1), this.accessNode_83(), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_106(), this.mSet_0, new ProviderImpl(this, 23), new ProviderImpl(this, 17), new CachingProviderImpl(this, 25), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 14));
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 2), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 9));
+    }
+
+    Node_84 cacheNode_84() {
+      Object local = this.mNode_84Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_84(this.mComponent_318.mSet_2, this.mComponent_318.mDependency_310.ep_2(), this.mDependency_312.ep_2(), this.mComponent_318.mSet_0, this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 2), this.cacheNode_173(), this.cacheNode_305(), this.mComponent_318.cacheNode_133(), this.mComponent_318.cacheNode_262(), new ProviderImpl(this, 18), this.mSet_2, this.accessNode_148(), this.mComponent_318.cacheNode_102(), this.cacheNode_37(), this.mComponent_318.cacheNode_107(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 12), new CachingProviderImpl(this, 10), this.mComponent_318.cacheNode_30());
+        this.mNode_84Instance = local;
+      }
+      return (Node_84) local;
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_319Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_319Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_319Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_319Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_319.Creator {
+      Yatagan$Component_318 fComponent_318;
+
+      private Dependency_312 mSetDep_0;
+
+      private Node_239 mSet_0;
+
+      private Node_265 mSet_1;
+
+      private Node_246 mSet_2;
+
+      private Node_34 mSet_3;
+
+      ComponentFactoryImpl(Yatagan$Component_318 fComponent_318) {
+        this.fComponent_318 = fComponent_318;
+      }
+
+      @Override
+      public Component_319.Creator setDep_0(Dependency_312 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_319.Creator set_0(Node_239 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_319.Creator set_1(Node_265 i) {
+        this.mSet_1 = i;
+        return this;
+      }
+
+      @Override
+      public Component_319.Creator set_2(Node_246 i) {
+        this.mSet_2 = i;
+        return this;
+      }
+
+      @Override
+      public Component_319.Creator set_3(Node_34 i) {
+        this.mSet_3 = i;
+        return this;
+      }
+
+      @Override
+      public Component_319 create() {
+        return new Component_319Impl(this.fComponent_318, this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_320Impl implements Component_320 {
+    private Object mNode_277Instance;
+
+    private Object mNode_97Instance;
+
+    private Object mNode_169Instance;
+
+    private Object mNode_119Instance;
+
+    private Object mNode_168Instance;
+
+    final Node_189 mSet_0;
+
+    final Dependency_313 mDependency_313;
+
+    final Yatagan$Component_318 mComponent_318;
+
+    Component_320Impl(Yatagan$Component_318 pComponent_318, Dependency_313 pSetDep_0,
+        Node_189 pSet_0) {
+      this.mComponent_318 = pComponent_318;
+      this.mDependency_313 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    }
+
+    @Override
+    public Node_292 getGet_0() {
+      return this.mDependency_313.ep_2();
+    }
+
+    @Override
+    public Provider<Node_51> getGet_1() {
+      return new ProviderImpl(this, 1);
+    }
+
+    @Override
+    public void inject_0(Injectee_352 i) {
+      i.setMember_0(this.mComponent_318.cacheNode_172());
+      i.setMember_1(this.accessNode_90());
+      i.setMember_2(this.accessNode_209());
+      i.setMember_3(this.accessNode_51());
+      i.setMember_4(this.mDependency_313.ep_2());
+      i.setMember_5(this.accessNode_209());
+      i.setMember_6(this.mComponent_318.cacheNode_254());
+    }
+
+    @Override
+    public void inject_1(Injectee_353 i) {
+      i.setMember_0(this.mComponent_318.accessNode_210());
+      i.setMember_1(this.mComponent_318.mSet_0);
+      i.setMember_2(this.mComponent_318.mSet_0);
+      i.setMember_3(this.mComponent_318.cacheNode_30());
+      i.setMember_4(this.mComponent_318.mDependency_310.ep_0());
+      i.setMember_5(this.accessNode_51());
+      i.setMember_6(this.mComponent_318.cacheNode_133());
+      i.setMember_7(this.cacheNode_277());
+      i.setMember_8(this.accessNode_83());
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.mDependency_313.ep_2();
+        case 1: return this.accessNode_51();
+        case 2: return this.accessNode_209();
+        case 3: return this.cacheNode_277();
+        case 4: return this.accessNode_83();
+        case 5: return new Node_95(new ProviderImpl(this, 3), this.mComponent_318.cacheNode_133(), new ProviderImpl(this, 0), this.mComponent_318.mDependency_310.ep_5(), new CachingProviderImpl(this, 1), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mSet_2, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new CachingProviderImpl(this, 7), this.mComponent_318.cacheNode_262(), this.accessNode_52(), this.mComponent_318.mSet_1, this.mComponent_318.cacheNode_106(), this.mComponent_318.mSet_0, this.cacheNode_97());
+        case 6: return this.cacheNode_119();
+        case 7: return this.accessNode_149();
+        case 8: return Checks.checkProvisionNotNull(Module_394.Companion.provides_462());
+        case 9: return this.accessNode_52();
+        case 10: return this.cacheNode_168();
+        case 11: return this.accessNode_175();
+        case 12: return this.accessNode_295();
+        case 13: return this.accessNode_286();
+        case 14: return this.cacheNode_97();
+        case 15: return this.accessNode_47();
+        case 16: return new Node_216(this.mComponent_318.cacheNode_281(), this.accessNode_52(), new ProviderImpl(this, 15), this.accessNode_51(), this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_3, this.cacheNode_277(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 7), this.mComponent_318.cacheNode_257(), this.accessNode_295());
+        case 17: return this.accessNode_242();
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_90 accessNode_90() {
+      return Checks.checkProvisionNotNull(Module_394.Companion.provides_460(new CachingProviderImpl(this, 4), new CachingProviderImpl(this, 9), new ProviderImpl(this, 10)));
+    }
+
+    Node_277 cacheNode_277() {
+      Object local = this.mNode_277Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_394.Companion.provides_461(this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_11(), this.accessNode_90(), this.accessNode_295(), this.accessNode_286(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 17), this.mComponent_318.mSet_0, this.cacheNode_97(), this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mDependency_310.ep_1(), this.mComponent_318.cacheNode_133(), this.accessNode_209(), this.mComponent_318.mDependency_310.ep_4(), this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20)));
+        this.mNode_277Instance = local;
+      }
+      return (Node_277) local;
+    }
+
+    Node_52 accessNode_52() {
+      return Checks.checkProvisionNotNull(Module_394.Companion.provides_463(new ProviderImpl(this, 10), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new ProviderImpl(this, 16), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.cacheNode_15(), new ProviderImpl(this, 2), this.mComponent_318.mSet_3, new ProviderImpl(this, 14), new CachingProviderImpl(this, 15), this.accessNode_286(), this.mComponent_318.accessNode_210(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), this.mComponent_318.cacheNode_133(), this.mDependency_313.ep_0()));
+    }
+
+    Node_175 accessNode_175() {
+      return Checks.checkProvisionNotNull(Module_394.Companion.provides_464(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 19), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.cacheNode_15(), this.mComponent_318.cacheNode_172(), this.mDependency_313.ep_0(), this.mComponent_318.cacheNode_17(), this.mComponent_318.mSet_0, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), this.mComponent_318.cacheNode_262(), new CachingProviderImpl(this, 2), this.mComponent_318.mDependency_310.ep_4(), Checks.checkProvisionNotNull(Module_394.Companion.provides_462()), this.cacheNode_119(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), this.mComponent_318.cacheNode_254(), this.mDependency_313.ep_2(), this.cacheNode_169(), this.mComponent_318.cacheNode_281(), this.accessNode_83(), this.mComponent_318.cacheNode_107(), new ProviderImpl(this, 10), new CachingProviderImpl(this, 12)));
+    }
+
+    Node_97 cacheNode_97() {
+      Object local = this.mNode_97Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_394.Companion.provides_465(this.accessNode_52(), this.accessNode_242(), this.mComponent_318.cacheNode_17(), this.mDependency_313.ep_1()));
+        this.mNode_97Instance = local;
+      }
+      return (Node_97) local;
+    }
+
+    Node_169 cacheNode_169() {
+      Object local = this.mNode_169Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_394.Companion.provides_466());
+        this.mNode_169Instance = local;
+      }
+      return (Node_169) local;
+    }
+
+    Node_119 cacheNode_119() {
+      Object local = this.mNode_119Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_119(this.mComponent_318.cacheNode_257(), this.mComponent_318.cacheNode_133(), this.accessNode_83(), this.mDependency_313.ep_1(), this.mComponent_318.cacheNode_17(), new CachingProviderImpl(this, 1));
+        this.mNode_119Instance = local;
+      }
+      return (Node_119) local;
+    }
+
+    Node_149 accessNode_149() {
+      return new Node_149(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 13), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_257(), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 15), this.mComponent_318.cacheNode_262(), this.accessNode_90(), this.mComponent_318.cacheNode_11(), new ProviderImpl(this, 14), this.cacheNode_169(), this.mComponent_318.cacheNode_254(), this.accessNode_295(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 18), this.mComponent_318.cacheNode_30(), this.mComponent_318.mDependency_310.ep_0(), this.cacheNode_168());
+    }
+
+    Node_168 cacheNode_168() {
+      Object local = this.mNode_168Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_168(this.mComponent_318.cacheNode_30(), this.accessNode_295(), this.mComponent_318.mDependency_310.ep_4(), this.accessNode_52(), new ProviderImpl(this, 14), new CachingProviderImpl(this, 15), this.mComponent_318.mSet_1, new CachingProviderImpl(this, 5), this.mComponent_318.mSet_0, this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_3, this.cacheNode_169(), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_46(), this.mComponent_318.cacheNode_133(), this.accessNode_51(), new ProviderImpl(this, 3), this.mDependency_313.ep_1());
+        this.mNode_168Instance = local;
+      }
+      return (Node_168) local;
+    }
+
+    Node_209 accessNode_209() {
+      return new Node_209(this.accessNode_149(), this.cacheNode_168(), this.mDependency_313.ep_1(), this.mComponent_318.mDependency_310.ep_5(), this.accessNode_83(), new CachingProviderImpl(this, 8), this.mDependency_313.ep_0(), this.mComponent_318.cacheNode_257(), new CachingProviderImpl(this, 11), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 0), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_11(), this.mComponent_318.mDependency_310.ep_2(), this.accessNode_149(), new ProviderImpl(this, 0), new ProviderImpl(this, 6), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mComponent_318.cacheNode_281());
+    }
+
+    Node_242 accessNode_242() {
+      return new Node_242(this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.cacheNode_107(), this.mComponent_318.cacheNode_172(), this.mComponent_318.cacheNode_133(), new CachingProviderImpl(this, 9), this.mComponent_318.mSet_1, this.mDependency_313.ep_0(), new CachingProviderImpl(this, 1), Checks.checkProvisionNotNull(Module_394.Companion.provides_462()), this.mComponent_318.mSet_0, this.cacheNode_169(), this.mComponent_318.cacheNode_30(), this.mComponent_318.mSet_2, new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mDependency_313.ep_2(), this.accessNode_175(), this.accessNode_47(), this.mComponent_318.cacheNode_11());
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.mComponent_318.cacheNode_257(), this.mComponent_318.mSet_3, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 8), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), this.mComponent_318.cacheNode_133(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3));
+    }
+
+    Node_295 accessNode_295() {
+      return new Node_295(this.mDependency_313.ep_1(), this.mComponent_318.mDependency_310.ep_5());
+    }
+
+    Node_47 accessNode_47() {
+      return new Node_47(this.accessNode_83(), this.accessNode_52(), this.mComponent_318.cacheNode_17(), this.accessNode_175(), this.cacheNode_169(), Checks.checkProvisionNotNull(Module_394.Companion.provides_462()), this.mComponent_318.cacheNode_46(), this.mSet_0, this.mComponent_318.cacheNode_106(), this.mComponent_318.cacheNode_262(), new CachingProviderImpl(this, 17), this.accessNode_295(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.accessNode_90(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), this.mComponent_318.cacheNode_257(), new CachingProviderImpl(this, 2), this.mComponent_318.cacheNode_11(), this.mComponent_318.accessNode_210(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20));
+    }
+
+    Node_51 accessNode_51() {
+      return new Node_51(new CachingProviderImpl(this, 5), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_17(), this.mComponent_318.cacheNode_133(), this.cacheNode_119(), new CachingProviderImpl(this, 7), this.accessNode_90(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 5), new CachingProviderImpl(this, 2), this.mComponent_318.cacheNode_106(), this.mComponent_318.mSet_0, new CachingProviderImpl(this, 8), new ProviderImpl(this, 7), this.mComponent_318.cacheNode_281(), this.mComponent_318.cacheNode_15());
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 2), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 13));
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_320Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_320Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_320Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_320Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_320.Creator {
+      Yatagan$Component_318 fComponent_318;
+
+      private Dependency_313 mSetDep_0;
+
+      private Node_189 mSet_0;
+
+      ComponentFactoryImpl(Yatagan$Component_318 fComponent_318) {
+        this.fComponent_318 = fComponent_318;
+      }
+
+      @Override
+      public Component_320.Creator setDep_0(Dependency_313 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_320.Creator set_0(Node_189 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_320 create() {
+        return new Component_320Impl(this.fComponent_318, this.mSetDep_0, this.mSet_0);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_321Impl implements Component_321 {
+    private Object mNode_175Instance;
+
+    private Object mNode_169Instance;
+
+    private Object mNode_52Instance;
+
+    private Object mNode_277Instance;
+
+    private Object mNode_119Instance;
+
+    private Object mNode_168Instance;
+
+    final Node_189 mSet_0;
+
+    final Dependency_313 mDependency_313;
+
+    final Yatagan$Component_318 mComponent_318;
+
+    Component_321Impl(Yatagan$Component_318 pComponent_318, Dependency_313 pSetDep_0,
+        Node_189 pSet_0) {
+      this.mComponent_318 = pComponent_318;
+      this.mDependency_313 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    }
+
+    @Override
+    public Node_175 getGet_0() {
+      return this.cacheNode_175();
+    }
+
+    @Override
+    public Provider<Node_168> getGet_1() {
+      return new ProviderImpl(this, 1);
+    }
+
+    @Override
+    public Node_180 getGet_2() {
+      return this.mDependency_313.ep_0();
+    }
+
+    @Override
+    public Node_51 getGet_3() {
+      return this.accessNode_51();
+    }
+
+    @Override
+    public Node_95 getGet_4() {
+      return this.accessNode_95();
+    }
+
+    @Override
+    public void inject_0(Injectee_354 i) {
+      i.setMember_0(this.mDependency_313.ep_1());
+      i.setMember_1(this.mDependency_313.ep_1());
+    }
+
+    @Override
+    public void inject_1(Injectee_355 i) {
+      i.setMember_0(this.mComponent_318.mSet_3);
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.cacheNode_175();
+        case 1: return this.cacheNode_168();
+        case 2: return this.accessNode_51();
+        case 3: return this.accessNode_95();
+        case 4: return this.accessNode_209();
+        case 5: return this.cacheNode_277();
+        case 6: return this.cacheNode_119();
+        case 7: return this.mDependency_313.ep_2();
+        case 8: return this.accessNode_83();
+        case 9: return this.accessNode_295();
+        case 10: return this.cacheNode_52();
+        case 11: return this.accessNode_97();
+        case 12: return this.accessNode_47();
+        case 13: return this.accessNode_149();
+        case 14: return this.accessNode_286();
+        case 15: return new Node_216(this.mComponent_318.cacheNode_281(), this.cacheNode_52(), new ProviderImpl(this, 12), this.accessNode_51(), this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_3, this.cacheNode_277(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 7), this.mComponent_318.cacheNode_257(), this.accessNode_295());
+        case 16: return this.accessNode_242();
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_175 cacheNode_175() {
+      Object local = this.mNode_175Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_395.Companion.provides_471(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 19), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.cacheNode_15(), this.mComponent_318.cacheNode_172(), this.mDependency_313.ep_0(), this.mComponent_318.cacheNode_17(), this.mComponent_318.mSet_0, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), this.mComponent_318.cacheNode_262(), new CachingProviderImpl(this, 4), this.mComponent_318.mDependency_310.ep_4(), new ProviderImpl(this, 5), this.cacheNode_119(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), this.mComponent_318.cacheNode_254(), this.mDependency_313.ep_2(), this.cacheNode_169(), this.mComponent_318.cacheNode_281(), this.accessNode_83(), this.mComponent_318.cacheNode_107(), new ProviderImpl(this, 1), new CachingProviderImpl(this, 9)));
+        this.mNode_175Instance = local;
+      }
+      return (Node_175) local;
+    }
+
+    Node_169 cacheNode_169() {
+      Object local = this.mNode_169Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_395.Companion.provides_472());
+        this.mNode_169Instance = local;
+      }
+      return (Node_169) local;
+    }
+
+    Node_52 cacheNode_52() {
+      Object local = this.mNode_52Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_395.Companion.provides_473(new ProviderImpl(this, 1), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new ProviderImpl(this, 15), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.cacheNode_15(), new ProviderImpl(this, 4), this.mComponent_318.mSet_3, new CachingProviderImpl(this, 11), new CachingProviderImpl(this, 12), this.accessNode_286(), this.mComponent_318.accessNode_210(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), this.mComponent_318.cacheNode_133(), this.mDependency_313.ep_0()));
+        this.mNode_52Instance = local;
+      }
+      return (Node_52) local;
+    }
+
+    Node_97 accessNode_97() {
+      return Checks.checkProvisionNotNull(Module_395.Companion.provides_474(this.cacheNode_52(), this.accessNode_242(), this.mComponent_318.cacheNode_17(), this.mDependency_313.ep_1()));
+    }
+
+    Node_277 cacheNode_277() {
+      Object local = this.mNode_277Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_395.Companion.provides_475(this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_11(), this.accessNode_90(), this.accessNode_295(), this.accessNode_286(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 17), this.mComponent_318.mSet_0, new CachingProviderImpl(this, 11), this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mDependency_310.ep_1(), this.mComponent_318.cacheNode_133(), this.accessNode_209(), this.mComponent_318.mDependency_310.ep_4(), this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20)));
+        this.mNode_277Instance = local;
+      }
+      return (Node_277) local;
+    }
+
+    Node_90 accessNode_90() {
+      return Checks.checkProvisionNotNull(Module_395.Companion.provides_476(new CachingProviderImpl(this, 8), new ProviderImpl(this, 10), new ProviderImpl(this, 1)));
+    }
+
+    Node_119 cacheNode_119() {
+      Object local = this.mNode_119Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_119(this.mComponent_318.cacheNode_257(), this.mComponent_318.cacheNode_133(), this.accessNode_83(), this.mDependency_313.ep_1(), this.mComponent_318.cacheNode_17(), new CachingProviderImpl(this, 2));
+        this.mNode_119Instance = local;
+      }
+      return (Node_119) local;
+    }
+
+    Node_149 accessNode_149() {
+      return new Node_149(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 13), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_257(), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 12), this.mComponent_318.cacheNode_262(), this.accessNode_90(), this.mComponent_318.cacheNode_11(), new CachingProviderImpl(this, 11), this.cacheNode_169(), this.mComponent_318.cacheNode_254(), this.accessNode_295(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 18), this.mComponent_318.cacheNode_30(), this.mComponent_318.mDependency_310.ep_0(), this.cacheNode_168());
+    }
+
+    Node_168 cacheNode_168() {
+      Object local = this.mNode_168Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_168(this.mComponent_318.cacheNode_30(), this.accessNode_295(), this.mComponent_318.mDependency_310.ep_4(), this.cacheNode_52(), new ProviderImpl(this, 11), new CachingProviderImpl(this, 12), this.mComponent_318.mSet_1, new CachingProviderImpl(this, 3), this.mComponent_318.mSet_0, this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_3, this.cacheNode_169(), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_46(), this.mComponent_318.cacheNode_133(), this.accessNode_51(), new ProviderImpl(this, 5), this.mDependency_313.ep_1());
+        this.mNode_168Instance = local;
+      }
+      return (Node_168) local;
+    }
+
+    Node_209 accessNode_209() {
+      return new Node_209(this.accessNode_149(), this.cacheNode_168(), this.mDependency_313.ep_1(), this.mComponent_318.mDependency_310.ep_5(), this.accessNode_83(), new ProviderImpl(this, 5), this.mDependency_313.ep_0(), this.mComponent_318.cacheNode_257(), new ProviderImpl(this, 0), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 0), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_11(), this.mComponent_318.mDependency_310.ep_2(), this.accessNode_149(), new ProviderImpl(this, 7), new ProviderImpl(this, 6), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mComponent_318.cacheNode_281());
+    }
+
+    Node_242 accessNode_242() {
+      return new Node_242(this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.cacheNode_107(), this.mComponent_318.cacheNode_172(), this.mComponent_318.cacheNode_133(), new ProviderImpl(this, 10), this.mComponent_318.mSet_1, this.mDependency_313.ep_0(), new CachingProviderImpl(this, 2), this.cacheNode_277(), this.mComponent_318.mSet_0, this.cacheNode_169(), this.mComponent_318.cacheNode_30(), this.mComponent_318.mSet_2, new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mDependency_313.ep_2(), this.cacheNode_175(), this.accessNode_47(), this.mComponent_318.cacheNode_11());
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.mComponent_318.cacheNode_257(), this.mComponent_318.mSet_3, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 8), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), this.mComponent_318.cacheNode_133(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3));
+    }
+
+    Node_295 accessNode_295() {
+      return new Node_295(this.mDependency_313.ep_1(), this.mComponent_318.mDependency_310.ep_5());
+    }
+
+    Node_47 accessNode_47() {
+      return new Node_47(this.accessNode_83(), this.cacheNode_52(), this.mComponent_318.cacheNode_17(), this.cacheNode_175(), this.cacheNode_169(), this.cacheNode_277(), this.mComponent_318.cacheNode_46(), this.mSet_0, this.mComponent_318.cacheNode_106(), this.mComponent_318.cacheNode_262(), new CachingProviderImpl(this, 16), this.accessNode_295(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.accessNode_90(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), this.mComponent_318.cacheNode_257(), new CachingProviderImpl(this, 4), this.mComponent_318.cacheNode_11(), this.mComponent_318.accessNode_210(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20));
+    }
+
+    Node_51 accessNode_51() {
+      return new Node_51(new CachingProviderImpl(this, 3), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_17(), this.mComponent_318.cacheNode_133(), this.cacheNode_119(), new CachingProviderImpl(this, 13), this.accessNode_90(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 5), new CachingProviderImpl(this, 4), this.mComponent_318.cacheNode_106(), this.mComponent_318.mSet_0, new ProviderImpl(this, 5), new ProviderImpl(this, 13), this.mComponent_318.cacheNode_281(), this.mComponent_318.cacheNode_15());
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 2), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 14));
+    }
+
+    Node_95 accessNode_95() {
+      return new Node_95(new ProviderImpl(this, 5), this.mComponent_318.cacheNode_133(), new ProviderImpl(this, 7), this.mComponent_318.mDependency_310.ep_5(), new CachingProviderImpl(this, 2), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mSet_2, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new CachingProviderImpl(this, 13), this.mComponent_318.cacheNode_262(), this.cacheNode_52(), this.mComponent_318.mSet_1, this.mComponent_318.cacheNode_106(), this.mComponent_318.mSet_0, this.accessNode_97());
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_321Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_321Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_321Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_321Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_321.Creator {
+      Yatagan$Component_318 fComponent_318;
+
+      private Dependency_313 mSetDep_0;
+
+      private Node_189 mSet_0;
+
+      ComponentFactoryImpl(Yatagan$Component_318 fComponent_318) {
+        this.fComponent_318 = fComponent_318;
+      }
+
+      @Override
+      public Component_321.Creator setDep_0(Dependency_313 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_321.Creator set_0(Node_189 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_321 create() {
+        return new Component_321Impl(this.fComponent_318, this.mSetDep_0, this.mSet_0);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_322Impl implements Component_322 {
+    private Object mNode_175Instance;
+
+    private Object mNode_52Instance;
+
+    private Object mNode_90Instance;
+
+    private Object mNode_119Instance;
+
+    private Object mNode_168Instance;
+
+    final Node_189 mSet_0;
+
+    final Dependency_313 mDependency_313;
+
+    final Yatagan$Component_318 mComponent_318;
+
+    Component_322Impl(Yatagan$Component_318 pComponent_318, Dependency_313 pSetDep_0,
+        Node_189 pSet_0) {
+      this.mComponent_318 = pComponent_318;
+      this.mDependency_313 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    }
+
+    @Override
+    public Node_175 getGet_0() {
+      return this.cacheNode_175();
+    }
+
+    @Override
+    public Node_119 getGet_1() {
+      return this.cacheNode_119();
+    }
+
+    @Override
+    public void inject_0(Injectee_356 i) {
+      i.setMember_0(this.cacheNode_119());
+      i.setMember_1(this.mComponent_318.accessNode_210());
+      i.setMember_2(this.mComponent_318.mSet_0);
+      i.setMember_3(this.mComponent_318.mDependency_310.ep_5());
+      i.setMember_4(this.accessNode_286());
+      i.setMember_5(this.cacheNode_52());
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.cacheNode_175();
+        case 1: return this.cacheNode_119();
+        case 2: return this.accessNode_286();
+        case 3: return this.cacheNode_52();
+        case 4: return this.accessNode_209();
+        case 5: return this.accessNode_277();
+        case 6: return this.mDependency_313.ep_2();
+        case 7: return this.accessNode_83();
+        case 8: return this.cacheNode_168();
+        case 9: return this.accessNode_295();
+        case 10: return this.accessNode_51();
+        case 11: return new Node_216(this.mComponent_318.cacheNode_281(), this.cacheNode_52(), new ProviderImpl(this, 13), this.accessNode_51(), this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_3, this.accessNode_277(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 7), this.mComponent_318.cacheNode_257(), this.accessNode_295());
+        case 12: return this.accessNode_97();
+        case 13: return this.accessNode_47();
+        case 14: return this.accessNode_149();
+        case 15: return new Node_95(new CachingProviderImpl(this, 5), this.mComponent_318.cacheNode_133(), new ProviderImpl(this, 6), this.mComponent_318.mDependency_310.ep_5(), new CachingProviderImpl(this, 10), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mSet_2, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new CachingProviderImpl(this, 14), this.mComponent_318.cacheNode_262(), this.cacheNode_52(), this.mComponent_318.mSet_1, this.mComponent_318.cacheNode_106(), this.mComponent_318.mSet_0, this.accessNode_97());
+        case 16: return this.accessNode_242();
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_175 cacheNode_175() {
+      Object local = this.mNode_175Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_396.Companion.provides_481(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 19), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.cacheNode_15(), this.mComponent_318.cacheNode_172(), this.mDependency_313.ep_0(), this.mComponent_318.cacheNode_17(), this.mComponent_318.mSet_0, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 5), this.mComponent_318.cacheNode_262(), this.accessNode_209(), this.mComponent_318.mDependency_310.ep_4(), this.accessNode_277(), this.cacheNode_119(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), this.mComponent_318.cacheNode_254(), this.mDependency_313.ep_2(), Checks.checkProvisionNotNull(Module_396.Companion.provides_483()), this.mComponent_318.cacheNode_281(), this.accessNode_83(), this.mComponent_318.cacheNode_107(), this.cacheNode_168(), new CachingProviderImpl(this, 9)));
+        this.mNode_175Instance = local;
+      }
+      return (Node_175) local;
+    }
+
+    Node_52 cacheNode_52() {
+      Object local = this.mNode_52Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_396.Companion.provides_482(new ProviderImpl(this, 8), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new ProviderImpl(this, 11), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.cacheNode_15(), new ProviderImpl(this, 4), this.mComponent_318.mSet_3, new CachingProviderImpl(this, 12), new CachingProviderImpl(this, 13), this.accessNode_286(), this.mComponent_318.accessNode_210(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), this.mComponent_318.cacheNode_133(), this.mDependency_313.ep_0()));
+        this.mNode_52Instance = local;
+      }
+      return (Node_52) local;
+    }
+
+    Node_97 accessNode_97() {
+      return Checks.checkProvisionNotNull(Module_396.Companion.provides_484(this.cacheNode_52(), this.accessNode_242(), this.mComponent_318.cacheNode_17(), this.mDependency_313.ep_1()));
+    }
+
+    Node_277 accessNode_277() {
+      return Checks.checkProvisionNotNull(Module_396.Companion.provides_485(this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_11(), this.cacheNode_90(), this.accessNode_295(), this.accessNode_286(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 17), this.mComponent_318.mSet_0, new CachingProviderImpl(this, 12), this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.mDependency_310.ep_0(), this.mComponent_318.mDependency_310.ep_1(), this.mComponent_318.cacheNode_133(), this.accessNode_209(), this.mComponent_318.mDependency_310.ep_4(), this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20)));
+    }
+
+    Node_90 cacheNode_90() {
+      Object local = this.mNode_90Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_396.Companion.provides_486(new CachingProviderImpl(this, 7), new ProviderImpl(this, 3), new ProviderImpl(this, 8)));
+        this.mNode_90Instance = local;
+      }
+      return (Node_90) local;
+    }
+
+    Node_119 cacheNode_119() {
+      Object local = this.mNode_119Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_119(this.mComponent_318.cacheNode_257(), this.mComponent_318.cacheNode_133(), this.accessNode_83(), this.mDependency_313.ep_1(), this.mComponent_318.cacheNode_17(), new CachingProviderImpl(this, 10));
+        this.mNode_119Instance = local;
+      }
+      return (Node_119) local;
+    }
+
+    Node_149 accessNode_149() {
+      return new Node_149(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 13), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 15), this.mComponent_318.cacheNode_107(), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_257(), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 13), this.mComponent_318.cacheNode_262(), this.cacheNode_90(), this.mComponent_318.cacheNode_11(), new CachingProviderImpl(this, 12), Checks.checkProvisionNotNull(Module_396.Companion.provides_483()), this.mComponent_318.cacheNode_254(), this.accessNode_295(), new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 18), this.mComponent_318.cacheNode_30(), this.mComponent_318.mDependency_310.ep_0(), this.cacheNode_168());
+    }
+
+    Node_168 cacheNode_168() {
+      Object local = this.mNode_168Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_168(this.mComponent_318.cacheNode_30(), this.accessNode_295(), this.mComponent_318.mDependency_310.ep_4(), this.cacheNode_52(), new ProviderImpl(this, 12), new CachingProviderImpl(this, 13), this.mComponent_318.mSet_1, new CachingProviderImpl(this, 15), this.mComponent_318.mSet_0, this.mComponent_318.accessNode_210(), this.mComponent_318.mSet_3, Checks.checkProvisionNotNull(Module_396.Companion.provides_483()), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_46(), this.mComponent_318.cacheNode_133(), this.accessNode_51(), new CachingProviderImpl(this, 5), this.mDependency_313.ep_1());
+        this.mNode_168Instance = local;
+      }
+      return (Node_168) local;
+    }
+
+    Node_209 accessNode_209() {
+      return new Node_209(this.accessNode_149(), this.cacheNode_168(), this.mDependency_313.ep_1(), this.mComponent_318.mDependency_310.ep_5(), this.accessNode_83(), new CachingProviderImpl(this, 5), this.mDependency_313.ep_0(), this.mComponent_318.cacheNode_257(), new ProviderImpl(this, 0), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 0), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_11(), this.mComponent_318.mDependency_310.ep_2(), this.accessNode_149(), new ProviderImpl(this, 6), new ProviderImpl(this, 1), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mComponent_318.cacheNode_281());
+    }
+
+    Node_242 accessNode_242() {
+      return new Node_242(this.mComponent_318.mDependency_310.ep_5(), this.mComponent_318.cacheNode_107(), this.mComponent_318.cacheNode_172(), this.mComponent_318.cacheNode_133(), new ProviderImpl(this, 3), this.mComponent_318.mSet_1, this.mDependency_313.ep_0(), new CachingProviderImpl(this, 10), this.accessNode_277(), this.mComponent_318.mSet_0, Checks.checkProvisionNotNull(Module_396.Companion.provides_483()), this.mComponent_318.cacheNode_30(), this.mComponent_318.mSet_2, new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 14), this.mDependency_313.ep_2(), this.cacheNode_175(), this.accessNode_47(), this.mComponent_318.cacheNode_11());
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.mComponent_318.cacheNode_257(), this.mComponent_318.mSet_3, new Yatagan$Component_318.CachingProviderImpl(this.mComponent_318, 1), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 8), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), this.mComponent_318.cacheNode_133(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3));
+    }
+
+    Node_295 accessNode_295() {
+      return new Node_295(this.mDependency_313.ep_1(), this.mComponent_318.mDependency_310.ep_5());
+    }
+
+    Node_47 accessNode_47() {
+      return new Node_47(this.accessNode_83(), this.cacheNode_52(), this.mComponent_318.cacheNode_17(), this.cacheNode_175(), Checks.checkProvisionNotNull(Module_396.Companion.provides_483()), this.accessNode_277(), this.mComponent_318.cacheNode_46(), this.mSet_0, this.mComponent_318.cacheNode_106(), this.mComponent_318.cacheNode_262(), new CachingProviderImpl(this, 16), this.accessNode_295(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 11), this.cacheNode_90(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 10), this.mComponent_318.cacheNode_257(), new CachingProviderImpl(this, 4), this.mComponent_318.cacheNode_11(), this.mComponent_318.accessNode_210(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20));
+    }
+
+    Node_51 accessNode_51() {
+      return new Node_51(new CachingProviderImpl(this, 15), this.mComponent_318.mDependency_310.ep_2(), this.mComponent_318.cacheNode_17(), this.mComponent_318.cacheNode_133(), this.cacheNode_119(), new CachingProviderImpl(this, 14), this.cacheNode_90(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 5), new CachingProviderImpl(this, 4), this.mComponent_318.cacheNode_106(), this.mComponent_318.mSet_0, new CachingProviderImpl(this, 5), new ProviderImpl(this, 14), this.mComponent_318.cacheNode_281(), this.mComponent_318.cacheNode_15());
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_318.cacheNode_257(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 3), this.mComponent_318.mSet_0, this.mComponent_318.cacheNode_17(), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 18), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 9), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 20), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 2), new Yatagan$Component_318.ProviderImpl(this.mComponent_318, 16), this.mComponent_318.mDependency_310.ep_1(), new CachingProviderImpl(this, 2));
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_322Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_322Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_322Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_322Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_322.Creator {
+      Yatagan$Component_318 fComponent_318;
+
+      private Dependency_313 mSetDep_0;
+
+      private Node_189 mSet_0;
+
+      ComponentFactoryImpl(Yatagan$Component_318 fComponent_318) {
+        this.fComponent_318 = fComponent_318;
+      }
+
+      @Override
+      public Component_322.Creator setDep_0(Dependency_313 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_322.Creator set_0(Node_189 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_322 create() {
+        return new Component_322Impl(this.fComponent_318, this.mSetDep_0, this.mSet_0);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$Component_318 mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$Component_318 delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$Component_318 mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$Component_318 factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements Component_318.Creator {
+    private Dependency_310 mSetDep_0;
+
+    private Node_130 mSet_0;
+
+    private Node_176 mSet_1;
+
+    private Node_134 mSet_2;
+
+    private Node_238 mSet_3;
+
+    @Override
+    public Component_318.Creator setDep_0(Dependency_310 i) {
+      this.mSetDep_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_318.Creator set_0(Node_130 i) {
+      this.mSet_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_318.Creator set_1(Node_176 i) {
+      this.mSet_1 = i;
+      return this;
+    }
+
+    @Override
+    public Component_318.Creator set_2(Node_134 i) {
+      this.mSet_2 = i;
+      return this;
+    }
+
+    @Override
+    public Component_318.Creator set_3(Node_238 i) {
+      this.mSet_3 = i;
+      return this;
+    }
+
+    @Override
+    public Component_318 create() {
+      return new Yatagan$Component_318(this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$Component_323.java
+package test;
+
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$Component_323 implements Component_323 {
+  private Object mNode_102Instance;
+
+  private Object mNode_17Instance;
+
+  private Object mNode_30Instance;
+
+  private Object mNode_107Instance;
+
+  private Object mNode_11Instance;
+
+  private Object mNode_133Instance;
+
+  private Object mNode_172Instance;
+
+  private Object mNode_254Instance;
+
+  private Object mNode_257Instance;
+
+  private Object mNode_262Instance;
+
+  private Object mNode_281Instance;
+
+  private Object mNode_46Instance;
+
+  final Node_176 mSet_0;
+
+  final Node_238 mSet_1;
+
+  final Node_130 mSet_2;
+
+  final Node_134 mSet_3;
+
+  final Dependency_310 mDependency_310;
+
+  Yatagan$Component_323(Dependency_310 pSetDep_0, Node_176 pSet_0, Node_238 pSet_1, Node_130 pSet_2,
+      Node_134 pSet_3) {
+    this.mDependency_310 = Checks.checkInputNotNull(pSetDep_0);
+    this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+    this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+    this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+  }
+
+  @Override
+  public Component_324.Creator getChildCreator_0() {
+    return new Component_324Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Component_325.Creator getChildCreator_1() {
+    return new Component_325Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Component_326.Creator getChildCreator_2() {
+    return new Component_326Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Component_327.Creator getChildCreator_3() {
+    return new Component_327Impl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public Lazy<Node_224> getGet_0() {
+    return new CachingProviderImpl(this, 16);
+  }
+
+  @Override
+  public Node_300 getGet_1() {
+    return this.cacheNode_257();
+  }
+
+  @Override
+  public Node_210 getGet_2() {
+    return this.accessNode_210();
+  }
+
+  @Override
+  public Node_172 getGet_3() {
+    return this.cacheNode_172();
+  }
+
+  @Override
+  public Lazy<Node_176> getGet_4() {
+    return new CachingProviderImpl(this, 8);
+  }
+
+  @Override
+  public Provider<Node_133> getGet_5() {
+    return new ProviderImpl(this, 18);
+  }
+
+  @Override
+  public Node_122 getGet_6() {
+    return this.mSet_2;
+  }
+
+  @Override
+  public Node_257 getGet_7() {
+    return this.cacheNode_257();
+  }
+
+  @Override
+  public Node_281 getGet_8() {
+    return this.cacheNode_281();
+  }
+
+  @Override
+  public void inject_0(Injectee_357 i) {
+    i.setMember_0(this.cacheNode_257());
+    i.setMember_1(this.cacheNode_102());
+    i.setMember_2(this.cacheNode_11());
+    i.setMember_3(this.accessNode_83());
+    i.setMember_4(this.cacheNode_107());
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheNode_281();
+      case 1: return this.mDependency_310.ep_1();
+      case 2: return this.accessNode_210();
+      case 3: return this.cacheNode_262();
+      case 4: return this.cacheNode_11();
+      case 5: return this.cacheNode_257();
+      case 6: return this.cacheNode_102();
+      case 7: return this.mSet_3;
+      case 8: return this.mSet_0;
+      case 9: return this.mSet_2;
+      case 10: return this.accessNode_15();
+      case 11: return this.cacheNode_254();
+      case 12: return this.cacheNode_107();
+      case 13: return this.cacheNode_30();
+      case 14: return this.cacheNode_172();
+      case 15: return this.mSet_1;
+      case 16: return this.mDependency_310.ep_2();
+      case 17: return this.cacheNode_17();
+      case 18: return this.cacheNode_133();
+      case 19: return this.cacheNode_46();
+      case 20: return this.mDependency_310.ep_0();
+      case 21: return this.mDependency_310.ep_3();
+      case 22: return this.mDependency_310.ep_6();
+      case 23: return this.accessNode_83();
+      case 24: return this.accessNode_286();
+      default: throw new AssertionError();
+    }
+  }
+
+  Node_210 accessNode_210() {
+    return Checks.checkProvisionNotNull(Module_397.Companion.provides_490(this.mSet_2, this.accessNode_83(), this.mDependency_310.ep_0(), this.mSet_1, new ProviderImpl(this, 17), new ProviderImpl(this, 13), new ProviderImpl(this, 18), this.cacheNode_46(), new CachingProviderImpl(this, 24), new ProviderImpl(this, 0), this.mSet_2, this.mDependency_310.ep_2(), new ProviderImpl(this, 11)));
+  }
+
+  Node_102 cacheNode_102() {
+    Object local = this.mNode_102Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_397.Companion.provides_491(this.cacheNode_46(), new ProviderImpl(this, 13), this.accessNode_83(), this.cacheNode_17(), new ProviderImpl(this, 14), new ProviderImpl(this, 10), this.cacheNode_257(), new ProviderImpl(this, 3), new ProviderImpl(this, 11), this.mSet_2, new CachingProviderImpl(this, 9), this.cacheNode_133(), new ProviderImpl(this, 4), this.accessNode_286()));
+      this.mNode_102Instance = local;
+    }
+    return (Node_102) local;
+  }
+
+  Node_17 cacheNode_17() {
+    Object local = this.mNode_17Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_397.Companion.provides_492());
+      this.mNode_17Instance = local;
+    }
+    return (Node_17) local;
+  }
+
+  Node_30 cacheNode_30() {
+    Object local = this.mNode_30Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(Module_397.Companion.provides_493(new ProviderImpl(this, 18), this.cacheNode_172(), this.mSet_0, this.accessNode_210(), this.cacheNode_257(), this.accessNode_83(), this.mDependency_310.ep_1(), this.mDependency_310.ep_0(), new ProviderImpl(this, 6), this.cacheNode_254(), this.mSet_2, this.mSet_1, new CachingProviderImpl(this, 10), this.cacheNode_262(), this.cacheNode_281(), this.mSet_3, new ProviderImpl(this, 10), new CachingProviderImpl(this, 16)));
+      this.mNode_30Instance = local;
+    }
+    return (Node_30) local;
+  }
+
+  Node_15 accessNode_15() {
+    return Checks.checkProvisionNotNull(Module_397.Companion.provides_494(this.cacheNode_257(), this.mDependency_310.ep_2(), new ProviderImpl(this, 6), new ProviderImpl(this, 5), new ProviderImpl(this, 18), this.cacheNode_30(), new ProviderImpl(this, 9), this.mDependency_310.ep_0(), this.mDependency_310.ep_1(), new CachingProviderImpl(this, 10), new CachingProviderImpl(this, 2), this.cacheNode_46(), new ProviderImpl(this, 11)));
+  }
+
+  Node_107 cacheNode_107() {
+    Object local = this.mNode_107Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_107(this.accessNode_286(), this.mSet_0, this.cacheNode_133(), this.mDependency_310.ep_1(), new ProviderImpl(this, 0), this.cacheNode_102(), this.mSet_2, this.mDependency_310.ep_0(), this.cacheNode_46(), new ProviderImpl(this, 11), new ProviderImpl(this, 7), this.mSet_2, new ProviderImpl(this, 17), this.cacheNode_257());
+      this.mNode_107Instance = local;
+    }
+    return (Node_107) local;
+  }
+
+  Node_11 cacheNode_11() {
+    Object local = this.mNode_11Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_11(this.mDependency_310.ep_2(), this.mDependency_310.ep_0(), new ProviderImpl(this, 0), new CachingProviderImpl(this, 7), new ProviderImpl(this, 12), new ProviderImpl(this, 9), new ProviderImpl(this, 6), new CachingProviderImpl(this, 2), new ProviderImpl(this, 1), new ProviderImpl(this, 3), this.cacheNode_17(), this.cacheNode_257(), new CachingProviderImpl(this, 10), new CachingProviderImpl(this, 23), this.mSet_2, this.cacheNode_172(), this.mSet_0);
+      this.mNode_11Instance = local;
+    }
+    return (Node_11) local;
+  }
+
+  Node_133 cacheNode_133() {
+    Object local = this.mNode_133Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_133(new ProviderImpl(this, 3), new CachingProviderImpl(this, 2), this.mSet_3, new ProviderImpl(this, 0), new CachingProviderImpl(this, 15), this.mDependency_310.ep_1(), this.accessNode_15(), new CachingProviderImpl(this, 24), this.mDependency_310.ep_0());
+      this.mNode_133Instance = local;
+    }
+    return (Node_133) local;
+  }
+
+  Node_172 cacheNode_172() {
+    Object local = this.mNode_172Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_172(new ProviderImpl(this, 17), new CachingProviderImpl(this, 10), new ProviderImpl(this, 0), new CachingProviderImpl(this, 15), this.cacheNode_257());
+      this.mNode_172Instance = local;
+    }
+    return (Node_172) local;
+  }
+
+  Node_254 cacheNode_254() {
+    Object local = this.mNode_254Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_254(this.mSet_2, this.cacheNode_17(), this.mDependency_310.ep_1(), this.cacheNode_257(), new CachingProviderImpl(this, 15), new CachingProviderImpl(this, 10), new ProviderImpl(this, 18), new ProviderImpl(this, 6), new ProviderImpl(this, 24), new ProviderImpl(this, 23), this.cacheNode_172(), new ProviderImpl(this, 3), new ProviderImpl(this, 0), this.mSet_0, this.cacheNode_11(), new ProviderImpl(this, 13));
+      this.mNode_254Instance = local;
+    }
+    return (Node_254) local;
+  }
+
+  Node_257 cacheNode_257() {
+    Object local = this.mNode_257Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_257(new ProviderImpl(this, 5), new ProviderImpl(this, 15), new ProviderImpl(this, 11), this.mSet_2, new ProviderImpl(this, 0));
+      this.mNode_257Instance = local;
+    }
+    return (Node_257) local;
+  }
+
+  Node_262 cacheNode_262() {
+    Object local = this.mNode_262Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_262(new ProviderImpl(this, 18), this.cacheNode_46(), new ProviderImpl(this, 13), new ProviderImpl(this, 6), this.cacheNode_257(), new CachingProviderImpl(this, 10), this.cacheNode_11(), new ProviderImpl(this, 0), new CachingProviderImpl(this, 10), this.accessNode_83(), this.mSet_1, this.mDependency_310.ep_2(), this.mDependency_310.ep_0(), this.cacheNode_257(), this.cacheNode_254());
+      this.mNode_262Instance = local;
+    }
+    return (Node_262) local;
+  }
+
+  Node_281 cacheNode_281() {
+    Object local = this.mNode_281Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_281(this.cacheNode_46(), new CachingProviderImpl(this, 24), this.mDependency_310.ep_2(), new ProviderImpl(this, 13), new ProviderImpl(this, 12), this.cacheNode_254(), new CachingProviderImpl(this, 7), new CachingProviderImpl(this, 9), this.cacheNode_262(), this.mDependency_310.ep_0(), new ProviderImpl(this, 2), this.mSet_2, this.mSet_1, new ProviderImpl(this, 23), new ProviderImpl(this, 17));
+      this.mNode_281Instance = local;
+    }
+    return (Node_281) local;
+  }
+
+  Node_286 accessNode_286() {
+    return new Node_286(new CachingProviderImpl(this, 10), this.cacheNode_17(), new ProviderImpl(this, 13), this.cacheNode_257(), this.mSet_1, new CachingProviderImpl(this, 8), new ProviderImpl(this, 19), new ProviderImpl(this, 4), new ProviderImpl(this, 11), this.cacheNode_133(), new ProviderImpl(this, 14), new ProviderImpl(this, 5));
+  }
+
+  Node_46 cacheNode_46() {
+    Object local = this.mNode_46Instance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Node_46(this.cacheNode_17(), this.mDependency_310.ep_0());
+      this.mNode_46Instance = local;
+    }
+    return (Node_46) local;
+  }
+
+  Node_83 accessNode_83() {
+    return new Node_83(this.cacheNode_257(), new ProviderImpl(this, 5), this.mSet_2, this.cacheNode_17(), new ProviderImpl(this, 9), new ProviderImpl(this, 19), new ProviderImpl(this, 11), new ProviderImpl(this, 0), new CachingProviderImpl(this, 10), this.mDependency_310.ep_1(), new CachingProviderImpl(this, 24));
+  }
+
+  public static Component_323.Creator builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_324Impl implements Component_324 {
+    private Object mNode_173Instance;
+
+    private Object mNode_111Instance;
+
+    private Object mNode_162Instance;
+
+    private Object mNode_138Instance;
+
+    private Object mNode_276Instance;
+
+    private Object mNode_146Instance;
+
+    private Object mNode_267Instance;
+
+    private Object mNode_37Instance;
+
+    private Object mNode_305Instance;
+
+    private Object mNode_261Instance;
+
+    private Object mNode_84Instance;
+
+    final Node_265 mSet_0;
+
+    final Node_239 mSet_1;
+
+    final Node_34 mSet_2;
+
+    final Node_246 mSet_3;
+
+    final Dependency_312 mDependency_312;
+
+    final Yatagan$Component_323 mComponent_323;
+
+    Component_324Impl(Yatagan$Component_323 pComponent_323, Dependency_312 pSetDep_0,
+        Node_265 pSet_0, Node_239 pSet_1, Node_34 pSet_2, Node_246 pSet_3) {
+      this.mComponent_323 = pComponent_323;
+      this.mDependency_312 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+      this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+      this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+      this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+    }
+
+    @Override
+    public Node_173 getGet_0() {
+      return this.cacheNode_173();
+    }
+
+    @Override
+    public void inject_0(Injectee_358 i) {
+      i.setMember_0(this.accessNode_71());
+      i.setMember_1(this.cacheNode_111());
+      i.setMember_10(this.mComponent_323.mDependency_310.ep_1());
+      i.setMember_2(this.mComponent_323.cacheNode_281());
+      i.setMember_3(this.mComponent_323.mDependency_310.ep_1());
+      i.setMember_4(this.mComponent_323.accessNode_210());
+      i.setMember_5(this.cacheNode_162());
+      i.setMember_6(this.mDependency_312.ep_0());
+      i.setMember_7(this.cacheNode_111());
+      i.setMember_8(this.mSet_0);
+      i.setMember_9(this.cacheNode_138());
+    }
+
+    @Override
+    public void inject_1(Injectee_359 i) {
+      i.setMember_0(this.accessNode_123());
+      i.setMember_1(this.mComponent_323.cacheNode_262());
+      i.setMember_2(this.cacheNode_138());
+      i.setMember_3(this.cacheNode_276());
+      i.setMember_4(this.mComponent_323.cacheNode_11());
+      i.setMember_5(this.mSet_0);
+      i.setMember_6(this.mComponent_323.cacheNode_257());
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.cacheNode_173();
+        case 1: return this.accessNode_71();
+        case 2: return this.cacheNode_111();
+        case 3: return this.cacheNode_162();
+        case 4: return this.mDependency_312.ep_0();
+        case 5: return this.mSet_0;
+        case 6: return this.accessNode_123();
+        case 7: return this.cacheNode_276();
+        case 8: return this.cacheNode_146();
+        case 9: return this.cacheNode_267();
+        case 10: return this.accessNode_83();
+        case 11: return this.mSet_1;
+        case 12: return this.accessNode_182();
+        case 13: return this.mDependency_312.ep_1();
+        case 14: return this.accessNode_127();
+        case 15: return this.accessNode_286();
+        case 16: return this.accessNode_255();
+        case 17: return new Node_225();
+        case 18: return this.accessNode_121();
+        case 19: return this.cacheNode_84();
+        case 20: return this.accessNode_171();
+        case 21: return this.accessNode_291();
+        case 22: return this.accessNode_148();
+        case 23: return this.accessNode_36();
+        case 24: return this.mDependency_312.ep_2();
+        case 25: return this.cacheNode_37();
+        case 26: return this.cacheNode_305();
+        case 27: return this.mSet_3;
+        case 28: return this.cacheNode_261();
+        case 29: return this.accessNode_57();
+        case 30: return new Node_135(this.mComponent_323.cacheNode_262(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 15), this.accessNode_229(), this.mDependency_312.ep_0(), this.mComponent_323.mSet_2, this.mComponent_323.mDependency_310.ep_1(), this.accessNode_83(), this.mComponent_323.cacheNode_30(), this.cacheNode_146(), this.mDependency_312.ep_2(), this.mComponent_323.cacheNode_11(), this.mSet_2, this.mComponent_323.cacheNode_281());
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_173 cacheNode_173() {
+      Object local = this.mNode_173Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_498(this.mComponent_323.cacheNode_102()));
+        this.mNode_173Instance = local;
+      }
+      return (Node_173) local;
+    }
+
+    Node_111 cacheNode_111() {
+      Object local = this.mNode_111Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_499(this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_254(), this.mDependency_312.ep_1(), new ProviderImpl(this, 14), this.mComponent_323.cacheNode_262(), new ProviderImpl(this, 15), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), new CachingProviderImpl(this, 16), this.cacheNode_162(), this.mComponent_323.mSet_0, new ProviderImpl(this, 7), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_30(), this.mComponent_323.cacheNode_172()));
+        this.mNode_111Instance = local;
+      }
+      return (Node_111) local;
+    }
+
+    Node_162 cacheNode_162() {
+      Object local = this.mNode_162Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_500(new Node_225(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_262(), this.accessNode_121(), this.mComponent_323.mSet_1, new ProviderImpl(this, 19), this.mComponent_323.mDependency_310.ep_2(), new ProviderImpl(this, 20), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), new ProviderImpl(this, 10)));
+        this.mNode_162Instance = local;
+      }
+      return (Node_162) local;
+    }
+
+    Node_138 cacheNode_138() {
+      Object local = this.mNode_138Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_501(new ProviderImpl(this, 1), this.accessNode_56(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 16), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mDependency_312.ep_0(), this.mComponent_323.cacheNode_281(), this.accessNode_291(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new ProviderImpl(this, 7), new CachingProviderImpl(this, 6), new CachingProviderImpl(this, 22), new ProviderImpl(this, 3)));
+        this.mNode_138Instance = local;
+      }
+      return (Node_138) local;
+    }
+
+    Node_123 accessNode_123() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_502(new CachingProviderImpl(this, 22), this.cacheNode_138(), this.mSet_0, this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 23), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.accessNode_121(), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_17(), this.mDependency_312.ep_0(), this.mComponent_323.cacheNode_254(), this.cacheNode_111(), new ProviderImpl(this, 24), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_11(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_133(), this.accessNode_286(), new CachingProviderImpl(this, 16), this.mComponent_323.cacheNode_102(), this.mSet_2));
+    }
+
+    Node_276 cacheNode_276() {
+      Object local = this.mNode_276Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_503(this.mComponent_323.accessNode_15(), this.accessNode_291(), this.mComponent_323.cacheNode_11(), new CachingProviderImpl(this, 22), new CachingProviderImpl(this, 12), this.mComponent_323.cacheNode_254(), this.cacheNode_37(), this.mComponent_323.cacheNode_133()));
+        this.mNode_276Instance = local;
+      }
+      return (Node_276) local;
+    }
+
+    Node_146 cacheNode_146() {
+      Object local = this.mNode_146Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_504(this.mComponent_323.cacheNode_262(), this.accessNode_127(), new ProviderImpl(this, 26)));
+        this.mNode_146Instance = local;
+      }
+      return (Node_146) local;
+    }
+
+    Node_267 cacheNode_267() {
+      Object local = this.mNode_267Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_505(new CachingProviderImpl(this, 12), this.cacheNode_305(), this.cacheNode_138(), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_162(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_172(), new ProviderImpl(this, 5), this.mComponent_323.cacheNode_46(), this.accessNode_148(), this.mComponent_323.cacheNode_30()));
+        this.mNode_267Instance = local;
+      }
+      return (Node_267) local;
+    }
+
+    Node_255 accessNode_255() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_506(this.mComponent_323.cacheNode_281(), this.accessNode_36(), this.mComponent_323.mSet_0, this.accessNode_121(), this.mComponent_323.accessNode_210(), new Node_225(), this.mComponent_323.mDependency_310.ep_1(), this.accessNode_286(), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 25), this.accessNode_229(), this.accessNode_148(), new CachingProviderImpl(this, 6), this.cacheNode_162(), Checks.checkProvisionNotNull(Module_398.Companion.provides_514(this.mComponent_323.accessNode_15(), this.accessNode_36(), this.mComponent_323.mDependency_310.ep_1(), this.mSet_3, this.mSet_1, this.mComponent_323.mSet_2)), this.cacheNode_173(), this.accessNode_127(), this.mComponent_323.cacheNode_17(), this.accessNode_56(), this.cacheNode_146(), this.mComponent_323.cacheNode_102(), this.accessNode_182(), this.mComponent_323.cacheNode_172()));
+    }
+
+    Node_121 accessNode_121() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_507(this.mComponent_323.mDependency_310.ep_2(), new ProviderImpl(this, 26), this.accessNode_71(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_254(), this.mComponent_323.cacheNode_102(), new Node_225(), this.mComponent_323.mSet_2, this.accessNode_56(), new ProviderImpl(this, 25), new ProviderImpl(this, 19), new CachingProviderImpl(this, 23), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.accessNode_171(), this.accessNode_291(), new CachingProviderImpl(this, 22), this.cacheNode_138(), new ProviderImpl(this, 2), this.mComponent_323.mDependency_310.ep_0(), this.mSet_0, this.mComponent_323.mSet_1));
+    }
+
+    Node_171 accessNode_171() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_508(this.mComponent_323.mSet_3, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.mDependency_310.ep_1(), new ProviderImpl(this, 28), this.mComponent_323.cacheNode_133(), this.mComponent_323.mSet_2, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_257()));
+    }
+
+    Node_291 accessNode_291() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_509(this.mComponent_323.accessNode_210(), this.mComponent_323.mSet_0, this.accessNode_286(), new ProviderImpl(this, 8), this.accessNode_229()));
+    }
+
+    Node_36 accessNode_36() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_510(this.accessNode_56(), this.mComponent_323.cacheNode_46(), this.mDependency_312.ep_2(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), new ProviderImpl(this, 26), new ProviderImpl(this, 19), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_1(), this.accessNode_123(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_102(), this.mDependency_312.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.accessNode_286(), this.mComponent_323.mSet_1));
+    }
+
+    Node_37 cacheNode_37() {
+      Object local = this.mNode_37Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_511(this.accessNode_121(), this.mDependency_312.ep_0(), this.accessNode_286(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_257(), new ProviderImpl(this, 17), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 5), this.cacheNode_261(), this.cacheNode_162(), new ProviderImpl(this, 0), this.mComponent_323.cacheNode_281(), this.cacheNode_138(), this.accessNode_182(), this.mComponent_323.mSet_1, this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_17(), this.mSet_3, this.accessNode_255()));
+        this.mNode_37Instance = local;
+      }
+      return (Node_37) local;
+    }
+
+    Node_305 cacheNode_305() {
+      Object local = this.mNode_305Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_398.Companion.provides_512(this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mSet_0, new ProviderImpl(this, 25), new CachingProviderImpl(this, 21), this.mComponent_323.cacheNode_257(), this.accessNode_229(), this.mComponent_323.mSet_2, this.cacheNode_261(), this.mComponent_323.cacheNode_254(), new ProviderImpl(this, 9), this.cacheNode_138(), this.mComponent_323.cacheNode_102(), this.accessNode_57()));
+        this.mNode_305Instance = local;
+      }
+      return (Node_305) local;
+    }
+
+    Node_229 accessNode_229() {
+      return Checks.checkProvisionNotNull(Module_398.Companion.provides_513(this.mComponent_323.cacheNode_30(), this.mComponent_323.mSet_2, new Node_225(), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_46(), this.cacheNode_146(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_323.cacheNode_172()));
+    }
+
+    Node_127 accessNode_127() {
+      return new Node_127(new CachingProviderImpl(this, 18), this.mSet_2, this.mDependency_312.ep_1(), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 12));
+    }
+
+    Node_148 accessNode_148() {
+      return new Node_148(this.mSet_1, this.mComponent_323.mDependency_310.ep_1(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), new ProviderImpl(this, 19), this.cacheNode_305(), this.accessNode_71(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), new CachingProviderImpl(this, 16));
+    }
+
+    Node_182 accessNode_182() {
+      return new Node_182(this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_102(), this.mComponent_323.mSet_1, this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.accessNode_15(), this.mDependency_312.ep_1(), this.accessNode_83(), this.mComponent_323.mSet_3, this.mComponent_323.cacheNode_257(), new ProviderImpl(this, 25), this.accessNode_127(), this.mSet_3, this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 2), this.cacheNode_267(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.cacheNode_262(), this.cacheNode_146(), this.mSet_2, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16));
+    }
+
+    Node_261 cacheNode_261() {
+      Object local = this.mNode_261Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_261(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new ProviderImpl(this, 13), this.mSet_0, this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_46(), this.mComponent_323.cacheNode_172(), this.accessNode_171(), this.mComponent_323.cacheNode_254(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 2), this.mSet_1, this.accessNode_291(), new CachingProviderImpl(this, 18), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 29), new CachingProviderImpl(this, 16), this.mComponent_323.mSet_3, new ProviderImpl(this, 22), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_1(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17));
+        this.mNode_261Instance = local;
+      }
+      return (Node_261) local;
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+    }
+
+    Node_56 accessNode_56() {
+      return new Node_56(new CachingProviderImpl(this, 22), this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 29), this.accessNode_171(), this.mComponent_323.cacheNode_172(), this.cacheNode_261(), new CachingProviderImpl(this, 18), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_0());
+    }
+
+    Node_57 accessNode_57() {
+      return new Node_57(this.accessNode_286(), new ProviderImpl(this, 3), this.mComponent_323.mDependency_310.ep_1(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.cacheNode_172(), this.accessNode_36(), new ProviderImpl(this, 7), this.mComponent_323.cacheNode_262(), this.mComponent_323.mSet_0, this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_257(), new ProviderImpl(this, 27), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), new ProviderImpl(this, 30), this.mDependency_312.ep_0(), this.accessNode_71(), new ProviderImpl(this, 2));
+    }
+
+    Node_71 accessNode_71() {
+      return new Node_71(this.mComponent_323.mSet_3, new ProviderImpl(this, 8), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_281(), new ProviderImpl(this, 9), this.accessNode_83(), this.mComponent_323.mSet_2, this.mComponent_323.accessNode_15(), this.mSet_1, new ProviderImpl(this, 6), new ProviderImpl(this, 4), new ProviderImpl(this, 2), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 12));
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 15));
+    }
+
+    Node_84 cacheNode_84() {
+      Object local = this.mNode_84Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_84(this.mComponent_323.mSet_3, this.mComponent_323.mDependency_310.ep_2(), this.mDependency_312.ep_2(), this.mComponent_323.mSet_2, this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 13), this.cacheNode_173(), this.cacheNode_305(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_262(), new ProviderImpl(this, 28), this.mSet_3, this.accessNode_148(), this.mComponent_323.cacheNode_102(), this.cacheNode_37(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 15), new CachingProviderImpl(this, 11), this.mComponent_323.cacheNode_30());
+        this.mNode_84Instance = local;
+      }
+      return (Node_84) local;
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_324Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_324Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_324Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_324Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_324.Creator {
+      Yatagan$Component_323 fComponent_323;
+
+      private Dependency_312 mSetDep_0;
+
+      private Node_265 mSet_0;
+
+      private Node_239 mSet_1;
+
+      private Node_34 mSet_2;
+
+      private Node_246 mSet_3;
+
+      ComponentFactoryImpl(Yatagan$Component_323 fComponent_323) {
+        this.fComponent_323 = fComponent_323;
+      }
+
+      @Override
+      public Component_324.Creator setDep_0(Dependency_312 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_324.Creator set_0(Node_265 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_324.Creator set_1(Node_239 i) {
+        this.mSet_1 = i;
+        return this;
+      }
+
+      @Override
+      public Component_324.Creator set_2(Node_34 i) {
+        this.mSet_2 = i;
+        return this;
+      }
+
+      @Override
+      public Component_324.Creator set_3(Node_246 i) {
+        this.mSet_3 = i;
+        return this;
+      }
+
+      @Override
+      public Component_324 create() {
+        return new Component_324Impl(this.fComponent_323, this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_325Impl implements Component_325 {
+    private Object mNode_171Instance;
+
+    private Object mNode_162Instance;
+
+    private Object mNode_229Instance;
+
+    private Object mNode_121Instance;
+
+    private Object mNode_146Instance;
+
+    private Object mNode_267Instance;
+
+    private Object mNode_36Instance;
+
+    private Object mNode_291Instance;
+
+    private Object mNode_276Instance;
+
+    private Object mNode_261Instance;
+
+    private Object mNode_84Instance;
+
+    final Node_265 mSet_0;
+
+    final Node_246 mSet_1;
+
+    final Node_239 mSet_2;
+
+    final Node_34 mSet_3;
+
+    final Dependency_312 mDependency_312;
+
+    final Yatagan$Component_323 mComponent_323;
+
+    Component_325Impl(Yatagan$Component_323 pComponent_323, Dependency_312 pSetDep_0,
+        Node_265 pSet_0, Node_246 pSet_1, Node_239 pSet_2, Node_34 pSet_3) {
+      this.mComponent_323 = pComponent_323;
+      this.mDependency_312 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+      this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+      this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+      this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+    }
+
+    @Override
+    public Node_37 getGet_0() {
+      return this.accessNode_37();
+    }
+
+    @Override
+    public Lazy<Node_46> getGet_1() {
+      return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19);
+    }
+
+    @Override
+    public Provider<Node_171> getGet_2() {
+      return new ProviderImpl(this, 1);
+    }
+
+    @Override
+    public Node_162 getGet_3() {
+      return this.cacheNode_162();
+    }
+
+    @Override
+    public Node_17 getGet_4() {
+      return this.mComponent_323.cacheNode_17();
+    }
+
+    @Override
+    public void inject_0(Injectee_360 i) {
+      i.setMember_0(this.cacheNode_229());
+      i.setMember_1(this.mSet_0);
+      i.setMember_2(this.mComponent_323.cacheNode_133());
+      i.setMember_3(this.accessNode_173());
+      i.setMember_4(this.mComponent_323.cacheNode_107());
+      i.setMember_5(this.mComponent_323.cacheNode_281());
+      i.setMember_6(this.accessNode_286());
+      i.setMember_7(this.cacheNode_171());
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.accessNode_37();
+        case 1: return this.cacheNode_171();
+        case 2: return this.cacheNode_162();
+        case 3: return this.mSet_0;
+        case 4: return this.accessNode_173();
+        case 5: return this.accessNode_286();
+        case 6: return this.cacheNode_121();
+        case 7: return this.mDependency_312.ep_0();
+        case 8: return new Node_225();
+        case 9: return this.cacheNode_261();
+        case 10: return this.accessNode_182();
+        case 11: return this.mSet_1;
+        case 12: return this.accessNode_255();
+        case 13: return this.cacheNode_84();
+        case 14: return this.accessNode_83();
+        case 15: return this.cacheNode_146();
+        case 16: return this.accessNode_305();
+        case 17: return this.accessNode_71();
+        case 18: return this.cacheNode_267();
+        case 19: return this.cacheNode_36();
+        case 20: return this.cacheNode_291();
+        case 21: return this.accessNode_148();
+        case 22: return this.accessNode_111();
+        case 23: return this.mDependency_312.ep_1();
+        case 24: return this.mSet_2;
+        case 25: return this.accessNode_57();
+        case 26: return this.cacheNode_276();
+        case 27: return this.accessNode_123();
+        case 28: return this.accessNode_127();
+        case 29: return this.mDependency_312.ep_2();
+        case 30: return new Node_135(this.mComponent_323.cacheNode_262(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 15), this.cacheNode_229(), this.mDependency_312.ep_0(), this.mComponent_323.mSet_2, this.mComponent_323.mDependency_310.ep_1(), this.accessNode_83(), this.mComponent_323.cacheNode_30(), this.cacheNode_146(), this.mDependency_312.ep_2(), this.mComponent_323.cacheNode_11(), this.mSet_3, this.mComponent_323.cacheNode_281());
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_37 accessNode_37() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_518(new ProviderImpl(this, 6), this.mDependency_312.ep_0(), this.accessNode_286(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_257(), new ProviderImpl(this, 8), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 3), this.cacheNode_261(), new ProviderImpl(this, 2), new ProviderImpl(this, 4), this.mComponent_323.cacheNode_281(), this.accessNode_138(), new CachingProviderImpl(this, 10), this.mComponent_323.mSet_1, this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_17(), this.mSet_1, new CachingProviderImpl(this, 12)));
+    }
+
+    Node_171 cacheNode_171() {
+      Object local = this.mNode_171Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_519(this.mComponent_323.mSet_3, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.mDependency_310.ep_1(), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_133(), this.mComponent_323.mSet_2, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_257()));
+        this.mNode_171Instance = local;
+      }
+      return (Node_171) local;
+    }
+
+    Node_162 cacheNode_162() {
+      Object local = this.mNode_162Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_520(new Node_225(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_262(), this.cacheNode_121(), this.mComponent_323.mSet_1, new ProviderImpl(this, 13), this.mComponent_323.mDependency_310.ep_2(), new ProviderImpl(this, 1), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), new ProviderImpl(this, 14)));
+        this.mNode_162Instance = local;
+      }
+      return (Node_162) local;
+    }
+
+    Node_229 cacheNode_229() {
+      Object local = this.mNode_229Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_521(this.mComponent_323.cacheNode_30(), this.mComponent_323.mSet_2, new Node_225(), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_46(), this.cacheNode_146(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_323.cacheNode_172()));
+        this.mNode_229Instance = local;
+      }
+      return (Node_229) local;
+    }
+
+    Node_173 accessNode_173() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_522(this.mComponent_323.cacheNode_102()));
+    }
+
+    Node_121 cacheNode_121() {
+      Object local = this.mNode_121Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_523(this.mComponent_323.mDependency_310.ep_2(), this.accessNode_305(), this.accessNode_71(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.cacheNode_267(), this.mComponent_323.cacheNode_254(), this.mComponent_323.cacheNode_102(), new Node_225(), this.mComponent_323.mSet_2, this.accessNode_56(), this.accessNode_37(), new ProviderImpl(this, 13), this.cacheNode_36(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.cacheNode_171(), this.cacheNode_291(), this.accessNode_148(), this.accessNode_138(), this.accessNode_111(), this.mComponent_323.mDependency_310.ep_0(), this.mSet_0, this.mComponent_323.mSet_1));
+        this.mNode_121Instance = local;
+      }
+      return (Node_121) local;
+    }
+
+    Node_138 accessNode_138() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_524(new ProviderImpl(this, 17), this.accessNode_56(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 16), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mDependency_312.ep_0(), this.mComponent_323.cacheNode_281(), this.cacheNode_291(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new ProviderImpl(this, 26), new CachingProviderImpl(this, 27), new CachingProviderImpl(this, 21), new ProviderImpl(this, 2)));
+    }
+
+    Node_255 accessNode_255() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_525(this.mComponent_323.cacheNode_281(), this.cacheNode_36(), this.mComponent_323.mSet_0, new ProviderImpl(this, 6), this.mComponent_323.accessNode_210(), new Node_225(), this.mComponent_323.mDependency_310.ep_1(), this.accessNode_286(), this.mComponent_323.cacheNode_133(), this.accessNode_37(), this.cacheNode_229(), this.accessNode_148(), new CachingProviderImpl(this, 27), new ProviderImpl(this, 2), Checks.checkProvisionNotNull(Module_399.Companion.provides_534(this.mComponent_323.accessNode_15(), this.cacheNode_36(), this.mComponent_323.mDependency_310.ep_1(), this.mSet_1, this.mSet_2, this.mComponent_323.mSet_2)), this.accessNode_173(), this.accessNode_127(), this.mComponent_323.cacheNode_17(), this.accessNode_56(), this.cacheNode_146(), this.mComponent_323.cacheNode_102(), this.accessNode_182(), this.mComponent_323.cacheNode_172()));
+    }
+
+    Node_146 cacheNode_146() {
+      Object local = this.mNode_146Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_526(this.mComponent_323.cacheNode_262(), this.accessNode_127(), new CachingProviderImpl(this, 16)));
+        this.mNode_146Instance = local;
+      }
+      return (Node_146) local;
+    }
+
+    Node_305 accessNode_305() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_527(this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mSet_0, this.accessNode_37(), new ProviderImpl(this, 20), this.mComponent_323.cacheNode_257(), this.cacheNode_229(), this.mComponent_323.mSet_2, this.cacheNode_261(), this.mComponent_323.cacheNode_254(), new ProviderImpl(this, 18), this.accessNode_138(), this.mComponent_323.cacheNode_102(), this.accessNode_57()));
+    }
+
+    Node_267 cacheNode_267() {
+      Object local = this.mNode_267Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_528(new CachingProviderImpl(this, 10), this.accessNode_305(), this.accessNode_138(), this.mComponent_323.mDependency_310.ep_1(), new ProviderImpl(this, 2), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_172(), new ProviderImpl(this, 3), this.mComponent_323.cacheNode_46(), this.accessNode_148(), this.mComponent_323.cacheNode_30()));
+        this.mNode_267Instance = local;
+      }
+      return (Node_267) local;
+    }
+
+    Node_36 cacheNode_36() {
+      Object local = this.mNode_36Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_529(this.accessNode_56(), this.mComponent_323.cacheNode_46(), this.mDependency_312.ep_2(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), new CachingProviderImpl(this, 16), new ProviderImpl(this, 13), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_1(), this.accessNode_123(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_102(), this.mDependency_312.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.accessNode_286(), this.mComponent_323.mSet_1));
+        this.mNode_36Instance = local;
+      }
+      return (Node_36) local;
+    }
+
+    Node_291 cacheNode_291() {
+      Object local = this.mNode_291Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_530(this.mComponent_323.accessNode_210(), this.mComponent_323.mSet_0, this.accessNode_286(), new ProviderImpl(this, 15), this.cacheNode_229()));
+        this.mNode_291Instance = local;
+      }
+      return (Node_291) local;
+    }
+
+    Node_111 accessNode_111() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_531(this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_254(), this.mDependency_312.ep_1(), new ProviderImpl(this, 28), this.mComponent_323.cacheNode_262(), new ProviderImpl(this, 5), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_255(), new ProviderImpl(this, 2), this.mComponent_323.mSet_0, new ProviderImpl(this, 26), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_30(), this.mComponent_323.cacheNode_172()));
+    }
+
+    Node_276 cacheNode_276() {
+      Object local = this.mNode_276Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_399.Companion.provides_532(this.mComponent_323.accessNode_15(), this.cacheNode_291(), this.mComponent_323.cacheNode_11(), new CachingProviderImpl(this, 21), new CachingProviderImpl(this, 10), this.mComponent_323.cacheNode_254(), this.accessNode_37(), this.mComponent_323.cacheNode_133()));
+        this.mNode_276Instance = local;
+      }
+      return (Node_276) local;
+    }
+
+    Node_123 accessNode_123() {
+      return Checks.checkProvisionNotNull(Module_399.Companion.provides_533(new CachingProviderImpl(this, 21), this.accessNode_138(), this.mSet_0, this.mComponent_323.mDependency_310.ep_1(), new ProviderImpl(this, 19), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new ProviderImpl(this, 6), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_17(), this.mDependency_312.ep_0(), this.mComponent_323.cacheNode_254(), new CachingProviderImpl(this, 22), new ProviderImpl(this, 29), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_11(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_133(), this.accessNode_286(), new CachingProviderImpl(this, 12), this.mComponent_323.cacheNode_102(), this.mSet_3));
+    }
+
+    Node_127 accessNode_127() {
+      return new Node_127(new ProviderImpl(this, 6), this.mSet_3, this.mDependency_312.ep_1(), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 10));
+    }
+
+    Node_148 accessNode_148() {
+      return new Node_148(this.mSet_2, this.mComponent_323.mDependency_310.ep_1(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), new ProviderImpl(this, 13), this.accessNode_305(), this.accessNode_71(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), new CachingProviderImpl(this, 12));
+    }
+
+    Node_182 accessNode_182() {
+      return new Node_182(this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_102(), this.mComponent_323.mSet_1, this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.accessNode_15(), this.mDependency_312.ep_1(), this.accessNode_83(), this.mComponent_323.mSet_3, this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 0), this.accessNode_127(), this.mSet_1, this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 2), this.cacheNode_267(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.cacheNode_262(), this.cacheNode_146(), this.mSet_3, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16));
+    }
+
+    Node_261 cacheNode_261() {
+      Object local = this.mNode_261Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_261(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new ProviderImpl(this, 23), this.mSet_0, this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_46(), this.mComponent_323.cacheNode_172(), this.cacheNode_171(), this.mComponent_323.cacheNode_254(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 2), this.mSet_2, this.cacheNode_291(), new ProviderImpl(this, 6), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 25), new CachingProviderImpl(this, 12), this.mComponent_323.mSet_3, new ProviderImpl(this, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_1(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17));
+        this.mNode_261Instance = local;
+      }
+      return (Node_261) local;
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+    }
+
+    Node_56 accessNode_56() {
+      return new Node_56(new CachingProviderImpl(this, 21), this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 25), this.cacheNode_171(), this.mComponent_323.cacheNode_172(), this.cacheNode_261(), new ProviderImpl(this, 6), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_0());
+    }
+
+    Node_57 accessNode_57() {
+      return new Node_57(this.accessNode_286(), new ProviderImpl(this, 2), this.mComponent_323.mDependency_310.ep_1(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.cacheNode_172(), this.cacheNode_36(), new ProviderImpl(this, 26), this.mComponent_323.cacheNode_262(), this.mComponent_323.mSet_0, this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_257(), new ProviderImpl(this, 11), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), new ProviderImpl(this, 30), this.mDependency_312.ep_0(), this.accessNode_71(), new CachingProviderImpl(this, 22));
+    }
+
+    Node_71 accessNode_71() {
+      return new Node_71(this.mComponent_323.mSet_3, new ProviderImpl(this, 15), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_281(), new ProviderImpl(this, 18), this.accessNode_83(), this.mComponent_323.mSet_2, this.mComponent_323.accessNode_15(), this.mSet_2, new ProviderImpl(this, 27), new ProviderImpl(this, 7), new CachingProviderImpl(this, 22), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 10));
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 5));
+    }
+
+    Node_84 cacheNode_84() {
+      Object local = this.mNode_84Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_84(this.mComponent_323.mSet_3, this.mComponent_323.mDependency_310.ep_2(), this.mDependency_312.ep_2(), this.mComponent_323.mSet_2, this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 23), this.accessNode_173(), this.accessNode_305(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_262(), new ProviderImpl(this, 9), this.mSet_1, this.accessNode_148(), this.mComponent_323.cacheNode_102(), this.accessNode_37(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 15), new CachingProviderImpl(this, 24), this.mComponent_323.cacheNode_30());
+        this.mNode_84Instance = local;
+      }
+      return (Node_84) local;
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_325Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_325Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_325Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_325Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_325.Creator {
+      Yatagan$Component_323 fComponent_323;
+
+      private Dependency_312 mSetDep_0;
+
+      private Node_265 mSet_0;
+
+      private Node_246 mSet_1;
+
+      private Node_239 mSet_2;
+
+      private Node_34 mSet_3;
+
+      ComponentFactoryImpl(Yatagan$Component_323 fComponent_323) {
+        this.fComponent_323 = fComponent_323;
+      }
+
+      @Override
+      public Component_325.Creator setDep_0(Dependency_312 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_325.Creator set_0(Node_265 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_325.Creator set_1(Node_246 i) {
+        this.mSet_1 = i;
+        return this;
+      }
+
+      @Override
+      public Component_325.Creator set_2(Node_239 i) {
+        this.mSet_2 = i;
+        return this;
+      }
+
+      @Override
+      public Component_325.Creator set_3(Node_34 i) {
+        this.mSet_3 = i;
+        return this;
+      }
+
+      @Override
+      public Component_325 create() {
+        return new Component_325Impl(this.fComponent_323, this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_326Impl implements Component_326 {
+    private Object mNode_52Instance;
+
+    private Object mNode_144Instance;
+
+    private Object mNode_90Instance;
+
+    private Object mNode_119Instance;
+
+    private Object mNode_168Instance;
+
+    final Node_189 mSet_0;
+
+    final Dependency_313 mDependency_313;
+
+    final Yatagan$Component_323 mComponent_323;
+
+    Component_326Impl(Yatagan$Component_323 pComponent_323, Dependency_313 pSetDep_0,
+        Node_189 pSet_0) {
+      this.mComponent_323 = pComponent_323;
+      this.mDependency_313 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+    }
+
+    @Override
+    public Node_46 getGet_0() {
+      return this.mComponent_323.cacheNode_46();
+    }
+
+    @Override
+    public Node_164 getGet_1() {
+      return this.mComponent_323.mDependency_310.ep_1();
+    }
+
+    @Override
+    public Lazy<Node_176> getGet_2() {
+      return new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8);
+    }
+
+    @Override
+    public Lazy<Node_168> getGet_3() {
+      return new ProviderImpl(this, 0);
+    }
+
+    @Override
+    public Node_271 getGet_4() {
+      return this.mComponent_323.mDependency_310.ep_5();
+    }
+
+    @Override
+    public Node_102 getGet_5() {
+      return this.mComponent_323.cacheNode_102();
+    }
+
+    @Override
+    public Node_97 getGet_6() {
+      return this.accessNode_97();
+    }
+
+    @Override
+    public Node_250 getGet_7() {
+      return this.mDependency_313.ep_1();
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.cacheNode_168();
+        case 1: return this.accessNode_97();
+        case 2: return this.accessNode_295();
+        case 3: return this.cacheNode_52();
+        case 4: return this.accessNode_47();
+        case 5: return new Node_95(new CachingProviderImpl(this, 7), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 15), this.mComponent_323.mDependency_310.ep_5(), new CachingProviderImpl(this, 6), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mSet_3, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new CachingProviderImpl(this, 16), this.mComponent_323.cacheNode_262(), this.cacheNode_52(), this.mComponent_323.mSet_0, this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_2, this.accessNode_97());
+        case 6: return this.accessNode_51();
+        case 7: return this.accessNode_277();
+        case 8: return this.accessNode_242();
+        case 9: return new Node_216(this.mComponent_323.cacheNode_281(), this.cacheNode_52(), new ProviderImpl(this, 4), this.accessNode_51(), this.mComponent_323.accessNode_210(), this.mComponent_323.mSet_1, this.accessNode_277(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.cacheNode_257(), this.accessNode_295());
+        case 10: return this.accessNode_209();
+        case 11: return this.accessNode_286();
+        case 12: return this.accessNode_83();
+        case 13: return this.accessNode_175();
+        case 14: return this.cacheNode_144();
+        case 15: return this.mDependency_313.ep_2();
+        case 16: return this.accessNode_149();
+        case 17: return this.cacheNode_119();
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_97 accessNode_97() {
+      return Checks.checkProvisionNotNull(Module_400.Companion.provides_539(this.cacheNode_52(), this.accessNode_242(), this.mComponent_323.cacheNode_17(), this.mDependency_313.ep_1()));
+    }
+
+    Node_52 cacheNode_52() {
+      Object local = this.mNode_52Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_400.Companion.provides_540(new ProviderImpl(this, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new ProviderImpl(this, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.accessNode_15(), new ProviderImpl(this, 10), this.mComponent_323.mSet_1, new CachingProviderImpl(this, 1), new CachingProviderImpl(this, 4), this.accessNode_286(), this.mComponent_323.accessNode_210(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), this.mComponent_323.cacheNode_133(), this.mDependency_313.ep_0()));
+        this.mNode_52Instance = local;
+      }
+      return (Node_52) local;
+    }
+
+    Node_277 accessNode_277() {
+      return Checks.checkProvisionNotNull(Module_400.Companion.provides_541(this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_11(), this.cacheNode_90(), this.accessNode_295(), this.accessNode_286(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.mSet_2, new CachingProviderImpl(this, 1), this.mComponent_323.mDependency_310.ep_5(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.cacheNode_133(), this.accessNode_209(), this.mComponent_323.mDependency_310.ep_4(), this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11)));
+    }
+
+    Node_175 accessNode_175() {
+      return Checks.checkProvisionNotNull(Module_400.Companion.provides_542(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mDependency_310.ep_5(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_172(), this.mDependency_313.ep_0(), this.mComponent_323.cacheNode_17(), this.mComponent_323.mSet_2, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_262(), this.accessNode_209(), this.mComponent_323.mDependency_310.ep_4(), this.cacheNode_144(), this.cacheNode_119(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.cacheNode_254(), this.mDependency_313.ep_2(), this.accessNode_51(), this.mComponent_323.cacheNode_281(), this.accessNode_83(), this.mComponent_323.cacheNode_107(), this.cacheNode_168(), new CachingProviderImpl(this, 2)));
+    }
+
+    Node_144 cacheNode_144() {
+      Object local = this.mNode_144Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_400.Companion.provides_543());
+        this.mNode_144Instance = local;
+      }
+      return (Node_144) local;
+    }
+
+    Node_90 cacheNode_90() {
+      Object local = this.mNode_90Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_400.Companion.provides_544(new CachingProviderImpl(this, 12), new ProviderImpl(this, 3), new ProviderImpl(this, 0)));
+        this.mNode_90Instance = local;
+      }
+      return (Node_90) local;
+    }
+
+    Node_119 cacheNode_119() {
+      Object local = this.mNode_119Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_119(this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_133(), this.accessNode_83(), this.mDependency_313.ep_1(), this.mComponent_323.cacheNode_17(), new CachingProviderImpl(this, 6));
+        this.mNode_119Instance = local;
+      }
+      return (Node_119) local;
+    }
+
+    Node_149 accessNode_149() {
+      return new Node_149(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_323.cacheNode_107(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_257(), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 4), this.mComponent_323.cacheNode_262(), this.cacheNode_90(), this.mComponent_323.cacheNode_11(), new CachingProviderImpl(this, 1), this.accessNode_51(), this.mComponent_323.cacheNode_254(), this.accessNode_295(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), this.cacheNode_168());
+    }
+
+    Node_168 cacheNode_168() {
+      Object local = this.mNode_168Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_168(this.mComponent_323.cacheNode_30(), this.accessNode_295(), this.mComponent_323.mDependency_310.ep_4(), this.cacheNode_52(), new ProviderImpl(this, 1), new CachingProviderImpl(this, 4), this.mComponent_323.mSet_0, new CachingProviderImpl(this, 5), this.mComponent_323.mSet_2, this.mComponent_323.accessNode_210(), this.mComponent_323.mSet_1, this.accessNode_51(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_46(), this.mComponent_323.cacheNode_133(), this.accessNode_51(), new CachingProviderImpl(this, 7), this.mDependency_313.ep_1());
+        this.mNode_168Instance = local;
+      }
+      return (Node_168) local;
+    }
+
+    Node_209 accessNode_209() {
+      return new Node_209(this.accessNode_149(), this.cacheNode_168(), this.mDependency_313.ep_1(), this.mComponent_323.mDependency_310.ep_5(), this.accessNode_83(), new ProviderImpl(this, 14), this.mDependency_313.ep_0(), this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 13), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_11(), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_149(), new ProviderImpl(this, 15), new ProviderImpl(this, 17), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_281());
+    }
+
+    Node_242 accessNode_242() {
+      return new Node_242(this.mComponent_323.mDependency_310.ep_5(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 3), this.mComponent_323.mSet_0, this.mDependency_313.ep_0(), new CachingProviderImpl(this, 6), this.cacheNode_144(), this.mComponent_323.mSet_2, this.accessNode_51(), this.mComponent_323.cacheNode_30(), this.mComponent_323.mSet_3, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mDependency_313.ep_2(), this.accessNode_175(), this.accessNode_47(), this.mComponent_323.cacheNode_11());
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+    }
+
+    Node_295 accessNode_295() {
+      return new Node_295(this.mDependency_313.ep_1(), this.mComponent_323.mDependency_310.ep_5());
+    }
+
+    Node_47 accessNode_47() {
+      return new Node_47(this.accessNode_83(), this.cacheNode_52(), this.mComponent_323.cacheNode_17(), this.accessNode_175(), this.accessNode_51(), this.cacheNode_144(), this.mComponent_323.cacheNode_46(), this.mSet_0, this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_262(), new CachingProviderImpl(this, 8), this.accessNode_295(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.cacheNode_90(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_323.cacheNode_257(), new CachingProviderImpl(this, 10), this.mComponent_323.cacheNode_11(), this.mComponent_323.accessNode_210(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+    }
+
+    Node_51 accessNode_51() {
+      return new Node_51(new CachingProviderImpl(this, 5), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_17(), this.mComponent_323.cacheNode_133(), this.cacheNode_119(), new CachingProviderImpl(this, 16), this.cacheNode_90(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), new CachingProviderImpl(this, 10), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_2, new ProviderImpl(this, 14), new ProviderImpl(this, 16), this.mComponent_323.cacheNode_281(), this.mComponent_323.accessNode_15());
+    }
+
+    Node_83 accessNode_83() {
+      return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 11));
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_326Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_326Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_326Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_326Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_326.Creator {
+      Yatagan$Component_323 fComponent_323;
+
+      private Dependency_313 mSetDep_0;
+
+      private Node_189 mSet_0;
+
+      ComponentFactoryImpl(Yatagan$Component_323 fComponent_323) {
+        this.fComponent_323 = fComponent_323;
+      }
+
+      @Override
+      public Component_326.Creator setDep_0(Dependency_313 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_326.Creator set_0(Node_189 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_326 create() {
+        return new Component_326Impl(this.fComponent_323, this.mSetDep_0, this.mSet_0);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class Component_327Impl implements Component_327 {
+    private Object mNode_16Instance;
+
+    private Object mNode_293Instance;
+
+    private Object mNode_260Instance;
+
+    private Object mNode_184Instance;
+
+    private Object mNode_241Instance;
+
+    private Object mNode_108Instance;
+
+    private Object mNode_177Instance;
+
+    private Object mNode_33Instance;
+
+    final Node_69 mSet_0;
+
+    final Node_92 mSet_1;
+
+    final Dependency_311 mDependency_311;
+
+    final Yatagan$Component_323 mComponent_323;
+
+    Component_327Impl(Yatagan$Component_323 pComponent_323, Dependency_311 pSetDep_0,
+        Node_69 pSet_0, Node_92 pSet_1) {
+      this.mComponent_323 = pComponent_323;
+      this.mDependency_311 = Checks.checkInputNotNull(pSetDep_0);
+      this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+      this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+    }
+
+    @Override
+    public Component_328.Creator getChildCreator_0() {
+      return new Component_328Impl.ComponentFactoryImpl(this, this.mComponent_323);
+    }
+
+    @Override
+    public Component_329.Creator getChildCreator_1() {
+      return new Component_329Impl.ComponentFactoryImpl(this.mComponent_323, this);
+    }
+
+    @Override
+    public Component_330.Creator getChildCreator_2() {
+      return new Component_330Impl.ComponentFactoryImpl(this, this.mComponent_323);
+    }
+
+    @Override
+    public Component_331.Creator getChildCreator_3() {
+      return new Component_331Impl.ComponentFactoryImpl(this.mComponent_323, this);
+    }
+
+    @Override
+    public Node_130 getGet_0() {
+      return this.mComponent_323.mSet_2;
+    }
+
+    @Override
+    public Node_27 getGet_1() {
+      return this.mComponent_323.mDependency_310.ep_0();
+    }
+
+    @Override
+    public Node_185 getGet_10() {
+      return this.accessNode_185();
+    }
+
+    @Override
+    public Node_106 getGet_11() {
+      return this.mComponent_323.accessNode_15();
+    }
+
+    @Override
+    public Node_122 getGet_2() {
+      return this.mComponent_323.mSet_2;
+    }
+
+    @Override
+    public Node_16 getGet_3() {
+      return this.cacheNode_16();
+    }
+
+    @Override
+    public Lazy<Node_210> getGet_4() {
+      return new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 2);
+    }
+
+    @Override
+    public Lazy<Node_30> getGet_5() {
+      return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13);
+    }
+
+    @Override
+    public Node_266 getGet_6() {
+      return Checks.checkProvisionNotNull(Module_401.Companion.provides_547());
+    }
+
+    @Override
+    public Node_102 getGet_7() {
+      return this.mComponent_323.cacheNode_102();
+    }
+
+    @Override
+    public Node_125 getGet_8() {
+      return this.accessNode_125();
+    }
+
+    @Override
+    public Provider<Node_15> getGet_9() {
+      return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10);
+    }
+
+    @Override
+    public void inject_0(Injectee_361 i) {
+      i.setMember_0(this.mComponent_323.cacheNode_133());
+      i.setMember_1(this.mComponent_323.mSet_2);
+      i.setMember_2(this.mSet_0);
+      i.setMember_3(this.accessNode_142());
+      i.setMember_4(this.mSet_1);
+      i.setMember_5(this.mComponent_323.accessNode_210());
+      i.setMember_6(this.mComponent_323.mDependency_310.ep_1());
+      i.setMember_7(this.mComponent_323.accessNode_210());
+      i.setMember_8(this.mComponent_323.cacheNode_281());
+    }
+
+    @Override
+    public void inject_1(Injectee_362 i) {
+      i.setMember_0(this.accessNode_142());
+      i.setMember_1(this.accessNode_185());
+      i.setMember_10(this.accessNode_280());
+      i.setMember_2(this.mComponent_323.cacheNode_257());
+      i.setMember_3(this.mComponent_323.mDependency_310.ep_2());
+      i.setMember_4(this.cacheNode_293());
+      i.setMember_5(this.mComponent_323.cacheNode_30());
+      i.setMember_6(this.mComponent_323.cacheNode_46());
+      i.setMember_7(this.mComponent_323.cacheNode_30());
+      i.setMember_8(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()));
+      i.setMember_9(this.mComponent_323.accessNode_210());
+    }
+
+    @Override
+    public void inject_2(Injectee_363 i) {
+      i.setMember_0(this.mDependency_311.ep_0());
+      i.setMember_1(this.cacheNode_108());
+      i.setMember_2(this.cacheNode_260());
+      i.setMember_3(this.cacheNode_177());
+      i.setMember_4(this.mComponent_323.cacheNode_46());
+      i.setMember_5(this.mSet_0);
+      i.setMember_6(this.mComponent_323.mSet_2);
+      i.setMember_7(this.mComponent_323.cacheNode_281());
+      i.setMember_8(this.mComponent_323.mSet_3);
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return this.cacheNode_108();
+        case 1: return this.cacheNode_33();
+        case 2: return this.cacheNode_241();
+        case 3: return Checks.checkProvisionNotNull(Module_401.Companion.provides_554());
+        case 4: return this.cacheNode_293();
+        case 5: return this.mDependency_311.ep_0();
+        case 6: return Checks.checkProvisionNotNull(Module_401.Companion.provides_547());
+        case 7: return this.cacheNode_260();
+        case 8: return Checks.checkProvisionNotNull(Module_401.Companion.provides_550());
+        case 9: return this.mSet_0;
+        case 10: return this.accessNode_185();
+        case 11: return this.cacheNode_177();
+        case 12: return this.accessNode_280();
+        case 13: return this.cacheNode_184();
+        case 14: return this.cacheNode_16();
+        case 15: return this.mSet_1;
+        case 16: return this.mDependency_311.ep_2();
+        case 17: return this.mDependency_311.ep_3();
+        case 18: return this.accessNode_142();
+        case 19: return this.accessNode_286();
+        default: throw new AssertionError();
+      }
+    }
+
+    Node_16 cacheNode_16() {
+      Object local = this.mNode_16Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_401.Companion.provides_546(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.mSet_1, this.accessNode_142(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_262(), this.accessNode_125(), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new ProviderImpl(this, 11), this.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), this.cacheNode_184(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.mComponent_323.mSet_2, this.cacheNode_241(), new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 19)), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_323.cacheNode_133(), this.mDependency_311.ep_0(), new ProviderImpl(this, 10)));
+        this.mNode_16Instance = local;
+      }
+      return (Node_16) local;
+    }
+
+    Node_185 accessNode_185() {
+      return Checks.checkProvisionNotNull(Module_401.Companion.provides_548(this.mComponent_323.cacheNode_102(), this.accessNode_280(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 14), this.mDependency_311.ep_0(), this.cacheNode_293(), this.mComponent_323.mDependency_310.ep_2()));
+    }
+
+    Node_293 cacheNode_293() {
+      Object local = this.mNode_293Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_401.Companion.provides_549(this.mComponent_323.cacheNode_46(), this.cacheNode_184(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_257()));
+        this.mNode_293Instance = local;
+      }
+      return (Node_293) local;
+    }
+
+    Node_260 cacheNode_260() {
+      Object local = this.mNode_260Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_401.Companion.provides_551(this.mComponent_323.mDependency_310.ep_1(), this.mDependency_311.ep_0(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_323.mSet_2, this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, this.cacheNode_16(), new ProviderImpl(this, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_11(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_281()));
+        this.mNode_260Instance = local;
+      }
+      return (Node_260) local;
+    }
+
+    Node_184 cacheNode_184() {
+      Object local = this.mNode_184Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_401.Companion.provides_552(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_254(), new ProviderImpl(this, 7), new ProviderImpl(this, 12), this.mComponent_323.cacheNode_107(), this.mSet_0, this.mComponent_323.accessNode_15(), new CachingProviderImpl(this, 15), this.accessNode_286(), new ProviderImpl(this, 2), new ProviderImpl(this, 3)));
+        this.mNode_184Instance = local;
+      }
+      return (Node_184) local;
+    }
+
+    Node_241 cacheNode_241() {
+      Object local = this.mNode_241Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = Checks.checkProvisionNotNull(Module_401.Companion.provides_553(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new ProviderImpl(this, 14), new ProviderImpl(this, 7), this.mComponent_323.mSet_1, this.accessNode_132(), this.accessNode_125()));
+        this.mNode_241Instance = local;
+      }
+      return (Node_241) local;
+    }
+
+    Node_108 cacheNode_108() {
+      Object local = this.mNode_108Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_108(new CachingProviderImpl(this, 18), this.mSet_1, new ProviderImpl(this, 11), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 13), this.mComponent_323.mSet_2, this.cacheNode_293(), this.mComponent_323.mSet_3, this.mComponent_323.mDependency_310.ep_2(), new ProviderImpl(this, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10));
+        this.mNode_108Instance = local;
+      }
+      return (Node_108) local;
+    }
+
+    Node_125 accessNode_125() {
+      return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mSet_0, this.mComponent_323.cacheNode_257(), this.cacheNode_108(), this.mComponent_323.mSet_1, new ProviderImpl(this, 4), new ProviderImpl(this, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+    }
+
+    Node_132 accessNode_132() {
+      return new Node_132(this.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mDependency_311.ep_0());
+    }
+
+    Node_142 accessNode_142() {
+      return new Node_142(new ProviderImpl(this, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.cacheNode_184(), new CachingProviderImpl(this, 19), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new ProviderImpl(this, 2), this.mComponent_323.mSet_1, this.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+    }
+
+    Node_177 cacheNode_177() {
+      Object local = this.mNode_177Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_177(this.cacheNode_241(), new CachingProviderImpl(this, 19), this.mComponent_323.cacheNode_281(), this.accessNode_132(), new ProviderImpl(this, 3), this.mComponent_323.cacheNode_107(), this.mComponent_323.mSet_1, new ProviderImpl(this, 9), this.mComponent_323.accessNode_15(), this.cacheNode_260(), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_133());
+        this.mNode_177Instance = local;
+      }
+      return (Node_177) local;
+    }
+
+    Node_280 accessNode_280() {
+      return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.cacheNode_184(), this.mComponent_323.mSet_1, new ProviderImpl(this, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+    }
+
+    Node_286 accessNode_286() {
+      return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+    }
+
+    Node_33 cacheNode_33() {
+      Object local = this.mNode_33Instance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Node_33(this.cacheNode_177(), new ProviderImpl(this, 4), this.accessNode_280(), this.mComponent_323.cacheNode_172(), this.cacheNode_108(), this.mComponent_323.mSet_3, this.accessNode_132(), new CachingProviderImpl(this, 9), this.mComponent_323.cacheNode_254(), this.cacheNode_184(), this.mComponent_323.cacheNode_11(), this.mComponent_323.mSet_2, this.cacheNode_241(), this.accessNode_185());
+        this.mNode_33Instance = local;
+      }
+      return (Node_33) local;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class Component_328Impl implements Component_328 {
+      private Object mNode_259Instance;
+
+      private Object mNode_23Instance;
+
+      private Object mNode_139Instance;
+
+      private Object mNode_256Instance;
+
+      private Object mNode_20Instance;
+
+      private Object mNode_74Instance;
+
+      private Object mNode_116Instance;
+
+      private Object mNode_247Instance;
+
+      private Object mNode_131Instance;
+
+      private Object mNode_156Instance;
+
+      private Object mNode_181Instance;
+
+      private Object mNode_206Instance;
+
+      private Object mNode_29Instance;
+
+      private Object mNode_63Instance;
+
+      private Object mNode_88Instance;
+
+      final Node_200 mSet_0;
+
+      final Node_299 mSet_1;
+
+      final Node_273 mSet_2;
+
+      final Node_207 mSet_3;
+
+      final Dependency_315 mDependency_315;
+
+      final Component_327Impl mComponent_327;
+
+      final Yatagan$Component_323 mComponent_323;
+
+      Component_328Impl(Component_327Impl pComponent_327, Yatagan$Component_323 pComponent_323,
+          Dependency_315 pSetDep_0, Node_200 pSet_0, Node_299 pSet_1, Node_273 pSet_2,
+          Node_207 pSet_3) {
+        this.mComponent_327 = pComponent_327;
+        this.mComponent_323 = pComponent_323;
+        this.mDependency_315 = Checks.checkInputNotNull(pSetDep_0);
+        this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+        this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+        this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+      }
+
+      @Override
+      public Component_332.Creator getChildCreator_0() {
+        return new Component_332Impl.ComponentFactoryImpl(this.mComponent_327, this.mComponent_323, this);
+      }
+
+      @Override
+      public Node_259 getGet_0() {
+        return this.cacheNode_259();
+      }
+
+      @Override
+      public Node_23 getGet_1() {
+        return this.cacheNode_23();
+      }
+
+      @Override
+      public Node_33 getGet_2() {
+        return this.mComponent_327.cacheNode_33();
+      }
+
+      @Override
+      public Node_139 getGet_3() {
+        return this.cacheNode_139();
+      }
+
+      Object switch$$access(int slot) {
+        switch(slot) {
+          case 0: return this.cacheNode_116();
+          case 1: return this.mSet_1;
+          case 2: return this.cacheNode_206();
+          case 3: return this.accessNode_170();
+          case 4: return this.cacheNode_88();
+          case 5: return this.mSet_2;
+          case 6: return this.mDependency_315.ep_0();
+          case 7: return this.accessNode_73();
+          case 8: return this.cacheNode_20();
+          case 9: return this.cacheNode_29();
+          case 10: return this.cacheNode_247();
+          case 11: return this.cacheNode_23();
+          case 12: return this.cacheNode_139();
+          case 13: return this.accessNode_274();
+          case 14: return this.cacheNode_156();
+          case 15: return this.mSet_0;
+          case 16: return this.accessNode_211();
+          case 17: return this.cacheNode_131();
+          case 18: return this.accessNode_112();
+          case 19: return this.mSet_3;
+          case 20: return this.accessNode_83();
+          case 21: return this.accessNode_125();
+          case 22: return this.accessNode_286();
+          case 23: return this.accessNode_174();
+          case 24: return this.cacheNode_256();
+          case 25: return this.accessNode_280();
+          case 26: return this.accessNode_158();
+          case 27: return this.accessNode_245();
+          case 28: return this.accessNode_82();
+          case 29: return this.cacheNode_74();
+          case 30: return this.accessNode_197();
+          default: throw new AssertionError();
+        }
+      }
+
+      Node_259 cacheNode_259() {
+        Object local = this.mNode_259Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_562(this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.accessNode_83(), this.mSet_0, this.accessNode_132(), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 28)));
+          this.mNode_259Instance = local;
+        }
+        return (Node_259) local;
+      }
+
+      Node_23 cacheNode_23() {
+        Object local = this.mNode_23Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_563(this.mComponent_327.mSet_0, this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 1), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), this.accessNode_82()));
+          this.mNode_23Instance = local;
+        }
+        return (Node_23) local;
+      }
+
+      Node_139 cacheNode_139() {
+        Object local = this.mNode_139Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_564(this.cacheNode_256(), this.accessNode_289(), new CachingProviderImpl(this, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.cacheNode_20(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 26), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.mComponent_323.mSet_1, this.mComponent_327.accessNode_185(), this.cacheNode_74(), this.mComponent_327.cacheNode_33(), this.mComponent_323.mSet_2, this.accessNode_142(), this.mComponent_323.cacheNode_17()));
+          this.mNode_139Instance = local;
+        }
+        return (Node_139) local;
+      }
+
+      Node_256 cacheNode_256() {
+        Object local = this.mNode_256Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_565(new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.accessNode_280(), this.accessNode_197(), this.mComponent_323.cacheNode_254()));
+          this.mNode_256Instance = local;
+        }
+        return (Node_256) local;
+      }
+
+      Node_211 accessNode_211() {
+        return Checks.checkProvisionNotNull(Module_402.Companion.provides_566(this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.mSet_0, this.mComponent_323.mSet_1, this.accessNode_286(), this.mComponent_323.cacheNode_17(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_0, this.mSet_2, this.mSet_1));
+      }
+
+      Node_20 cacheNode_20() {
+        Object local = this.mNode_20Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_567(this.cacheNode_29(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_281(), this.cacheNode_29(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_177(), new ProviderImpl(this, 25), this.accessNode_83(), this.mComponent_323.cacheNode_107(), this.accessNode_286(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_327.mDependency_311.ep_1(), new ProviderImpl(this, 4), this.accessNode_112(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.cacheNode_102()));
+          this.mNode_20Instance = local;
+        }
+        return (Node_20) local;
+      }
+
+      Node_74 cacheNode_74() {
+        Object local = this.mNode_74Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_568(this.mComponent_323.mSet_3, new ProviderImpl(this, 30), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_327.cacheNode_241(), this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_254(), this.accessNode_174(), this.cacheNode_20(), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_262(), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 13), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1, new ProviderImpl(this, 15)));
+          this.mNode_74Instance = local;
+        }
+        return (Node_74) local;
+      }
+
+      Node_116 cacheNode_116() {
+        Object local = this.mNode_116Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_569(this.mComponent_327.cacheNode_16(), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, new Component_327Impl.CachingProviderImpl(this.mComponent_327, 8), this.mComponent_323.cacheNode_133(), this.cacheNode_23(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_108(), this.cacheNode_88(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_46(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.accessNode_174(), this.accessNode_286(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mDependency_315.ep_0(), this.cacheNode_256(), this.mComponent_327.mSet_0, new ProviderImpl(this, 12)));
+          this.mNode_116Instance = local;
+        }
+        return (Node_116) local;
+      }
+
+      Node_112 accessNode_112() {
+        return Checks.checkProvisionNotNull(Module_402.Companion.provides_570(this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 17), this.accessNode_211(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_108(), this.cacheNode_116(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_3()));
+      }
+
+      Node_73 accessNode_73() {
+        return Checks.checkProvisionNotNull(Module_402.Companion.provides_571(this.mComponent_323.cacheNode_46(), this.mComponent_327.mSet_1, new ProviderImpl(this, 8)));
+      }
+
+      Node_247 cacheNode_247() {
+        Object local = this.mNode_247Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_402.Companion.provides_572(this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_323.accessNode_15(), this.mSet_0, this.mComponent_323.cacheNode_17(), this.mComponent_323.cacheNode_254(), this.mComponent_323.cacheNode_257(), this.accessNode_289(), new CachingProviderImpl(this, 25), this.mComponent_327.cacheNode_184(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mSet_0, new ProviderImpl(this, 8), this.mComponent_327.cacheNode_260(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Node_64(this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 11), this.mComponent_323.cacheNode_254(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.accessNode_125(), new ProviderImpl(this, 10), new CachingProviderImpl(this, 27), this.mDependency_315.ep_0(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 14), this.mComponent_323.cacheNode_11(), this.mComponent_327.accessNode_185()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.cacheNode_63(), this.cacheNode_206(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, new CachingProviderImpl(this, 19), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_172(), this.mComponent_327.mDependency_311.ep_0()));
+          this.mNode_247Instance = local;
+        }
+        return (Node_247) local;
+      }
+
+      Node_32 accessNode_32() {
+        return Checks.checkProvisionNotNull(Module_402.Companion.provides_573(this.accessNode_286(), new ProviderImpl(this, 24), this.mComponent_323.accessNode_210(), this.accessNode_170(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 13), this.mComponent_323.mDependency_310.ep_1()));
+      }
+
+      Node_170 accessNode_170() {
+        return Checks.checkProvisionNotNull(Module_402.Companion.provides_574(this.accessNode_132(), this.accessNode_211(), this.mComponent_323.cacheNode_107(), this.mDependency_315.ep_0(), this.mComponent_327.mSet_0, new CachingProviderImpl(this, 25), this.mSet_3, new ProviderImpl(this, 14), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new ProviderImpl(this, 11), this.cacheNode_29(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.accessNode_158(), new ProviderImpl(this, 20), this.mComponent_327.mSet_1, this.mComponent_323.cacheNode_46(), this.cacheNode_63(), this.accessNode_142()));
+      }
+
+      Node_125 accessNode_125() {
+        return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+      }
+
+      Node_131 cacheNode_131() {
+        Object local = this.mNode_131Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_131(this.accessNode_245(), this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.cacheNode_256(), this.accessNode_170(), this.mComponent_323.cacheNode_102(), this.mComponent_323.cacheNode_46(), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.cacheNode_177(), this.accessNode_280(), new CachingProviderImpl(this, 26), new CachingProviderImpl(this, 7), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_172(), this.mComponent_327.cacheNode_16(), this.mComponent_323.accessNode_15(), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_289(), this.mSet_0, this.mComponent_327.cacheNode_33(), this.mComponent_323.mDependency_310.ep_2(), this.cacheNode_29(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), this.mComponent_327.cacheNode_241(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_262());
+          this.mNode_131Instance = local;
+        }
+        return (Node_131) local;
+      }
+
+      Node_132 accessNode_132() {
+        return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+      }
+
+      Node_142 accessNode_142() {
+        return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 22), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+      }
+
+      Node_156 cacheNode_156() {
+        Object local = this.mNode_156Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_156(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_3(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_327.cacheNode_177(), this.mComponent_327.cacheNode_33(), new CachingProviderImpl(this, 18), this.mComponent_323.accessNode_210(), this.mComponent_327.accessNode_185(), this.mSet_2, this.accessNode_289(), new CachingProviderImpl(this, 15), new ProviderImpl(this, 24), this.accessNode_223(), this.mComponent_323.mSet_3, new ProviderImpl(this, 29), this.accessNode_174(), this.accessNode_32(), this.mSet_1, this.mComponent_323.mDependency_310.ep_1(), this.accessNode_132(), this.mComponent_323.cacheNode_17());
+          this.mNode_156Instance = local;
+        }
+        return (Node_156) local;
+      }
+
+      Node_158 accessNode_158() {
+        return new Node_158(this.mComponent_327.cacheNode_293());
+      }
+
+      Node_174 accessNode_174() {
+        return new Node_174(new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new ProviderImpl(this, 12), new ProviderImpl(this, 11), this.mComponent_327.cacheNode_241(), this.mComponent_323.mDependency_310.ep_2(), new CachingProviderImpl(this, 30), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_88(), this.mSet_3, new ProviderImpl(this, 15), new CachingProviderImpl(this, 27), this.cacheNode_247(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_260(), this.accessNode_32(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()));
+      }
+
+      Node_181 cacheNode_181() {
+        Object local = this.mNode_181Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_181(this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), this.mComponent_327.accessNode_185(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mSet_2, this.mComponent_323.mSet_3, this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()));
+          this.mNode_181Instance = local;
+        }
+        return (Node_181) local;
+      }
+
+      Node_197 accessNode_197() {
+        return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new ProviderImpl(this, 0), this.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_23(), this.mComponent_323.mSet_2, new ProviderImpl(this, 5), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+      }
+
+      Node_206 cacheNode_206() {
+        Object local = this.mNode_206Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_206(this.mComponent_327.mSet_0, new CachingProviderImpl(this, 7), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mSet_2, this.cacheNode_259(), this.mComponent_327.mDependency_311.ep_0(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.cacheNode_281(), this.accessNode_286(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.accessNode_280(), this.cacheNode_29(), this.cacheNode_63(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.cacheNode_181(), this.mComponent_327.cacheNode_108(), new CachingProviderImpl(this, 23), this.mComponent_327.cacheNode_16());
+          this.mNode_206Instance = local;
+        }
+        return (Node_206) local;
+      }
+
+      Node_223 accessNode_223() {
+        return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 11), this.mComponent_323.mDependency_310.ep_1(), new ProviderImpl(this, 12), this.mComponent_323.mDependency_310.ep_3(), new ProviderImpl(this, 9), new ProviderImpl(this, 4), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.cacheNode_206(), new CachingProviderImpl(this, 13), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new ProviderImpl(this, 8), this.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+      }
+
+      Node_245 accessNode_245() {
+        return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.cacheNode_156(), new ProviderImpl(this, 0), this.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new ProviderImpl(this, 2), this.mSet_0, this.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 20));
+      }
+
+      Node_274 accessNode_274() {
+        return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 27), this.cacheNode_88(), this.mSet_2, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+      }
+
+      Node_280 accessNode_280() {
+        return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+      }
+
+      Node_286 accessNode_286() {
+        return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+      }
+
+      Node_289 accessNode_289() {
+        return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+      }
+
+      Node_29 cacheNode_29() {
+        Object local = this.mNode_29Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_29(this.mComponent_327.mDependency_311.ep_1(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.accessNode_142(), new CachingProviderImpl(this, 7), new ProviderImpl(this, 24), this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 15), new CachingProviderImpl(this, 25), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), this.cacheNode_63(), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_241());
+          this.mNode_29Instance = local;
+        }
+        return (Node_29) local;
+      }
+
+      Node_63 cacheNode_63() {
+        Object local = this.mNode_63Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_63(this.accessNode_83(), this.accessNode_125(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_30(), this.mComponent_323.accessNode_15(), this.accessNode_286(), this.mSet_1, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_327.cacheNode_177(), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mSet_1, this.mComponent_327.cacheNode_241());
+          this.mNode_63Instance = local;
+        }
+        return (Node_63) local;
+      }
+
+      Node_82 accessNode_82() {
+        return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new ProviderImpl(this, 0), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 21), this.accessNode_245());
+      }
+
+      Node_83 accessNode_83() {
+        return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 22));
+      }
+
+      Node_88 cacheNode_88() {
+        Object local = this.mNode_88Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_88(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), new ProviderImpl(this, 24), this.mComponent_323.mSet_3, this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_107(), this.accessNode_223(), new CachingProviderImpl(this, 27), this.mComponent_327.mSet_0, this.mComponent_323.mSet_2, this.cacheNode_29(), new Component_327Impl.ProviderImpl(this.mComponent_327, 6), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.accessNode_210(), new Component_327Impl.ProviderImpl(this.mComponent_327, 5), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_83(), this.cacheNode_29());
+          this.mNode_88Instance = local;
+        }
+        return (Node_88) local;
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_332Impl implements Component_332 {
+        private Object mNode_39Instance;
+
+        private Object mNode_240Instance;
+
+        private Object mNode_86Instance;
+
+        private Object mNode_104Instance;
+
+        private Object mNode_136Instance;
+
+        private Object mNode_208Instance;
+
+        private Object mNode_275Instance;
+
+        final Dependency_316 mDependency_316;
+
+        final Component_327Impl mComponent_327;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_328Impl mComponent_328;
+
+        Component_332Impl(Component_327Impl pComponent_327, Yatagan$Component_323 pComponent_323,
+            Component_328Impl pComponent_328, Dependency_316 pSetDep_0) {
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_328 = pComponent_328;
+          this.mDependency_316 = Checks.checkInputNotNull(pSetDep_0);
+        }
+
+        @Override
+        public Lazy<Node_108> getGet_0() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 0);
+        }
+
+        @Override
+        public Node_254 getGet_1() {
+          return this.mComponent_323.cacheNode_254();
+        }
+
+        @Override
+        public Node_188 getGet_2() {
+          return this.accessNode_188();
+        }
+
+        @Override
+        public Node_158 getGet_3() {
+          return this.accessNode_158();
+        }
+
+        @Override
+        public Lazy<Node_221> getGet_4() {
+          return new CachingProviderImpl(this, 1);
+        }
+
+        @Override
+        public Provider<Node_33> getGet_5() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 1);
+        }
+
+        @Override
+        public void inject_0(Injectee_367 i) {
+          i.setMember_0(this.mComponent_328.cacheNode_63());
+          i.setMember_1(this.mComponent_323.mDependency_310.ep_1());
+          i.setMember_2(this.accessNode_274());
+        }
+
+        @Override
+        public void inject_1(Injectee_368 i) {
+          i.setMember_0(this.mComponent_328.cacheNode_116());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.accessNode_188();
+            case 1: return this.accessNode_221();
+            case 2: return this.accessNode_274();
+            case 3: return this.cacheNode_39();
+            case 4: return this.accessNode_289();
+            case 5: return this.accessNode_197();
+            case 6: return this.accessNode_280();
+            case 7: return this.accessNode_125();
+            case 8: return this.accessNode_245();
+            case 9: return this.accessNode_82();
+            case 10: return this.accessNode_19();
+            case 11: return this.accessNode_286();
+            case 12: return this.accessNode_83();
+            case 13: return this.cacheNode_240();
+            case 14: return this.cacheNode_136();
+            case 15: return this.cacheNode_86();
+            case 16: return this.accessNode_167();
+            case 17: return this.cacheNode_104();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_221 accessNode_221() {
+          return Checks.checkProvisionNotNull(Module_406.Companion.provides_632(this.accessNode_197(), this.mComponent_323.mDependency_310.ep_0(), new CachingProviderImpl(this, 0), this.mComponent_328.cacheNode_116()));
+        }
+
+        Node_39 cacheNode_39() {
+          Object local = this.mNode_39Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_406.Companion.provides_633(this.accessNode_82(), this.accessNode_62(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, this.accessNode_19(), this.mComponent_323.accessNode_15(), this.cacheNode_208(), this.mComponent_327.cacheNode_260(), this.mComponent_328.accessNode_73(), this.mComponent_328.accessNode_170(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 11), this.accessNode_245(), this.mComponent_328.cacheNode_20(), new Component_328Impl.CachingProviderImpl(this.mComponent_328, 6), this.mComponent_323.accessNode_15(), this.mComponent_328.cacheNode_29(), this.mComponent_327.mSet_0, this.accessNode_125(), this.mComponent_328.cacheNode_247(), this.mComponent_327.cacheNode_108()));
+            this.mNode_39Instance = local;
+          }
+          return (Node_39) local;
+        }
+
+        Node_240 cacheNode_240() {
+          Object local = this.mNode_240Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_406.Companion.provides_635(this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_260()));
+            this.mNode_240Instance = local;
+          }
+          return (Node_240) local;
+        }
+
+        Node_161 accessNode_161() {
+          return Checks.checkProvisionNotNull(Module_406.Companion.provides_636(this.mComponent_323.mSet_2, this.accessNode_280(), this.accessNode_167(), this.accessNode_132(), new CachingProviderImpl(this, 5), this.mComponent_328.cacheNode_131(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), this.mComponent_323.cacheNode_257(), this.mComponent_328.cacheNode_29(), this.mComponent_323.mSet_1, this.cacheNode_86()));
+        }
+
+        Node_86 cacheNode_86() {
+          Object local = this.mNode_86Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_406.Companion.provides_637(this.mComponent_328.accessNode_32(), this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 15), this.mComponent_327.accessNode_185(), this.mComponent_327.accessNode_185(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), new Component_328Impl.CachingProviderImpl(this.mComponent_328, 16), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.mComponent_327.mDependency_311.ep_0(), new ProviderImpl(this, 17), this.cacheNode_208(), this.mComponent_323.mSet_3, new ProviderImpl(this, 3), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_327.cacheNode_16(), this.mComponent_328.cacheNode_29(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_107(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_328.accessNode_112()));
+            this.mNode_86Instance = local;
+          }
+          return (Node_86) local;
+        }
+
+        Node_167 accessNode_167() {
+          return Checks.checkProvisionNotNull(Module_406.Companion.provides_639(this.mComponent_328.mSet_3, this.mComponent_327.mSet_0, this.mComponent_323.accessNode_15(), this.accessNode_83(), this.accessNode_221(), this.mComponent_323.accessNode_15(), this.accessNode_132(), this.accessNode_280(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.mSet_1));
+        }
+
+        Node_104 cacheNode_104() {
+          Object local = this.mNode_104Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_104(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), Checks.checkProvisionNotNull(Module_406.Companion.provides_640(this.accessNode_132(), this.accessNode_223(), new ProviderImpl(this, 8), new Component_328Impl.ProviderImpl(this.mComponent_328, 9), new ProviderImpl(this, 16), new Component_328Impl.ProviderImpl(this.mComponent_328, 12), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), this.cacheNode_240(), new Component_328Impl.ProviderImpl(this.mComponent_328, 5), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_406.Companion.provides_641(this.accessNode_274(), this.mComponent_323.cacheNode_257())), this.mComponent_327.mSet_0, this.mComponent_328.cacheNode_206(), this.cacheNode_136(), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.accessNode_197(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.cacheNode_257(), this.cacheNode_104())), this.accessNode_161(), new Component_328Impl.CachingProviderImpl(this.mComponent_328, 1), this.mComponent_327.accessNode_185(), this.accessNode_62(), this.mComponent_328.mDependency_315.ep_0(), this.accessNode_132(), this.mComponent_323.cacheNode_17(), this.mComponent_323.mDependency_310.ep_3());
+            this.mNode_104Instance = local;
+          }
+          return (Node_104) local;
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_136 cacheNode_136() {
+          Object local = this.mNode_136Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_136(this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_16(), new Node_302(), this.mComponent_328.cacheNode_23());
+            this.mNode_136Instance = local;
+          }
+          return (Node_136) local;
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 11), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_158 accessNode_158() {
+          return new Node_158(this.mComponent_327.cacheNode_293());
+        }
+
+        Node_188 accessNode_188() {
+          return new Node_188(this.mComponent_323.cacheNode_102(), this.accessNode_274(), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.cacheNode_39(), this.accessNode_132(), this.accessNode_289(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_328.mSet_1, this.accessNode_142(), this.accessNode_197(), new CachingProviderImpl(this, 6), this.mComponent_328.accessNode_32(), Checks.checkProvisionNotNull(Module_406.Companion.provides_634(this.accessNode_83(), this.mComponent_328.cacheNode_139(), this.accessNode_158(), this.accessNode_125(), this.accessNode_132(), this.mComponent_328.mDependency_315.ep_0(), this.mComponent_323.cacheNode_172(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), new ProviderImpl(this, 6), this.accessNode_286(), this.mComponent_323.mSet_0, new ProviderImpl(this, 13), this.cacheNode_208(), this.cacheNode_39())));
+        }
+
+        Node_19 accessNode_19() {
+          return new Node_19(this.mComponent_327.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Component_328Impl.ProviderImpl(this.mComponent_328, 0), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 4), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_328.cacheNode_88(), this.mComponent_323.cacheNode_281(), this.accessNode_142(), this.accessNode_161(), this.mComponent_328.cacheNode_139(), this.cacheNode_136(), new ProviderImpl(this, 15), this.mComponent_327.cacheNode_33(), this.mComponent_328.cacheNode_206(), new Node_302(), new ProviderImpl(this, 1), this.mComponent_323.mSet_2, this.mComponent_328.cacheNode_181(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_328.mDependency_315.ep_0(), Checks.checkProvisionNotNull(Module_406.Companion.provides_638(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.cacheNode_275(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 14), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_107(), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()))));
+        }
+
+        Node_197 accessNode_197() {
+          return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_328Impl.ProviderImpl(this.mComponent_328, 0), this.mComponent_328.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_328.cacheNode_23(), this.mComponent_323.mSet_2, new Component_328Impl.ProviderImpl(this.mComponent_328, 5), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+        }
+
+        Node_208 cacheNode_208() {
+          Object local = this.mNode_208Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_208(this.mComponent_323.cacheNode_172(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_328.cacheNode_116(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Component_328Impl.ProviderImpl(this.mComponent_328, 16), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_327.cacheNode_108(), this.mComponent_328.cacheNode_139(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_210(), this.mComponent_323.mDependency_310.ep_3(), new Node_302(), this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10));
+            this.mNode_208Instance = local;
+          }
+          return (Node_208) local;
+        }
+
+        Node_223 accessNode_223() {
+          return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new Component_328Impl.ProviderImpl(this.mComponent_328, 11), this.mComponent_323.mDependency_310.ep_1(), new Component_328Impl.ProviderImpl(this.mComponent_328, 12), this.mComponent_323.mDependency_310.ep_3(), new Component_328Impl.ProviderImpl(this.mComponent_328, 9), new Component_328Impl.ProviderImpl(this.mComponent_328, 4), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.mComponent_328.cacheNode_206(), new CachingProviderImpl(this, 2), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new Component_328Impl.ProviderImpl(this.mComponent_328, 8), this.mComponent_328.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+        }
+
+        Node_245 accessNode_245() {
+          return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_328.cacheNode_156(), new Component_328Impl.ProviderImpl(this.mComponent_328, 0), this.mComponent_328.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Component_328Impl.ProviderImpl(this.mComponent_328, 2), this.mComponent_328.mSet_0, this.mComponent_328.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 12));
+        }
+
+        Node_274 accessNode_274() {
+          return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_328.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_328.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 8), this.mComponent_328.cacheNode_88(), this.mComponent_328.mSet_2, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_328.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+        }
+
+        Node_275 cacheNode_275() {
+          Object local = this.mNode_275Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_275(this.accessNode_274(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_323.cacheNode_281(), this.accessNode_197(), this.accessNode_83(), this.cacheNode_136(), this.accessNode_223(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_260(), this.accessNode_280(), new Node_174(new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_328Impl.ProviderImpl(this.mComponent_328, 12), new Component_328Impl.ProviderImpl(this.mComponent_328, 11), this.mComponent_327.cacheNode_241(), this.mComponent_323.mDependency_310.ep_2(), new CachingProviderImpl(this, 5), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_328.cacheNode_88(), this.mComponent_328.mSet_3, new Component_328Impl.ProviderImpl(this.mComponent_328, 15), new CachingProviderImpl(this, 8), this.mComponent_328.cacheNode_247(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_260(), this.mComponent_328.accessNode_32(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554())), this.mComponent_327.mDependency_311.ep_1(), new Component_328Impl.ProviderImpl(this.mComponent_328, 3), new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new CachingProviderImpl(this, 10), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_161(), this.mComponent_327.mSet_1, this.cacheNode_208(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_328.accessNode_211(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_323.cacheNode_11());
+            this.mNode_275Instance = local;
+          }
+          return (Node_275) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_289 accessNode_289() {
+          return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+        }
+
+        Node_62 accessNode_62() {
+          return new Node_62(this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_328.cacheNode_259(), this.mComponent_328.mSet_0, this.mComponent_328.mDependency_315.ep_0(), this.accessNode_289(), this.mComponent_328.cacheNode_247(), this.mComponent_328.cacheNode_29(), this.mComponent_328.cacheNode_29());
+        }
+
+        Node_82 accessNode_82() {
+          return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new Component_328Impl.ProviderImpl(this.mComponent_328, 0), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 7), this.accessNode_245());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 11));
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_332Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_332Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_332Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_332Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_332.Creator {
+          Component_327Impl fComponent_327;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_328Impl fComponent_328;
+
+          private Dependency_316 mSetDep_0;
+
+          ComponentFactoryImpl(Component_327Impl fComponent_327,
+              Yatagan$Component_323 fComponent_323, Component_328Impl fComponent_328) {
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_328 = fComponent_328;
+          }
+
+          @Override
+          public Component_332.Creator setDep_0(Dependency_316 i) {
+            this.mSetDep_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_332 create() {
+            return new Component_332Impl(this.fComponent_327, this.fComponent_323, this.fComponent_328, this.mSetDep_0);
+          }
+        }
+      }
+
+      static final class ProviderImpl implements Lazy {
+        private final Component_328Impl mDelegate;
+
+        private final int mIndex;
+
+        ProviderImpl(Component_328Impl delegate, int index) {
+          this.mDelegate = delegate;
+          this.mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          return this.mDelegate.switch$$access(this.mIndex);
+        }
+      }
+
+      private static final class CachingProviderImpl implements Lazy {
+        private final Component_328Impl mDelegate;
+
+        private final int mIndex;
+
+        private Object mValue;
+
+        CachingProviderImpl(Component_328Impl factory, int index) {
+          mDelegate = factory;
+          mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          Object local = mValue;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = mDelegate.switch$$access(mIndex);
+            mValue = local;
+          }
+          return local;
+        }
+      }
+
+      private static final class ComponentFactoryImpl implements Component_328.Creator {
+        Component_327Impl fComponent_327;
+
+        Yatagan$Component_323 fComponent_323;
+
+        private Dependency_315 mSetDep_0;
+
+        private Node_200 mSet_0;
+
+        private Node_299 mSet_1;
+
+        private Node_273 mSet_2;
+
+        private Node_207 mSet_3;
+
+        ComponentFactoryImpl(Component_327Impl fComponent_327,
+            Yatagan$Component_323 fComponent_323) {
+          this.fComponent_327 = fComponent_327;
+          this.fComponent_323 = fComponent_323;
+        }
+
+        @Override
+        public Component_328.Creator setDep_0(Dependency_315 i) {
+          this.mSetDep_0 = i;
+          return this;
+        }
+
+        @Override
+        public Component_328.Creator set_0(Node_200 i) {
+          this.mSet_0 = i;
+          return this;
+        }
+
+        @Override
+        public Component_328.Creator set_1(Node_299 i) {
+          this.mSet_1 = i;
+          return this;
+        }
+
+        @Override
+        public Component_328.Creator set_2(Node_273 i) {
+          this.mSet_2 = i;
+          return this;
+        }
+
+        @Override
+        public Component_328.Creator set_3(Node_207 i) {
+          this.mSet_3 = i;
+          return this;
+        }
+
+        @Override
+        public Component_328 create() {
+          return new Component_328Impl(this.fComponent_327, this.fComponent_323, this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+        }
+      }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class Component_329Impl implements Component_329 {
+      private Object mNode_28Instance;
+
+      private Object mNode_213Instance;
+
+      private Object mNode_303Instance;
+
+      private Object mNode_263Instance;
+
+      private Object mNode_145Instance;
+
+      private Object mNode_217Instance;
+
+      private Object mNode_230Instance;
+
+      private Object mNode_105Instance;
+
+      private Object mNode_191Instance;
+
+      private Object mNode_110Instance;
+
+      private Object mNode_183Instance;
+
+      private Object mNode_192Instance;
+
+      private Object mNode_244Instance;
+
+      private Object mNode_35Instance;
+
+      final Dependency_314 mDependency_314;
+
+      final Yatagan$Component_323 mComponent_323;
+
+      final Component_327Impl mComponent_327;
+
+      Component_329Impl(Yatagan$Component_323 pComponent_323, Component_327Impl pComponent_327,
+          Dependency_314 pSetDep_0) {
+        this.mComponent_323 = pComponent_323;
+        this.mComponent_327 = pComponent_327;
+        this.mDependency_314 = Checks.checkInputNotNull(pSetDep_0);
+      }
+
+      @Override
+      public Component_333.Creator getChildCreator_0() {
+        return new Component_333Impl.ComponentFactoryImpl(this, this.mComponent_323, this.mComponent_327);
+      }
+
+      @Override
+      public Component_334.Creator getChildCreator_1() {
+        return new Component_334Impl.ComponentFactoryImpl(this.mComponent_327, this.mComponent_323, this);
+      }
+
+      @Override
+      public Component_335.Creator getChildCreator_2() {
+        return new Component_335Impl.ComponentFactoryImpl(this.mComponent_327, this.mComponent_323, this);
+      }
+
+      @Override
+      public Component_336.Creator getChildCreator_3() {
+        return new Component_336Impl.ComponentFactoryImpl(this, this.mComponent_323, this.mComponent_327);
+      }
+
+      @Override
+      public Component_337.Creator getChildCreator_4() {
+        return new Component_337Impl.ComponentFactoryImpl(this.mComponent_327, this.mComponent_323, this);
+      }
+
+      @Override
+      public Node_177 getGet_0() {
+        return this.mComponent_327.cacheNode_177();
+      }
+
+      @Override
+      public Node_272 getGet_1() {
+        return this.accessNode_272();
+      }
+
+      @Override
+      public Node_238 getGet_2() {
+        return this.mComponent_323.mSet_1;
+      }
+
+      @Override
+      public Lazy<Node_130> getGet_3() {
+        return new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9);
+      }
+
+      @Override
+      public Lazy<Node_28> getGet_4() {
+        return new ProviderImpl(this, 14);
+      }
+
+      @Override
+      public Node_133 getGet_5() {
+        return this.mComponent_323.cacheNode_133();
+      }
+
+      @Override
+      public Node_260 getGet_6() {
+        return this.mComponent_327.cacheNode_260();
+      }
+
+      @Override
+      public Node_266 getGet_7() {
+        return Checks.checkProvisionNotNull(Module_401.Companion.provides_547());
+      }
+
+      @Override
+      public Node_192 getGet_8() {
+        return this.cacheNode_192();
+      }
+
+      @Override
+      public Node_286 getGet_9() {
+        return this.accessNode_286();
+      }
+
+      Object switch$$access(int slot) {
+        switch(slot) {
+          case 0: return this.cacheNode_217();
+          case 1: return this.cacheNode_213();
+          case 2: return this.cacheNode_303();
+          case 3: return this.mDependency_314.ep_0();
+          case 4: return this.cacheNode_244();
+          case 5: return this.mDependency_314.ep_1();
+          case 6: return this.accessNode_308();
+          case 7: return this.accessNode_31();
+          case 8: return this.accessNode_251();
+          case 9: return this.cacheNode_192();
+          case 10: return this.cacheNode_183();
+          case 11: return this.cacheNode_230();
+          case 12: return this.cacheNode_35();
+          case 13: return Checks.checkProvisionNotNull(Module_403.Companion.provides_585());
+          case 14: return this.cacheNode_28();
+          case 15: return this.cacheNode_105();
+          case 16: return this.accessNode_272();
+          case 17: return this.accessNode_286();
+          case 18: return this.accessNode_125();
+          case 19: return new Node_96(new CachingProviderImpl(this, 23), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.cacheNode_105(), this.mComponent_327.cacheNode_16(), new ProviderImpl(this, 2), this.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.cacheNode_263(), this.mComponent_323.mSet_0);
+          case 20: return this.accessNode_280();
+          case 21: return this.accessNode_142();
+          case 22: return this.accessNode_65();
+          case 23: return this.accessNode_231();
+          case 24: return this.accessNode_83();
+          default: throw new AssertionError();
+        }
+      }
+
+      Node_28 cacheNode_28() {
+        Object local = this.mNode_28Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_578(this.mComponent_327.mDependency_311.ep_0(), this.accessNode_132(), this.cacheNode_263(), this.mComponent_327.cacheNode_33(), new CachingProviderImpl(this, 7), this.mComponent_323.cacheNode_133(), this.cacheNode_213(), this.mComponent_323.cacheNode_281(), new ProviderImpl(this, 6), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_281(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_0, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_145(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), Checks.checkProvisionNotNull(Module_403.Companion.provides_585())));
+          this.mNode_28Instance = local;
+        }
+        return (Node_28) local;
+      }
+
+      Node_213 cacheNode_213() {
+        Object local = this.mNode_213Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_579(this.cacheNode_303(), this.mComponent_323.cacheNode_46(), new Node_163(new ProviderImpl(this, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.cacheNode_145(), this.accessNode_308(), this.accessNode_280(), new CachingProviderImpl(this, 7), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), this.mComponent_323.mSet_3, this.accessNode_83(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_293()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.cacheNode_281(), new CachingProviderImpl(this, 19), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.mComponent_327.accessNode_185()));
+          this.mNode_213Instance = local;
+        }
+        return (Node_213) local;
+      }
+
+      Node_303 cacheNode_303() {
+        Object local = this.mNode_303Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_580(this.mComponent_327.cacheNode_16(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_33()));
+          this.mNode_303Instance = local;
+        }
+        return (Node_303) local;
+      }
+
+      Node_263 cacheNode_263() {
+        Object local = this.mNode_263Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_581(this.mComponent_323.mDependency_310.ep_0()));
+          this.mNode_263Instance = local;
+        }
+        return (Node_263) local;
+      }
+
+      Node_31 accessNode_31() {
+        return Checks.checkProvisionNotNull(Module_403.Companion.provides_582(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.accessNode_185(), this.mComponent_327.mSet_0, new CachingProviderImpl(this, 21), this.mComponent_327.cacheNode_241(), this.mComponent_323.cacheNode_281(), this.cacheNode_145(), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.accessNode_65(), this.accessNode_132(), this.mComponent_323.cacheNode_107()));
+      }
+
+      Node_308 accessNode_308() {
+        return Checks.checkProvisionNotNull(Module_403.Companion.provides_583(this.mComponent_327.cacheNode_108(), new CachingProviderImpl(this, 7), new ProviderImpl(this, 4), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.mSet_3, this.mComponent_327.mSet_1, this.cacheNode_230(), new ProviderImpl(this, 9), new ProviderImpl(this, 20), this.mComponent_323.cacheNode_102(), Checks.checkProvisionNotNull(Module_403.Companion.provides_585()), this.accessNode_132(), this.mComponent_323.cacheNode_254(), this.mComponent_327.cacheNode_16(), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 8), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mDependency_314.ep_0(), this.mComponent_323.cacheNode_17(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547())));
+      }
+
+      Node_145 cacheNode_145() {
+        Object local = this.mNode_145Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_584(new CachingProviderImpl(this, 8), new ProviderImpl(this, 18), new ProviderImpl(this, 17), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), new CachingProviderImpl(this, 19), new ProviderImpl(this, 15), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.accessNode_280(), this.mComponent_323.cacheNode_102(), this.mComponent_323.mSet_3, this.mComponent_323.cacheNode_17()));
+          this.mNode_145Instance = local;
+        }
+        return (Node_145) local;
+      }
+
+      Node_217 cacheNode_217() {
+        Object local = this.mNode_217Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_586(this.mComponent_323.cacheNode_133(), this.mComponent_327.cacheNode_293(), this.mComponent_323.mDependency_310.ep_3(), this.accessNode_272(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_2()));
+          this.mNode_217Instance = local;
+        }
+        return (Node_217) local;
+      }
+
+      Node_230 cacheNode_230() {
+        Object local = this.mNode_230Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_587(this.accessNode_132()));
+          this.mNode_230Instance = local;
+        }
+        return (Node_230) local;
+      }
+
+      Node_251 accessNode_251() {
+        return Checks.checkProvisionNotNull(Module_403.Companion.provides_588(this.accessNode_125(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new CachingProviderImpl(this, 22), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_184(), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_231(), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_244(), this.mComponent_323.cacheNode_133(), this.cacheNode_263(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 22), this.cacheNode_191(), this.mComponent_327.mSet_1, this.mComponent_323.cacheNode_172(), this.mDependency_314.ep_0(), this.mComponent_323.accessNode_15()));
+      }
+
+      Node_105 cacheNode_105() {
+        Object local = this.mNode_105Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_589(new Component_327Impl.ProviderImpl(this.mComponent_327, 5), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.cacheNode_303(), this.mDependency_314.ep_0(), this.cacheNode_28(), this.mComponent_323.cacheNode_262(), this.cacheNode_35(), this.accessNode_132(), new CachingProviderImpl(this, 23), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new CachingProviderImpl(this, 8), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), new CachingProviderImpl(this, 19)));
+          this.mNode_105Instance = local;
+        }
+        return (Node_105) local;
+      }
+
+      Node_191 cacheNode_191() {
+        Object local = this.mNode_191Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_403.Companion.provides_590(this.accessNode_142(), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 19), this.mComponent_323.cacheNode_133(), this.cacheNode_244(), this.mComponent_327.mSet_1, this.cacheNode_217(), this.mComponent_323.cacheNode_281(), this.cacheNode_263(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 10)));
+          this.mNode_191Instance = local;
+        }
+        return (Node_191) local;
+      }
+
+      Node_110 cacheNode_110() {
+        Object local = this.mNode_110Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_110(this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_107(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_293(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_46(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.mComponent_323.mSet_0, this.accessNode_132(), this.cacheNode_213(), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_30(), this.mComponent_323.cacheNode_254(), this.cacheNode_263(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_323.mSet_3, this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 14));
+          this.mNode_110Instance = local;
+        }
+        return (Node_110) local;
+      }
+
+      Node_125 accessNode_125() {
+        return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+      }
+
+      Node_132 accessNode_132() {
+        return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+      }
+
+      Node_142 accessNode_142() {
+        return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 17), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+      }
+
+      Node_183 cacheNode_183() {
+        Object local = this.mNode_183Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_183(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_102(), new ProviderImpl(this, 1), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_308(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 17), new CachingProviderImpl(this, 19), this.cacheNode_28(), new CachingProviderImpl(this, 8), this.accessNode_280());
+          this.mNode_183Instance = local;
+        }
+        return (Node_183) local;
+      }
+
+      Node_192 cacheNode_192() {
+        Object local = this.mNode_192Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_192(this.cacheNode_263(), new CachingProviderImpl(this, 19), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 12), this.accessNode_272(), this.mComponent_327.cacheNode_260(), this.accessNode_280(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_323.mDependency_310.ep_6(), this.cacheNode_217(), this.mComponent_327.mSet_0, this.mComponent_327.cacheNode_293(), this.accessNode_31(), this.accessNode_83());
+          this.mNode_192Instance = local;
+        }
+        return (Node_192) local;
+      }
+
+      Node_231 accessNode_231() {
+        return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.cacheNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 21), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 17), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 3), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.cacheNode_244(), this.mComponent_327.cacheNode_177(), new ProviderImpl(this, 0));
+      }
+
+      Node_244 cacheNode_244() {
+        Object local = this.mNode_244Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_244(new ProviderImpl(this, 20), new CachingProviderImpl(this, 18), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new CachingProviderImpl(this, 8), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 7), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_327.cacheNode_16(), new CachingProviderImpl(this, 19), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), Checks.checkProvisionNotNull(Module_403.Companion.provides_585()));
+          this.mNode_244Instance = local;
+        }
+        return (Node_244) local;
+      }
+
+      Node_272 accessNode_272() {
+        return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new ProviderImpl(this, 1), this.cacheNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+      }
+
+      Node_280 accessNode_280() {
+        return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+      }
+
+      Node_286 accessNode_286() {
+        return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+      }
+
+      Node_35 cacheNode_35() {
+        Object local = this.mNode_35Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_35(this.mComponent_327.cacheNode_177(), new ProviderImpl(this, 13), this.mComponent_323.cacheNode_46(), new CachingProviderImpl(this, 16), new ProviderImpl(this, 0), new Component_327Impl.ProviderImpl(this.mComponent_327, 7), this.mComponent_327.cacheNode_108(), this.accessNode_280(), this.cacheNode_230(), this.mComponent_323.mSet_0, new ProviderImpl(this, 10), new ProviderImpl(this, 1), this.mComponent_323.mDependency_310.ep_6(), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 23), this.mComponent_323.cacheNode_11(), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), this.mComponent_327.cacheNode_184());
+          this.mNode_35Instance = local;
+        }
+        return (Node_35) local;
+      }
+
+      Node_65 accessNode_65() {
+        return new Node_65(this.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.cacheNode_183());
+      }
+
+      Node_83 accessNode_83() {
+        return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 17));
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_333Impl implements Component_333 {
+        final Component_329Impl mComponent_329;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_327Impl mComponent_327;
+
+        Component_333Impl(Component_329Impl pComponent_329, Yatagan$Component_323 pComponent_323,
+            Component_327Impl pComponent_327) {
+          this.mComponent_329 = pComponent_329;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_327 = pComponent_327;
+        }
+
+        @Override
+        public Node_145 getGet_0() {
+          return this.mComponent_329.cacheNode_145();
+        }
+
+        @Override
+        public Node_153 getGet_1() {
+          return this.mComponent_323.mDependency_310.ep_6();
+        }
+
+        @Override
+        public Node_262 getGet_2() {
+          return this.mComponent_323.cacheNode_262();
+        }
+
+        @Override
+        public Node_217 getGet_3() {
+          return this.mComponent_329.cacheNode_217();
+        }
+
+        @Override
+        public Node_142 getGet_4() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 0), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3()), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        @Override
+        public Node_33 getGet_5() {
+          return this.mComponent_327.cacheNode_33();
+        }
+
+        @Override
+        public void inject_0(Injectee_369 i) {
+          i.setMember_0(this.mComponent_323.cacheNode_46());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+            default: throw new AssertionError();
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_333Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_333Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_333.Creator {
+          Component_329Impl fComponent_329;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_327Impl fComponent_327;
+
+          ComponentFactoryImpl(Component_329Impl fComponent_329,
+              Yatagan$Component_323 fComponent_323, Component_327Impl fComponent_327) {
+            this.fComponent_329 = fComponent_329;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_327 = fComponent_327;
+          }
+
+          @Override
+          public Component_333 create() {
+            return new Component_333Impl(this.fComponent_329, this.fComponent_323, this.fComponent_327);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_334Impl implements Component_334 {
+        final Component_327Impl mComponent_327;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_329Impl mComponent_329;
+
+        Component_334Impl(Component_327Impl pComponent_327, Yatagan$Component_323 pComponent_323,
+            Component_329Impl pComponent_329) {
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_329 = pComponent_329;
+        }
+
+        @Override
+        public Node_272 getGet_0() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_329Impl.ProviderImpl(this.mComponent_329, 1), this.mComponent_329.cacheNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_329.cacheNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 0), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 1), new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0()), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_329Impl.ProviderImpl(this.mComponent_329, 3), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_329.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_329Impl.ProviderImpl(this.mComponent_329, 0)), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 1)));
+        }
+
+        @Override
+        public Provider<Node_195> getGet_1() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 5);
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 1), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3()), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+            case 1: return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+            default: throw new AssertionError();
+          }
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_334Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_334Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_334Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_334Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_334.Creator {
+          Component_327Impl fComponent_327;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_329Impl fComponent_329;
+
+          ComponentFactoryImpl(Component_327Impl fComponent_327,
+              Yatagan$Component_323 fComponent_323, Component_329Impl fComponent_329) {
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_329 = fComponent_329;
+          }
+
+          @Override
+          public Component_334 create() {
+            return new Component_334Impl(this.fComponent_327, this.fComponent_323, this.fComponent_329);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_335Impl implements Component_335 {
+        private Object mNode_284Instance;
+
+        private Object mNode_143Instance;
+
+        private Object mNode_79Instance;
+
+        private Object mNode_222Instance;
+
+        private Object mNode_80Instance;
+
+        private Object mNode_186Instance;
+
+        private Object mNode_258Instance;
+
+        private Object mNode_278Instance;
+
+        private Object mNode_282Instance;
+
+        private Object mNode_285Instance;
+
+        final Node_77 mSet_0;
+
+        final Component_327Impl mComponent_327;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_329Impl mComponent_329;
+
+        Component_335Impl(Component_327Impl pComponent_327, Yatagan$Component_323 pComponent_323,
+            Component_329Impl pComponent_329, Node_77 pSet_0) {
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_329 = pComponent_329;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        }
+
+        @Override
+        public Node_260 getGet_0() {
+          return this.mComponent_327.cacheNode_260();
+        }
+
+        @Override
+        public Node_163 getGet_1() {
+          return new Node_163(new Component_329Impl.ProviderImpl(this.mComponent_329, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_329.cacheNode_145(), this.mComponent_329.accessNode_308(), this.accessNode_280(), new Component_329Impl.CachingProviderImpl(this.mComponent_329, 7), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), this.mComponent_323.mSet_3, this.accessNode_83(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_293());
+        }
+
+        @Override
+        public void inject_0(Injectee_370 i) {
+          i.setMember_0(this.mComponent_323.mSet_2);
+          i.setMember_1(this.mComponent_323.mDependency_310.ep_0());
+          i.setMember_2(this.mComponent_323.cacheNode_254());
+          i.setMember_3(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()));
+        }
+
+        @Override
+        public void inject_1(Injectee_371 i) {
+          i.setMember_0(this.mComponent_329.mDependency_314.ep_1());
+          i.setMember_1(this.accessNode_286());
+          i.setMember_2(this.cacheNode_284());
+          i.setMember_3(this.mComponent_327.cacheNode_33());
+          i.setMember_4(this.mComponent_329.cacheNode_244());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.accessNode_286();
+            case 1: return this.cacheNode_284();
+            case 2: return this.accessNode_214();
+            case 3: return this.cacheNode_186();
+            case 4: return this.accessNode_253();
+            case 5: return this.cacheNode_143();
+            case 6: return this.cacheNode_278();
+            case 7: return this.accessNode_234();
+            case 8: return this.cacheNode_258();
+            case 9: return this.accessNode_142();
+            case 10: return Checks.checkProvisionNotNull(Module_409.Companion.provides_650(new ProviderImpl(this, 12), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_329.accessNode_308(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_329.cacheNode_217(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_280(), this.mComponent_323.cacheNode_11(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.cacheNode_143(), this.mComponent_329.cacheNode_183(), this.mComponent_323.cacheNode_107(), this.accessNode_65(), new ProviderImpl(this, 1)));
+            case 11: return this.accessNode_53();
+            case 12: return this.mSet_0;
+            case 13: return this.accessNode_231();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_284 cacheNode_284() {
+          Object local = this.mNode_284Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_409.Companion.provides_644(this.mComponent_329.cacheNode_217(), this.accessNode_280(), this.mComponent_323.cacheNode_262(), this.accessNode_214(), this.cacheNode_186(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 16)));
+            this.mNode_284Instance = local;
+          }
+          return (Node_284) local;
+        }
+
+        Node_214 accessNode_214() {
+          return Checks.checkProvisionNotNull(Module_409.Companion.provides_645(this.mComponent_329.cacheNode_217(), this.mComponent_327.cacheNode_33(), this.cacheNode_282(), this.accessNode_253(), this.mComponent_323.cacheNode_107(), this.cacheNode_143(), new ProviderImpl(this, 6), this.accessNode_234(), this.mComponent_329.accessNode_251(), this.mComponent_323.cacheNode_254(), this.cacheNode_258(), this.accessNode_280()));
+        }
+
+        Node_253 accessNode_253() {
+          return Checks.checkProvisionNotNull(Module_409.Companion.provides_646(this.mComponent_323.mSet_2, this.accessNode_53(), this.mComponent_329.cacheNode_191(), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_260(), this.mComponent_329.cacheNode_183(), this.mComponent_327.cacheNode_177(), this.mComponent_329.cacheNode_263(), this.cacheNode_285(), this.accessNode_94(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.cacheNode_278(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_329.cacheNode_303(), this.mComponent_329.mDependency_314.ep_0()));
+        }
+
+        Node_143 cacheNode_143() {
+          Object local = this.mNode_143Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_409.Companion.provides_647(new Node_109(this.accessNode_269(), this.mComponent_329.cacheNode_244(), new CachingProviderImpl(this, 4)), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_117(), this.accessNode_194(), this.mComponent_323.cacheNode_254(), new Node_42(this.accessNode_272(), this.mComponent_329.cacheNode_244(), this.mComponent_323.accessNode_15(), this.mComponent_329.cacheNode_28(), new ProviderImpl(this, 3), this.mComponent_327.cacheNode_16(), this.mComponent_323.cacheNode_257(), this.accessNode_96(), this.mComponent_327.mDependency_311.ep_3(), new ProviderImpl(this, 5), Checks.checkProvisionNotNull(Module_403.Companion.provides_585()), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_6(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_241(), new Component_329Impl.ProviderImpl(this.mComponent_329, 5), this.mComponent_327.mSet_1, this.mComponent_329.accessNode_251(), this.mComponent_323.cacheNode_133()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.accessNode_65(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_17(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.cacheNode_293(), this.mComponent_329.cacheNode_191(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13)));
+            this.mNode_143Instance = local;
+          }
+          return (Node_143) local;
+        }
+
+        Node_234 accessNode_234() {
+          return Checks.checkProvisionNotNull(Module_409.Companion.provides_648(this.accessNode_125(), this.accessNode_194(), this.mComponent_323.cacheNode_107(), this.cacheNode_79(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.accessNode_286(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_258(), this.accessNode_272(), this.mComponent_329.cacheNode_35(), this.mComponent_329.cacheNode_183(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 17), this.mComponent_329.cacheNode_192(), this.mComponent_327.cacheNode_108()));
+        }
+
+        Node_79 cacheNode_79() {
+          Object local = this.mNode_79Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_409.Companion.provides_649(this.accessNode_125(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new ProviderImpl(this, 1), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_11(), this.mComponent_329.cacheNode_110(), this.accessNode_94(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_241(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 6), this.accessNode_83(), this.accessNode_269(), this.mComponent_323.cacheNode_102(), this.cacheNode_143()));
+            this.mNode_79Instance = local;
+          }
+          return (Node_79) local;
+        }
+
+        Node_117 accessNode_117() {
+          return Checks.checkProvisionNotNull(Module_409.Companion.provides_651(this.accessNode_280(), new Component_329Impl.ProviderImpl(this.mComponent_329, 8), this.mComponent_323.accessNode_210(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.accessNode_15(), this.accessNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_329.accessNode_308(), Checks.checkProvisionNotNull(Module_409.Companion.provides_655(this.mComponent_323.cacheNode_281(), this.mComponent_327.cacheNode_260(), this.mComponent_329.mDependency_314.ep_0(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 8), new CachingProviderImpl(this, 11), new ProviderImpl(this, 3), new ProviderImpl(this, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_329Impl.CachingProviderImpl(this.mComponent_329, 6), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 7), this.mComponent_323.accessNode_210(), new ProviderImpl(this, 10), this.mComponent_329.cacheNode_183(), this.accessNode_269(), this.mComponent_329.cacheNode_191(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_257(), this.cacheNode_80(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), new CachingProviderImpl(this, 4), this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()))), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.cacheNode_186(), this.mComponent_323.cacheNode_107(), new Component_329Impl.ProviderImpl(this.mComponent_329, 11), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_260(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_262(), this.mComponent_323.accessNode_15(), this.mComponent_329.cacheNode_244(), this.accessNode_53(), this.cacheNode_222()));
+        }
+
+        Node_222 cacheNode_222() {
+          Object local = this.mNode_222Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_409.Companion.provides_652(this.mComponent_329.cacheNode_28(), this.mComponent_323.cacheNode_281()));
+            this.mNode_222Instance = local;
+          }
+          return (Node_222) local;
+        }
+
+        Node_194 accessNode_194() {
+          return Checks.checkProvisionNotNull(Module_409.Companion.provides_653(this.mComponent_329.cacheNode_35(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_293(), this.mComponent_323.accessNode_15(), this.mComponent_327.cacheNode_108(), this.mSet_0, new CachingProviderImpl(this, 10)));
+        }
+
+        Node_269 accessNode_269() {
+          return Checks.checkProvisionNotNull(Module_409.Companion.provides_654(this.mComponent_327.cacheNode_293()));
+        }
+
+        Node_80 cacheNode_80() {
+          Object local = this.mNode_80Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_409.Companion.provides_656(this.mComponent_323.mDependency_310.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_329.accessNode_308(), this.mComponent_329.cacheNode_183(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.accessNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_262(), this.mComponent_329.cacheNode_191(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.mComponent_327.cacheNode_33(), this.accessNode_83(), new Component_329Impl.CachingProviderImpl(this.mComponent_329, 7)));
+            this.mNode_80Instance = local;
+          }
+          return (Node_80) local;
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 0), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_329.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_329.cacheNode_183(), this.mComponent_323.accessNode_210(), this.accessNode_125());
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_231 accessNode_231() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_329.cacheNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 9), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 0), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_329Impl.ProviderImpl(this.mComponent_329, 3), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_329.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_329Impl.ProviderImpl(this.mComponent_329, 0));
+        }
+
+        Node_258 cacheNode_258() {
+          Object local = this.mNode_258Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_258(this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_403.Companion.provides_585()), this.mComponent_323.cacheNode_262(), this.accessNode_280(), this.cacheNode_79(), this.accessNode_280(), this.mComponent_329.cacheNode_145(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.accessNode_15(), this.cacheNode_143(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_329.cacheNode_230(), this.accessNode_253(), this.mComponent_323.cacheNode_133());
+            this.mNode_258Instance = local;
+          }
+          return (Node_258) local;
+        }
+
+        Node_272 accessNode_272() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_329Impl.ProviderImpl(this.mComponent_329, 1), this.mComponent_329.cacheNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+        }
+
+        Node_278 cacheNode_278() {
+          Object local = this.mNode_278Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_278(this.cacheNode_186(), this.mComponent_329.cacheNode_263(), new CachingProviderImpl(this, 10), new ProviderImpl(this, 8), this.accessNode_269(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_323.accessNode_15(), new Component_329Impl.ProviderImpl(this.mComponent_329, 2), this.accessNode_125(), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1);
+            this.mNode_278Instance = local;
+          }
+          return (Node_278) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_282 cacheNode_282() {
+          Object local = this.mNode_282Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_282(new Component_329Impl.CachingProviderImpl(this.mComponent_329, 5), this.mComponent_327.cacheNode_16(), this.mComponent_329.accessNode_31(), this.accessNode_142(), this.mComponent_323.mSet_3, this.accessNode_83(), this.accessNode_234(), this.mComponent_329.accessNode_251(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new ProviderImpl(this, 1), this.mComponent_323.cacheNode_257(), this.accessNode_65(), this.accessNode_280(), this.cacheNode_79(), this.mComponent_329.cacheNode_303(), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new CachingProviderImpl(this, 10), this.mComponent_329.cacheNode_217(), this.mComponent_329.cacheNode_230(), this.accessNode_117(), this.mComponent_329.cacheNode_110(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.cacheNode_222());
+            this.mNode_282Instance = local;
+          }
+          return (Node_282) local;
+        }
+
+        Node_285 cacheNode_285() {
+          Object local = this.mNode_285Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_285(this.mComponent_329.cacheNode_145(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 2), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_329.cacheNode_303(), this.accessNode_96(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.accessNode_132());
+            this.mNode_285Instance = local;
+          }
+          return (Node_285) local;
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_53 accessNode_53() {
+          return new Node_53(this.mComponent_327.mDependency_311.ep_0(), this.cacheNode_222(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_329.cacheNode_244(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new CachingProviderImpl(this, 10), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_177(), new Component_329Impl.ProviderImpl(this.mComponent_329, 0), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 2), this.mComponent_329.cacheNode_105(), this.mComponent_329.cacheNode_230(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+        }
+
+        Node_65 accessNode_65() {
+          return new Node_65(this.mComponent_329.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.mComponent_329.cacheNode_183());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 0));
+        }
+
+        Node_94 accessNode_94() {
+          return new Node_94(this.mComponent_329.cacheNode_145(), this.accessNode_83(), this.mComponent_323.mDependency_310.ep_3(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.cacheNode_186(), this.mComponent_327.cacheNode_108(), this.accessNode_269(), new Component_329Impl.ProviderImpl(this.mComponent_329, 1), this.mComponent_327.mSet_1, this.mComponent_329.mDependency_314.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_262(), this.mComponent_329.cacheNode_303(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_329.cacheNode_105(), this.mComponent_329.cacheNode_192(), this.accessNode_280());
+        }
+
+        Node_96 accessNode_96() {
+          return new Node_96(new CachingProviderImpl(this, 13), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.mComponent_329.cacheNode_105(), this.mComponent_327.cacheNode_16(), new Component_329Impl.ProviderImpl(this.mComponent_329, 2), this.mComponent_329.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.mComponent_329.cacheNode_263(), this.mComponent_323.mSet_0);
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_335Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_335Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_335Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_335Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_335.Creator {
+          Component_327Impl fComponent_327;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_329Impl fComponent_329;
+
+          private Node_77 mSet_0;
+
+          ComponentFactoryImpl(Component_327Impl fComponent_327,
+              Yatagan$Component_323 fComponent_323, Component_329Impl fComponent_329) {
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_329 = fComponent_329;
+          }
+
+          @Override
+          public Component_335.Creator set_0(Node_77 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_335 create() {
+            return new Component_335Impl(this.fComponent_327, this.fComponent_323, this.fComponent_329, this.mSet_0);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_336Impl implements Component_336 {
+        private Object mNode_186Instance;
+
+        final Node_165 mSet_0;
+
+        final Component_329Impl mComponent_329;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_327Impl mComponent_327;
+
+        Component_336Impl(Component_329Impl pComponent_329, Yatagan$Component_323 pComponent_323,
+            Component_327Impl pComponent_327, Node_165 pSet_0) {
+          this.mComponent_329 = pComponent_329;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_327 = pComponent_327;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        }
+
+        @Override
+        public Node_165 getGet_0() {
+          return this.mSet_0;
+        }
+
+        @Override
+        public Node_192 getGet_1() {
+          return this.mComponent_329.cacheNode_192();
+        }
+
+        @Override
+        public Node_46 getGet_2() {
+          return this.mComponent_323.cacheNode_46();
+        }
+
+        @Override
+        public Node_231 getGet_3() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_329.cacheNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 0), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 1), new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0()), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_329Impl.ProviderImpl(this.mComponent_329, 3), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_329.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_329Impl.ProviderImpl(this.mComponent_329, 0));
+        }
+
+        @Override
+        public Node_186 getGet_4() {
+          return this.cacheNode_186();
+        }
+
+        @Override
+        public Provider<Node_227> getGet_5() {
+          return new Component_329Impl.ProviderImpl(this.mComponent_329, 5);
+        }
+
+        @Override
+        public Node_251 getGet_6() {
+          return this.mComponent_329.accessNode_251();
+        }
+
+        @Override
+        public Node_30 getGet_7() {
+          return this.mComponent_323.cacheNode_30();
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.accessNode_142();
+            case 1: return this.accessNode_286();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 1), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_329.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_329.cacheNode_183(), this.mComponent_323.accessNode_210(), new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254()));
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_336Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_336Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_336Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_336Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_336.Creator {
+          Component_329Impl fComponent_329;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_327Impl fComponent_327;
+
+          private Node_165 mSet_0;
+
+          ComponentFactoryImpl(Component_329Impl fComponent_329,
+              Yatagan$Component_323 fComponent_323, Component_327Impl fComponent_327) {
+            this.fComponent_329 = fComponent_329;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_327 = fComponent_327;
+          }
+
+          @Override
+          public Component_336.Creator set_0(Node_165 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_336 create() {
+            return new Component_336Impl(this.fComponent_329, this.fComponent_323, this.fComponent_327, this.mSet_0);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_337Impl implements Component_337 {
+        private Object mNode_234Instance;
+
+        private Object mNode_284Instance;
+
+        private Object mNode_236Instance;
+
+        private Object mNode_194Instance;
+
+        private Object mNode_214Instance;
+
+        private Object mNode_143Instance;
+
+        private Object mNode_186Instance;
+
+        private Object mNode_258Instance;
+
+        private Object mNode_278Instance;
+
+        private Object mNode_282Instance;
+
+        private Object mNode_285Instance;
+
+        final Node_77 mSet_0;
+
+        final Component_327Impl mComponent_327;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_329Impl mComponent_329;
+
+        Component_337Impl(Component_327Impl pComponent_327, Yatagan$Component_323 pComponent_323,
+            Component_329Impl pComponent_329, Node_77 pSet_0) {
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_329 = pComponent_329;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        }
+
+        @Override
+        public Lazy<Node_260> getGet_0() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 7);
+        }
+
+        @Override
+        public Node_193 getGet_1() {
+          return Checks.checkProvisionNotNull(Module_401.Companion.provides_550());
+        }
+
+        @Override
+        public Node_92 getGet_2() {
+          return this.mComponent_327.mSet_1;
+        }
+
+        @Override
+        public Node_254 getGet_3() {
+          return this.mComponent_323.cacheNode_254();
+        }
+
+        @Override
+        public void inject_0(Injectee_372 i) {
+          i.setMember_0(this.cacheNode_282());
+          i.setMember_1(this.accessNode_65());
+          i.setMember_2(this.mComponent_327.accessNode_185());
+        }
+
+        @Override
+        public void inject_1(Injectee_373 i) {
+          i.setMember_0(this.accessNode_117());
+        }
+
+        @Override
+        public void inject_2(Injectee_374 i) {
+          i.setMember_0(Checks.checkProvisionNotNull(Module_401.Companion.provides_547()));
+          i.setMember_1(this.accessNode_53());
+          i.setMember_2(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()));
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.accessNode_117();
+            case 1: return this.accessNode_53();
+            case 2: return this.accessNode_142();
+            case 3: return this.cacheNode_234();
+            case 4: return this.cacheNode_284();
+            case 5: return this.cacheNode_236();
+            case 6: return this.cacheNode_194();
+            case 7: return this.cacheNode_186();
+            case 8: return this.cacheNode_214();
+            case 9: return this.accessNode_286();
+            case 10: return this.cacheNode_258();
+            case 11: return this.cacheNode_278();
+            case 12: return this.cacheNode_143();
+            case 13: return this.mSet_0;
+            case 14: return this.accessNode_253();
+            case 15: return this.accessNode_231();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_117 accessNode_117() {
+          return Checks.checkProvisionNotNull(Module_411.Companion.provides_660(this.accessNode_280(), new Component_329Impl.ProviderImpl(this.mComponent_329, 8), this.mComponent_323.accessNode_210(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.accessNode_15(), this.cacheNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_329.accessNode_308(), Checks.checkProvisionNotNull(Module_411.Companion.provides_667(this.mComponent_323.cacheNode_281(), this.mComponent_327.cacheNode_260(), this.mComponent_329.mDependency_314.ep_0(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 10), new CachingProviderImpl(this, 1), new ProviderImpl(this, 7), new ProviderImpl(this, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_329Impl.CachingProviderImpl(this.mComponent_329, 6), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 3), this.mComponent_323.accessNode_210(), new ProviderImpl(this, 5), this.mComponent_329.cacheNode_183(), this.accessNode_269(), this.mComponent_329.cacheNode_191(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_257(), Checks.checkProvisionNotNull(Module_411.Companion.provides_671(this.mComponent_323.mDependency_310.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_329.accessNode_308(), this.mComponent_329.cacheNode_183(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.cacheNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_262(), this.mComponent_329.cacheNode_191(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.mComponent_327.cacheNode_33(), this.accessNode_83(), new Component_329Impl.CachingProviderImpl(this.mComponent_329, 7))), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), new CachingProviderImpl(this, 14), this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()))), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.cacheNode_186(), this.mComponent_323.cacheNode_107(), new Component_329Impl.ProviderImpl(this.mComponent_329, 11), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_260(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_262(), this.mComponent_323.accessNode_15(), this.mComponent_329.cacheNode_244(), this.accessNode_53(), this.accessNode_222()));
+        }
+
+        Node_234 cacheNode_234() {
+          Object local = this.mNode_234Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_411.Companion.provides_661(this.accessNode_125(), this.cacheNode_194(), this.mComponent_323.cacheNode_107(), this.accessNode_79(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.accessNode_286(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_258(), this.accessNode_272(), this.mComponent_329.cacheNode_35(), this.mComponent_329.cacheNode_183(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 17), this.mComponent_329.cacheNode_192(), this.mComponent_327.cacheNode_108()));
+            this.mNode_234Instance = local;
+          }
+          return (Node_234) local;
+        }
+
+        Node_284 cacheNode_284() {
+          Object local = this.mNode_284Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_411.Companion.provides_662(this.mComponent_329.cacheNode_217(), this.accessNode_280(), this.mComponent_323.cacheNode_262(), this.cacheNode_214(), this.cacheNode_186(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 16)));
+            this.mNode_284Instance = local;
+          }
+          return (Node_284) local;
+        }
+
+        Node_79 accessNode_79() {
+          return Checks.checkProvisionNotNull(Module_411.Companion.provides_663(this.accessNode_125(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new ProviderImpl(this, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_11(), this.mComponent_329.cacheNode_110(), this.accessNode_94(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_241(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 11), this.accessNode_83(), this.accessNode_269(), this.mComponent_323.cacheNode_102(), this.cacheNode_143()));
+        }
+
+        Node_236 cacheNode_236() {
+          Object local = this.mNode_236Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_411.Companion.provides_664(new ProviderImpl(this, 13), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_329.accessNode_308(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_329.cacheNode_217(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_280(), this.mComponent_323.cacheNode_11(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.cacheNode_143(), this.mComponent_329.cacheNode_183(), this.mComponent_323.cacheNode_107(), this.accessNode_65(), new ProviderImpl(this, 4)));
+            this.mNode_236Instance = local;
+          }
+          return (Node_236) local;
+        }
+
+        Node_222 accessNode_222() {
+          return Checks.checkProvisionNotNull(Module_411.Companion.provides_665(this.mComponent_329.cacheNode_28(), this.mComponent_323.cacheNode_281()));
+        }
+
+        Node_194 cacheNode_194() {
+          Object local = this.mNode_194Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_411.Companion.provides_666(this.mComponent_329.cacheNode_35(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_293(), this.mComponent_323.accessNode_15(), this.mComponent_327.cacheNode_108(), this.mSet_0, this.cacheNode_236()));
+            this.mNode_194Instance = local;
+          }
+          return (Node_194) local;
+        }
+
+        Node_214 cacheNode_214() {
+          Object local = this.mNode_214Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_411.Companion.provides_668(this.mComponent_329.cacheNode_217(), this.mComponent_327.cacheNode_33(), this.cacheNode_282(), this.accessNode_253(), this.mComponent_323.cacheNode_107(), this.cacheNode_143(), new ProviderImpl(this, 11), this.cacheNode_234(), this.mComponent_329.accessNode_251(), this.mComponent_323.cacheNode_254(), this.cacheNode_258(), this.accessNode_280()));
+            this.mNode_214Instance = local;
+          }
+          return (Node_214) local;
+        }
+
+        Node_269 accessNode_269() {
+          return Checks.checkProvisionNotNull(Module_411.Companion.provides_669(this.mComponent_327.cacheNode_293()));
+        }
+
+        Node_143 cacheNode_143() {
+          Object local = this.mNode_143Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_411.Companion.provides_670(new Node_109(this.accessNode_269(), this.mComponent_329.cacheNode_244(), new CachingProviderImpl(this, 14)), this.mComponent_327.mDependency_311.ep_0(), new CachingProviderImpl(this, 0), new ProviderImpl(this, 6), this.mComponent_323.cacheNode_254(), new Node_42(this.accessNode_272(), this.mComponent_329.cacheNode_244(), this.mComponent_323.accessNode_15(), this.mComponent_329.cacheNode_28(), new ProviderImpl(this, 7), this.mComponent_327.cacheNode_16(), this.mComponent_323.cacheNode_257(), this.accessNode_96(), this.mComponent_327.mDependency_311.ep_3(), new ProviderImpl(this, 12), Checks.checkProvisionNotNull(Module_403.Companion.provides_585()), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_6(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_241(), new Component_329Impl.ProviderImpl(this.mComponent_329, 5), this.mComponent_327.mSet_1, this.mComponent_329.accessNode_251(), this.mComponent_323.cacheNode_133()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.accessNode_65(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_17(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.cacheNode_293(), this.mComponent_329.cacheNode_191(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13)));
+            this.mNode_143Instance = local;
+          }
+          return (Node_143) local;
+        }
+
+        Node_253 accessNode_253() {
+          return Checks.checkProvisionNotNull(Module_411.Companion.provides_672(this.mComponent_323.mSet_2, this.accessNode_53(), this.mComponent_329.cacheNode_191(), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_260(), this.mComponent_329.cacheNode_183(), this.mComponent_327.cacheNode_177(), this.mComponent_329.cacheNode_263(), this.cacheNode_285(), this.accessNode_94(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.cacheNode_278(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_329.cacheNode_303(), this.mComponent_329.mDependency_314.ep_0()));
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 9), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_329.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_329.cacheNode_183(), this.mComponent_323.accessNode_210(), this.accessNode_125());
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_231 accessNode_231() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_329.cacheNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 2), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 9), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_329Impl.ProviderImpl(this.mComponent_329, 3), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_329.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_329Impl.ProviderImpl(this.mComponent_329, 0));
+        }
+
+        Node_258 cacheNode_258() {
+          Object local = this.mNode_258Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_258(this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_403.Companion.provides_585()), this.mComponent_323.cacheNode_262(), this.accessNode_280(), this.accessNode_79(), this.accessNode_280(), this.mComponent_329.cacheNode_145(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.accessNode_15(), this.cacheNode_143(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_329.cacheNode_230(), this.accessNode_253(), this.mComponent_323.cacheNode_133());
+            this.mNode_258Instance = local;
+          }
+          return (Node_258) local;
+        }
+
+        Node_272 accessNode_272() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_329Impl.ProviderImpl(this.mComponent_329, 1), this.mComponent_329.cacheNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+        }
+
+        Node_278 cacheNode_278() {
+          Object local = this.mNode_278Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_278(this.cacheNode_186(), this.mComponent_329.cacheNode_263(), new ProviderImpl(this, 5), new ProviderImpl(this, 10), this.accessNode_269(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_323.accessNode_15(), new Component_329Impl.ProviderImpl(this.mComponent_329, 2), this.accessNode_125(), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1);
+            this.mNode_278Instance = local;
+          }
+          return (Node_278) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_282 cacheNode_282() {
+          Object local = this.mNode_282Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_282(new Component_329Impl.CachingProviderImpl(this.mComponent_329, 5), this.mComponent_327.cacheNode_16(), this.mComponent_329.accessNode_31(), this.accessNode_142(), this.mComponent_323.mSet_3, this.accessNode_83(), this.cacheNode_234(), this.mComponent_329.accessNode_251(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new ProviderImpl(this, 4), this.mComponent_323.cacheNode_257(), this.accessNode_65(), this.accessNode_280(), this.accessNode_79(), this.mComponent_329.cacheNode_303(), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new ProviderImpl(this, 5), this.mComponent_329.cacheNode_217(), this.mComponent_329.cacheNode_230(), this.accessNode_117(), this.mComponent_329.cacheNode_110(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.accessNode_222());
+            this.mNode_282Instance = local;
+          }
+          return (Node_282) local;
+        }
+
+        Node_285 cacheNode_285() {
+          Object local = this.mNode_285Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_285(this.mComponent_329.cacheNode_145(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new ProviderImpl(this, 8), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_329.cacheNode_303(), this.accessNode_96(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.accessNode_132());
+            this.mNode_285Instance = local;
+          }
+          return (Node_285) local;
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_53 accessNode_53() {
+          return new Node_53(this.mComponent_327.mDependency_311.ep_0(), this.accessNode_222(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_329.cacheNode_244(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new ProviderImpl(this, 5), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_177(), new Component_329Impl.ProviderImpl(this.mComponent_329, 0), this.mComponent_327.cacheNode_293(), new ProviderImpl(this, 8), this.mComponent_329.cacheNode_105(), this.mComponent_329.cacheNode_230(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+        }
+
+        Node_65 accessNode_65() {
+          return new Node_65(this.mComponent_329.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.mComponent_329.cacheNode_183());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 9));
+        }
+
+        Node_94 accessNode_94() {
+          return new Node_94(this.mComponent_329.cacheNode_145(), this.accessNode_83(), this.mComponent_323.mDependency_310.ep_3(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.cacheNode_186(), this.mComponent_327.cacheNode_108(), this.accessNode_269(), new Component_329Impl.ProviderImpl(this.mComponent_329, 1), this.mComponent_327.mSet_1, this.mComponent_329.mDependency_314.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_262(), this.mComponent_329.cacheNode_303(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_329.cacheNode_105(), this.mComponent_329.cacheNode_192(), this.accessNode_280());
+        }
+
+        Node_96 accessNode_96() {
+          return new Node_96(new CachingProviderImpl(this, 15), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.mComponent_329.cacheNode_105(), this.mComponent_327.cacheNode_16(), new Component_329Impl.ProviderImpl(this.mComponent_329, 2), this.mComponent_329.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.mComponent_329.cacheNode_263(), this.mComponent_323.mSet_0);
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_337Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_337Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_337Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_337Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_337.Creator {
+          Component_327Impl fComponent_327;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_329Impl fComponent_329;
+
+          private Node_77 mSet_0;
+
+          ComponentFactoryImpl(Component_327Impl fComponent_327,
+              Yatagan$Component_323 fComponent_323, Component_329Impl fComponent_329) {
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_329 = fComponent_329;
+          }
+
+          @Override
+          public Component_337.Creator set_0(Node_77 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_337 create() {
+            return new Component_337Impl(this.fComponent_327, this.fComponent_323, this.fComponent_329, this.mSet_0);
+          }
+        }
+      }
+
+      static final class ProviderImpl implements Lazy {
+        private final Component_329Impl mDelegate;
+
+        private final int mIndex;
+
+        ProviderImpl(Component_329Impl delegate, int index) {
+          this.mDelegate = delegate;
+          this.mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          return this.mDelegate.switch$$access(this.mIndex);
+        }
+      }
+
+      private static final class CachingProviderImpl implements Lazy {
+        private final Component_329Impl mDelegate;
+
+        private final int mIndex;
+
+        private Object mValue;
+
+        CachingProviderImpl(Component_329Impl factory, int index) {
+          mDelegate = factory;
+          mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          Object local = mValue;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = mDelegate.switch$$access(mIndex);
+            mValue = local;
+          }
+          return local;
+        }
+      }
+
+      private static final class ComponentFactoryImpl implements Component_329.Creator {
+        Yatagan$Component_323 fComponent_323;
+
+        Component_327Impl fComponent_327;
+
+        private Dependency_314 mSetDep_0;
+
+        ComponentFactoryImpl(Yatagan$Component_323 fComponent_323,
+            Component_327Impl fComponent_327) {
+          this.fComponent_323 = fComponent_323;
+          this.fComponent_327 = fComponent_327;
+        }
+
+        @Override
+        public Component_329.Creator setDep_0(Dependency_314 i) {
+          this.mSetDep_0 = i;
+          return this;
+        }
+
+        @Override
+        public Component_329 create() {
+          return new Component_329Impl(this.fComponent_323, this.fComponent_327, this.mSetDep_0);
+        }
+      }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class Component_330Impl implements Component_330 {
+      private Object mNode_251Instance;
+
+      private Object mNode_217Instance;
+
+      private Object mNode_191Instance;
+
+      private Object mNode_230Instance;
+
+      private Object mNode_147Instance;
+
+      private Object mNode_28Instance;
+
+      private Object mNode_110Instance;
+
+      private Object mNode_183Instance;
+
+      private Object mNode_192Instance;
+
+      private Object mNode_244Instance;
+
+      private Object mNode_35Instance;
+
+      final Dependency_314 mDependency_314;
+
+      final Component_327Impl mComponent_327;
+
+      final Yatagan$Component_323 mComponent_323;
+
+      Component_330Impl(Component_327Impl pComponent_327, Yatagan$Component_323 pComponent_323,
+          Dependency_314 pSetDep_0) {
+        this.mComponent_327 = pComponent_327;
+        this.mComponent_323 = pComponent_323;
+        this.mDependency_314 = Checks.checkInputNotNull(pSetDep_0);
+      }
+
+      @Override
+      public Component_338.Creator getChildCreator_0() {
+        return new Component_338Impl.ComponentFactoryImpl(this.mComponent_327, this, this.mComponent_323);
+      }
+
+      @Override
+      public Component_339.Creator getChildCreator_1() {
+        return new Component_339Impl.ComponentFactoryImpl(this.mComponent_327, this, this.mComponent_323);
+      }
+
+      @Override
+      public Component_340.Creator getChildCreator_2() {
+        return new Component_340Impl.ComponentFactoryImpl(this.mComponent_323, this, this.mComponent_327);
+      }
+
+      @Override
+      public Component_341.Creator getChildCreator_3() {
+        return new Component_341Impl.ComponentFactoryImpl(this.mComponent_323, this, this.mComponent_327);
+      }
+
+      @Override
+      public Lazy<Node_231> getGet_0() {
+        return new CachingProviderImpl(this, 14);
+      }
+
+      @Override
+      public Node_164 getGet_1() {
+        return this.mComponent_323.mDependency_310.ep_1();
+      }
+
+      @Override
+      public Node_96 getGet_10() {
+        return this.accessNode_96();
+      }
+
+      @Override
+      public Lazy<Node_193> getGet_2() {
+        return new Component_327Impl.CachingProviderImpl(this.mComponent_327, 8);
+      }
+
+      @Override
+      public Lazy<Node_69> getGet_3() {
+        return new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9);
+      }
+
+      @Override
+      public Provider<Node_92> getGet_4() {
+        return new Component_327Impl.ProviderImpl(this.mComponent_327, 15);
+      }
+
+      @Override
+      public Lazy<Node_83> getGet_5() {
+        return new CachingProviderImpl(this, 15);
+      }
+
+      @Override
+      public Node_266 getGet_6() {
+        return Checks.checkProvisionNotNull(Module_401.Companion.provides_547());
+      }
+
+      @Override
+      public Node_251 getGet_7() {
+        return this.cacheNode_251();
+      }
+
+      @Override
+      public Node_30 getGet_8() {
+        return this.mComponent_323.cacheNode_30();
+      }
+
+      @Override
+      public Node_241 getGet_9() {
+        return this.mComponent_327.cacheNode_241();
+      }
+
+      @Override
+      public void inject_0(Injectee_364 i) {
+        i.setMember_0(this.mComponent_323.mDependency_310.ep_6());
+        i.setMember_1(this.accessNode_280());
+        i.setMember_2(this.mComponent_323.mDependency_310.ep_0());
+      }
+
+      @Override
+      public void inject_1(Injectee_365 i) {
+        i.setMember_0(this.mComponent_327.cacheNode_177());
+        i.setMember_1(this.cacheNode_192());
+        i.setMember_2(this.mComponent_323.cacheNode_281());
+        i.setMember_3(this.accessNode_263());
+        i.setMember_4(this.mDependency_314.ep_0());
+        i.setMember_5(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()));
+        i.setMember_6(this.mComponent_323.mDependency_310.ep_0());
+        i.setMember_7(this.mComponent_323.mSet_2);
+      }
+
+      @Override
+      public void inject_2(Injectee_366 i) {
+        i.setMember_0(this.mComponent_323.cacheNode_11());
+        i.setMember_1(this.cacheNode_110());
+        i.setMember_2(this.mComponent_323.mDependency_310.ep_3());
+        i.setMember_3(this.cacheNode_244());
+        i.setMember_4(this.accessNode_213());
+        i.setMember_5(this.mComponent_323.mSet_2);
+      }
+
+      Object switch$$access(int slot) {
+        switch(slot) {
+          case 0: return this.cacheNode_35();
+          case 1: return this.accessNode_31();
+          case 2: return this.accessNode_308();
+          case 3: return this.accessNode_213();
+          case 4: return this.mDependency_314.ep_1();
+          case 5: return this.cacheNode_244();
+          case 6: return this.cacheNode_251();
+          case 7: return this.cacheNode_147();
+          case 8: return this.accessNode_105();
+          case 9: return this.cacheNode_217();
+          case 10: return this.cacheNode_230();
+          case 11: return this.cacheNode_183();
+          case 12: return this.accessNode_303();
+          case 13: return this.mDependency_314.ep_0();
+          case 14: return this.accessNode_231();
+          case 15: return this.accessNode_83();
+          case 16: return this.accessNode_96();
+          case 17: return this.accessNode_280();
+          case 18: return this.accessNode_272();
+          case 19: return this.accessNode_142();
+          case 20: return this.accessNode_65();
+          case 21: return this.accessNode_125();
+          case 22: return this.accessNode_286();
+          default: throw new AssertionError();
+        }
+      }
+
+      Node_251 cacheNode_251() {
+        Object local = this.mNode_251Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_404.Companion.provides_594(this.accessNode_125(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.accessNode_65(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_184(), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_231(), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_244(), this.mComponent_323.cacheNode_133(), this.accessNode_263(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 22), this.cacheNode_191(), this.mComponent_327.mSet_1, this.mComponent_323.cacheNode_172(), this.mDependency_314.ep_0(), this.mComponent_323.accessNode_15()));
+          this.mNode_251Instance = local;
+        }
+        return (Node_251) local;
+      }
+
+      Node_263 accessNode_263() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_595(this.mComponent_323.mDependency_310.ep_0()));
+      }
+
+      Node_213 accessNode_213() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_596(this.accessNode_303(), this.mComponent_323.cacheNode_46(), new Node_163(new ProviderImpl(this, 5), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.accessNode_145(), this.accessNode_308(), this.accessNode_280(), new CachingProviderImpl(this, 1), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), this.mComponent_323.mSet_3, this.accessNode_83(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_293()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.cacheNode_281(), this.accessNode_96(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.mComponent_327.accessNode_185()));
+      }
+
+      Node_303 accessNode_303() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_597(this.mComponent_327.cacheNode_16(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_33()));
+      }
+
+      Node_217 cacheNode_217() {
+        Object local = this.mNode_217Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_404.Companion.provides_598(this.mComponent_323.cacheNode_133(), this.mComponent_327.cacheNode_293(), this.mComponent_323.mDependency_310.ep_3(), this.accessNode_272(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_2()));
+          this.mNode_217Instance = local;
+        }
+        return (Node_217) local;
+      }
+
+      Node_191 cacheNode_191() {
+        Object local = this.mNode_191Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_404.Companion.provides_599(this.accessNode_142(), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 16), this.mComponent_323.cacheNode_133(), this.cacheNode_244(), this.mComponent_327.mSet_1, this.cacheNode_217(), this.mComponent_323.cacheNode_281(), this.accessNode_263(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 10)));
+          this.mNode_191Instance = local;
+        }
+        return (Node_191) local;
+      }
+
+      Node_105 accessNode_105() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_600(new Component_327Impl.ProviderImpl(this.mComponent_327, 5), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.accessNode_303(), this.mDependency_314.ep_0(), this.cacheNode_28(), this.mComponent_323.cacheNode_262(), this.cacheNode_35(), this.accessNode_132(), this.accessNode_231(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.cacheNode_251(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), new CachingProviderImpl(this, 16)));
+      }
+
+      Node_230 cacheNode_230() {
+        Object local = this.mNode_230Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_404.Companion.provides_601(this.accessNode_132()));
+          this.mNode_230Instance = local;
+        }
+        return (Node_230) local;
+      }
+
+      Node_31 accessNode_31() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_602(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.accessNode_185(), this.mComponent_327.mSet_0, new CachingProviderImpl(this, 19), this.mComponent_327.cacheNode_241(), this.mComponent_323.cacheNode_281(), this.accessNode_145(), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new CachingProviderImpl(this, 20), this.accessNode_132(), this.mComponent_323.cacheNode_107()));
+      }
+
+      Node_147 cacheNode_147() {
+        Object local = this.mNode_147Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_404.Companion.provides_603());
+          this.mNode_147Instance = local;
+        }
+        return (Node_147) local;
+      }
+
+      Node_308 accessNode_308() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_604(this.mComponent_327.cacheNode_108(), this.accessNode_31(), this.cacheNode_244(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.mSet_3, this.mComponent_327.mSet_1, this.cacheNode_230(), this.cacheNode_192(), new ProviderImpl(this, 17), this.mComponent_323.cacheNode_102(), this.cacheNode_147(), this.accessNode_132(), this.mComponent_323.cacheNode_254(), this.mComponent_327.cacheNode_16(), this.mComponent_327.cacheNode_260(), new ProviderImpl(this, 6), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mDependency_314.ep_0(), this.mComponent_323.cacheNode_17(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547())));
+      }
+
+      Node_28 cacheNode_28() {
+        Object local = this.mNode_28Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_404.Companion.provides_605(this.mComponent_327.mDependency_311.ep_0(), this.accessNode_132(), this.accessNode_263(), this.mComponent_327.cacheNode_33(), this.accessNode_31(), this.mComponent_323.cacheNode_133(), new CachingProviderImpl(this, 3), this.mComponent_323.cacheNode_281(), new ProviderImpl(this, 2), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_281(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_0, this.mComponent_323.mDependency_310.ep_3(), this.accessNode_145(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.cacheNode_147()));
+          this.mNode_28Instance = local;
+        }
+        return (Node_28) local;
+      }
+
+      Node_145 accessNode_145() {
+        return Checks.checkProvisionNotNull(Module_404.Companion.provides_606(new ProviderImpl(this, 6), new ProviderImpl(this, 21), new ProviderImpl(this, 22), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), new CachingProviderImpl(this, 16), new CachingProviderImpl(this, 8), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.accessNode_280(), this.mComponent_323.cacheNode_102(), this.mComponent_323.mSet_3, this.mComponent_323.cacheNode_17()));
+      }
+
+      Node_110 cacheNode_110() {
+        Object local = this.mNode_110Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_110(this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_107(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_293(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_46(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.mComponent_323.mSet_0, this.accessNode_132(), this.accessNode_213(), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_30(), this.mComponent_323.cacheNode_254(), this.accessNode_263(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_323.mSet_3, this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 14));
+          this.mNode_110Instance = local;
+        }
+        return (Node_110) local;
+      }
+
+      Node_125 accessNode_125() {
+        return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+      }
+
+      Node_132 accessNode_132() {
+        return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+      }
+
+      Node_142 accessNode_142() {
+        return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 22), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+      }
+
+      Node_183 cacheNode_183() {
+        Object local = this.mNode_183Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_183(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 3), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_308(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 22), new CachingProviderImpl(this, 16), this.cacheNode_28(), new ProviderImpl(this, 6), this.accessNode_280());
+          this.mNode_183Instance = local;
+        }
+        return (Node_183) local;
+      }
+
+      Node_192 cacheNode_192() {
+        Object local = this.mNode_192Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_192(this.accessNode_263(), new CachingProviderImpl(this, 16), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 0), this.accessNode_272(), this.mComponent_327.cacheNode_260(), this.accessNode_280(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_323.mDependency_310.ep_6(), this.cacheNode_217(), this.mComponent_327.mSet_0, this.mComponent_327.cacheNode_293(), this.accessNode_31(), this.accessNode_83());
+          this.mNode_192Instance = local;
+        }
+        return (Node_192) local;
+      }
+
+      Node_231 accessNode_231() {
+        return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.accessNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 19), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 22), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 13), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.cacheNode_244(), this.mComponent_327.cacheNode_177(), new ProviderImpl(this, 9));
+      }
+
+      Node_244 cacheNode_244() {
+        Object local = this.mNode_244Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_244(new ProviderImpl(this, 17), new CachingProviderImpl(this, 21), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new ProviderImpl(this, 6), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 1), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_327.cacheNode_16(), new CachingProviderImpl(this, 16), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.cacheNode_147());
+          this.mNode_244Instance = local;
+        }
+        return (Node_244) local;
+      }
+
+      Node_272 accessNode_272() {
+        return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new CachingProviderImpl(this, 3), this.accessNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+      }
+
+      Node_280 accessNode_280() {
+        return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+      }
+
+      Node_286 accessNode_286() {
+        return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+      }
+
+      Node_35 cacheNode_35() {
+        Object local = this.mNode_35Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_35(this.mComponent_327.cacheNode_177(), new ProviderImpl(this, 7), this.mComponent_323.cacheNode_46(), new CachingProviderImpl(this, 18), new ProviderImpl(this, 9), new Component_327Impl.ProviderImpl(this.mComponent_327, 7), this.mComponent_327.cacheNode_108(), this.accessNode_280(), this.cacheNode_230(), this.mComponent_323.mSet_0, new ProviderImpl(this, 11), new CachingProviderImpl(this, 3), this.mComponent_323.mDependency_310.ep_6(), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 14), this.mComponent_323.cacheNode_11(), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), this.mComponent_327.cacheNode_184());
+          this.mNode_35Instance = local;
+        }
+        return (Node_35) local;
+      }
+
+      Node_65 accessNode_65() {
+        return new Node_65(this.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.cacheNode_183());
+      }
+
+      Node_83 accessNode_83() {
+        return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 22));
+      }
+
+      Node_96 accessNode_96() {
+        return new Node_96(new CachingProviderImpl(this, 14), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.accessNode_105(), this.mComponent_327.cacheNode_16(), new CachingProviderImpl(this, 12), this.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.accessNode_263(), this.mComponent_323.mSet_0);
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_338Impl implements Component_338 {
+        private Object mNode_284Instance;
+
+        private Object mNode_222Instance;
+
+        private Object mNode_236Instance;
+
+        private Object mNode_253Instance;
+
+        private Object mNode_143Instance;
+
+        private Object mNode_234Instance;
+
+        private Object mNode_117Instance;
+
+        private Object mNode_269Instance;
+
+        private Object mNode_186Instance;
+
+        private Object mNode_258Instance;
+
+        private Object mNode_278Instance;
+
+        private Object mNode_282Instance;
+
+        final Node_77 mSet_0;
+
+        final Component_327Impl mComponent_327;
+
+        final Component_330Impl mComponent_330;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        Component_338Impl(Component_327Impl pComponent_327, Component_330Impl pComponent_330,
+            Yatagan$Component_323 pComponent_323, Node_77 pSet_0) {
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_330 = pComponent_330;
+          this.mComponent_323 = pComponent_323;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        }
+
+        @Override
+        public Provider<Node_177> getGet_0() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 11);
+        }
+
+        @Override
+        public Node_184 getGet_1() {
+          return this.mComponent_327.cacheNode_184();
+        }
+
+        @Override
+        public Provider<Node_281> getGet_10() {
+          return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0);
+        }
+
+        @Override
+        public Lazy<Node_300> getGet_11() {
+          return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5);
+        }
+
+        @Override
+        public Node_293 getGet_12() {
+          return this.mComponent_327.cacheNode_293();
+        }
+
+        @Override
+        public Node_35 getGet_2() {
+          return this.mComponent_330.cacheNode_35();
+        }
+
+        @Override
+        public Node_284 getGet_3() {
+          return this.cacheNode_284();
+        }
+
+        @Override
+        public Provider<Node_31> getGet_4() {
+          return new Component_330Impl.ProviderImpl(this.mComponent_330, 1);
+        }
+
+        @Override
+        public Node_164 getGet_5() {
+          return this.mComponent_323.mDependency_310.ep_1();
+        }
+
+        @Override
+        public Provider<Node_308> getGet_6() {
+          return new Component_330Impl.ProviderImpl(this.mComponent_330, 2);
+        }
+
+        @Override
+        public Node_53 getGet_7() {
+          return this.accessNode_53();
+        }
+
+        @Override
+        public Lazy<Node_213> getGet_8() {
+          return new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3);
+        }
+
+        @Override
+        public Node_227 getGet_9() {
+          return this.mComponent_330.mDependency_314.ep_1();
+        }
+
+        @Override
+        public void inject_0(Injectee_375 i) {
+          i.setMember_0(this.mComponent_327.cacheNode_177());
+          i.setMember_1(this.mComponent_323.mDependency_310.ep_0());
+          i.setMember_2(this.mComponent_330.cacheNode_244());
+          i.setMember_3(this.mComponent_323.mDependency_310.ep_3());
+          i.setMember_4(this.mComponent_327.mSet_0);
+          i.setMember_5(this.mComponent_323.cacheNode_11());
+          i.setMember_6(this.mComponent_323.cacheNode_107());
+        }
+
+        @Override
+        public void inject_1(Injectee_376 i) {
+          i.setMember_0(this.mComponent_330.cacheNode_251());
+          i.setMember_1(this.mComponent_327.accessNode_185());
+          i.setMember_2(this.mComponent_330.cacheNode_147());
+          i.setMember_3(this.mComponent_330.accessNode_105());
+          i.setMember_4(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()));
+          i.setMember_5(this.mComponent_323.cacheNode_281());
+          i.setMember_6(this.mComponent_323.accessNode_15());
+          i.setMember_7(this.accessNode_125());
+          i.setMember_8(this.mComponent_330.accessNode_31());
+          i.setMember_9(new Node_81(this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_108(), new Node_233(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), this.mComponent_323.mSet_2, this.mComponent_330.accessNode_263(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_16())));
+        }
+
+        @Override
+        public void inject_2(Injectee_377 i) {
+          i.setMember_0(this.mComponent_327.cacheNode_108());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.cacheNode_284();
+            case 1: return this.accessNode_53();
+            case 2: return this.accessNode_214();
+            case 3: return this.cacheNode_186();
+            case 4: return this.cacheNode_236();
+            case 5: return this.accessNode_286();
+            case 6: return this.accessNode_142();
+            case 7: return this.cacheNode_253();
+            case 8: return this.cacheNode_143();
+            case 9: return this.cacheNode_278();
+            case 10: return this.cacheNode_234();
+            case 11: return this.cacheNode_258();
+            case 12: return this.mSet_0;
+            case 13: return this.cacheNode_117();
+            case 14: return this.accessNode_194();
+            case 15: return this.accessNode_231();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_284 cacheNode_284() {
+          Object local = this.mNode_284Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_675(this.mComponent_330.cacheNode_217(), this.accessNode_280(), this.mComponent_323.cacheNode_262(), this.accessNode_214(), this.cacheNode_186(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 16)));
+            this.mNode_284Instance = local;
+          }
+          return (Node_284) local;
+        }
+
+        Node_214 accessNode_214() {
+          return Checks.checkProvisionNotNull(Module_412.Companion.provides_676(this.mComponent_330.cacheNode_217(), this.mComponent_327.cacheNode_33(), this.cacheNode_282(), this.cacheNode_253(), this.mComponent_323.cacheNode_107(), this.cacheNode_143(), new ProviderImpl(this, 9), this.cacheNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_254(), this.cacheNode_258(), this.accessNode_280()));
+        }
+
+        Node_222 cacheNode_222() {
+          Object local = this.mNode_222Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_677(this.mComponent_330.cacheNode_28(), this.mComponent_323.cacheNode_281()));
+            this.mNode_222Instance = local;
+          }
+          return (Node_222) local;
+        }
+
+        Node_236 cacheNode_236() {
+          Object local = this.mNode_236Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_678(new ProviderImpl(this, 12), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_330.accessNode_308(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_330.cacheNode_217(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_280(), this.mComponent_323.cacheNode_11(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.cacheNode_143(), this.mComponent_330.cacheNode_183(), this.mComponent_323.cacheNode_107(), this.accessNode_65(), new ProviderImpl(this, 0)));
+            this.mNode_236Instance = local;
+          }
+          return (Node_236) local;
+        }
+
+        Node_253 cacheNode_253() {
+          Object local = this.mNode_253Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_679(this.mComponent_323.mSet_2, this.accessNode_53(), this.mComponent_330.cacheNode_191(), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_260(), this.mComponent_330.cacheNode_183(), this.mComponent_327.cacheNode_177(), this.mComponent_330.accessNode_263(), new Node_285(this.mComponent_330.accessNode_145(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 2), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.accessNode_96(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.accessNode_132()), this.accessNode_94(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.cacheNode_278(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.mComponent_330.mDependency_314.ep_0()));
+            this.mNode_253Instance = local;
+          }
+          return (Node_253) local;
+        }
+
+        Node_143 cacheNode_143() {
+          Object local = this.mNode_143Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_680(new Node_109(this.cacheNode_269(), this.mComponent_330.cacheNode_244(), new ProviderImpl(this, 7)), this.mComponent_327.mDependency_311.ep_0(), new ProviderImpl(this, 13), new CachingProviderImpl(this, 14), this.mComponent_323.cacheNode_254(), new Node_42(this.accessNode_272(), this.mComponent_330.cacheNode_244(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_28(), new ProviderImpl(this, 3), this.mComponent_327.cacheNode_16(), this.mComponent_323.cacheNode_257(), this.accessNode_96(), this.mComponent_327.mDependency_311.ep_3(), new ProviderImpl(this, 8), this.mComponent_330.cacheNode_147(), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_6(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_241(), new Component_330Impl.ProviderImpl(this.mComponent_330, 4), this.mComponent_327.mSet_1, this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_133()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.accessNode_65(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_17(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.cacheNode_293(), this.mComponent_330.cacheNode_191(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13)));
+            this.mNode_143Instance = local;
+          }
+          return (Node_143) local;
+        }
+
+        Node_234 cacheNode_234() {
+          Object local = this.mNode_234Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_681(this.accessNode_125(), this.accessNode_194(), this.mComponent_323.cacheNode_107(), this.accessNode_79(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.accessNode_286(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_258(), this.accessNode_272(), this.mComponent_330.cacheNode_35(), this.mComponent_330.cacheNode_183(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 17), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_108()));
+            this.mNode_234Instance = local;
+          }
+          return (Node_234) local;
+        }
+
+        Node_79 accessNode_79() {
+          return Checks.checkProvisionNotNull(Module_412.Companion.provides_682(this.accessNode_125(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new ProviderImpl(this, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_11(), this.mComponent_330.cacheNode_110(), this.accessNode_94(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_241(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 9), this.accessNode_83(), this.cacheNode_269(), this.mComponent_323.cacheNode_102(), this.cacheNode_143()));
+        }
+
+        Node_117 cacheNode_117() {
+          Object local = this.mNode_117Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_683(this.accessNode_280(), new Component_330Impl.ProviderImpl(this.mComponent_330, 6), this.mComponent_323.accessNode_210(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.accessNode_15(), this.accessNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_330.accessNode_308(), Checks.checkProvisionNotNull(Module_412.Companion.provides_686(this.mComponent_323.cacheNode_281(), this.mComponent_327.cacheNode_260(), this.mComponent_330.mDependency_314.ep_0(), this.mComponent_327.accessNode_185(), this.cacheNode_258(), new CachingProviderImpl(this, 1), new ProviderImpl(this, 3), new ProviderImpl(this, 0), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 2), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 10), this.mComponent_323.accessNode_210(), new ProviderImpl(this, 4), this.mComponent_330.cacheNode_183(), this.cacheNode_269(), this.mComponent_330.cacheNode_191(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_257(), Checks.checkProvisionNotNull(Module_412.Companion.provides_687(this.mComponent_323.mDependency_310.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_330.accessNode_308(), this.mComponent_330.cacheNode_183(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.accessNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_262(), this.mComponent_330.cacheNode_191(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.mComponent_327.cacheNode_33(), this.accessNode_83(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 1))), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), this.cacheNode_253(), this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()))), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.cacheNode_186(), this.mComponent_323.cacheNode_107(), new Component_330Impl.ProviderImpl(this.mComponent_330, 10), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_260(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_262(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_244(), this.accessNode_53(), this.cacheNode_222()));
+            this.mNode_117Instance = local;
+          }
+          return (Node_117) local;
+        }
+
+        Node_194 accessNode_194() {
+          return Checks.checkProvisionNotNull(Module_412.Companion.provides_684(this.mComponent_330.cacheNode_35(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_293(), this.mComponent_323.accessNode_15(), this.mComponent_327.cacheNode_108(), this.mSet_0, this.cacheNode_236()));
+        }
+
+        Node_269 cacheNode_269() {
+          Object local = this.mNode_269Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_412.Companion.provides_685(this.mComponent_327.cacheNode_293()));
+            this.mNode_269Instance = local;
+          }
+          return (Node_269) local;
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 5), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_330.cacheNode_183(), this.mComponent_323.accessNode_210(), this.accessNode_125());
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_231 accessNode_231() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_330.accessNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 6), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 5), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_330Impl.ProviderImpl(this.mComponent_330, 13), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_330.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9));
+        }
+
+        Node_258 cacheNode_258() {
+          Object local = this.mNode_258Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_258(this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_147(), this.mComponent_323.cacheNode_262(), this.accessNode_280(), this.accessNode_79(), this.accessNode_280(), this.mComponent_330.accessNode_145(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.accessNode_15(), this.cacheNode_143(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_330.cacheNode_230(), this.cacheNode_253(), this.mComponent_323.cacheNode_133());
+            this.mNode_258Instance = local;
+          }
+          return (Node_258) local;
+        }
+
+        Node_272 accessNode_272() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_330.accessNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+        }
+
+        Node_278 cacheNode_278() {
+          Object local = this.mNode_278Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_278(this.cacheNode_186(), this.mComponent_330.accessNode_263(), new ProviderImpl(this, 4), new ProviderImpl(this, 11), this.cacheNode_269(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_323.accessNode_15(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.accessNode_125(), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1);
+            this.mNode_278Instance = local;
+          }
+          return (Node_278) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_282 cacheNode_282() {
+          Object local = this.mNode_282Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_282(new Component_330Impl.CachingProviderImpl(this.mComponent_330, 4), this.mComponent_327.cacheNode_16(), this.mComponent_330.accessNode_31(), this.accessNode_142(), this.mComponent_323.mSet_3, this.accessNode_83(), this.cacheNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new ProviderImpl(this, 0), this.mComponent_323.cacheNode_257(), this.accessNode_65(), this.accessNode_280(), this.accessNode_79(), this.mComponent_330.accessNode_303(), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new ProviderImpl(this, 4), this.mComponent_330.cacheNode_217(), this.mComponent_330.cacheNode_230(), this.cacheNode_117(), this.mComponent_330.cacheNode_110(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.cacheNode_222());
+            this.mNode_282Instance = local;
+          }
+          return (Node_282) local;
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_53 accessNode_53() {
+          return new Node_53(this.mComponent_327.mDependency_311.ep_0(), this.cacheNode_222(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_330.cacheNode_244(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new ProviderImpl(this, 4), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 2), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_230(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+        }
+
+        Node_65 accessNode_65() {
+          return new Node_65(this.mComponent_330.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.mComponent_330.cacheNode_183());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 5));
+        }
+
+        Node_94 accessNode_94() {
+          return new Node_94(this.mComponent_330.accessNode_145(), this.accessNode_83(), this.mComponent_323.mDependency_310.ep_3(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.cacheNode_186(), this.mComponent_327.cacheNode_108(), this.cacheNode_269(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_327.mSet_1, this.mComponent_330.mDependency_314.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_262(), this.mComponent_330.accessNode_303(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_192(), this.accessNode_280());
+        }
+
+        Node_96 accessNode_96() {
+          return new Node_96(new CachingProviderImpl(this, 15), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.mComponent_330.accessNode_105(), this.mComponent_327.cacheNode_16(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.mComponent_330.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.mComponent_330.accessNode_263(), this.mComponent_323.mSet_0);
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_338Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_338Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_338Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_338Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_338.Creator {
+          Component_327Impl fComponent_327;
+
+          Component_330Impl fComponent_330;
+
+          Yatagan$Component_323 fComponent_323;
+
+          private Node_77 mSet_0;
+
+          ComponentFactoryImpl(Component_327Impl fComponent_327, Component_330Impl fComponent_330,
+              Yatagan$Component_323 fComponent_323) {
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_330 = fComponent_330;
+            this.fComponent_323 = fComponent_323;
+          }
+
+          @Override
+          public Component_338.Creator set_0(Node_77 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_338 create() {
+            return new Component_338Impl(this.fComponent_327, this.fComponent_330, this.fComponent_323, this.mSet_0);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_339Impl implements Component_339 {
+        private Object mNode_194Instance;
+
+        private Object mNode_214Instance;
+
+        private Object mNode_253Instance;
+
+        private Object mNode_143Instance;
+
+        private Object mNode_234Instance;
+
+        private Object mNode_117Instance;
+
+        private Object mNode_186Instance;
+
+        private Object mNode_258Instance;
+
+        private Object mNode_278Instance;
+
+        private Object mNode_285Instance;
+
+        final Node_165 mSet_0;
+
+        final Node_77 mSet_1;
+
+        final Component_327Impl mComponent_327;
+
+        final Component_330Impl mComponent_330;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        Component_339Impl(Component_327Impl pComponent_327, Component_330Impl pComponent_330,
+            Yatagan$Component_323 pComponent_323, Node_165 pSet_0, Node_77 pSet_1) {
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_330 = pComponent_330;
+          this.mComponent_323 = pComponent_323;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+          this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+        }
+
+        @Override
+        public Lazy<Node_285> getGet_0() {
+          return new ProviderImpl(this, 0);
+        }
+
+        @Override
+        public Node_266 getGet_1() {
+          return Checks.checkProvisionNotNull(Module_401.Companion.provides_547());
+        }
+
+        @Override
+        public Node_179 getGet_2() {
+          return this.mComponent_323.cacheNode_281();
+        }
+
+        @Override
+        public Node_172 getGet_3() {
+          return this.mComponent_323.cacheNode_172();
+        }
+
+        @Override
+        public Node_183 getGet_4() {
+          return this.mComponent_330.cacheNode_183();
+        }
+
+        @Override
+        public Node_194 getGet_5() {
+          return this.cacheNode_194();
+        }
+
+        @Override
+        public Node_165 getGet_6() {
+          return this.mSet_0;
+        }
+
+        @Override
+        public void inject_0(Injectee_378 i) {
+          i.setMember_0(this.mComponent_327.cacheNode_33());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.cacheNode_285();
+            case 1: return this.cacheNode_194();
+            case 2: return this.cacheNode_214();
+            case 3: return this.mSet_1;
+            case 4: return this.accessNode_236();
+            case 5: return this.cacheNode_253();
+            case 6: return this.cacheNode_143();
+            case 7: return this.cacheNode_278();
+            case 8: return this.cacheNode_234();
+            case 9: return this.cacheNode_258();
+            case 10: return this.accessNode_231();
+            case 11: return this.accessNode_142();
+            case 12: return this.accessNode_284();
+            case 13: return this.cacheNode_117();
+            case 14: return this.accessNode_53();
+            case 15: return this.accessNode_286();
+            case 16: return this.cacheNode_186();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_194 cacheNode_194() {
+          Object local = this.mNode_194Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_413.Companion.provides_690(this.mComponent_330.cacheNode_35(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_293(), this.mComponent_323.accessNode_15(), this.mComponent_327.cacheNode_108(), this.mSet_1, this.accessNode_236()));
+            this.mNode_194Instance = local;
+          }
+          return (Node_194) local;
+        }
+
+        Node_214 cacheNode_214() {
+          Object local = this.mNode_214Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_413.Companion.provides_691(this.mComponent_330.cacheNode_217(), this.mComponent_327.cacheNode_33(), new Node_282(new Component_330Impl.CachingProviderImpl(this.mComponent_330, 4), this.mComponent_327.cacheNode_16(), this.mComponent_330.accessNode_31(), this.accessNode_142(), this.mComponent_323.mSet_3, this.accessNode_83(), this.cacheNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new CachingProviderImpl(this, 12), this.mComponent_323.cacheNode_257(), this.accessNode_65(), this.accessNode_280(), this.accessNode_79(), this.mComponent_330.accessNode_303(), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new CachingProviderImpl(this, 4), this.mComponent_330.cacheNode_217(), this.mComponent_330.cacheNode_230(), this.cacheNode_117(), this.mComponent_330.cacheNode_110(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.accessNode_222()), this.cacheNode_253(), this.mComponent_323.cacheNode_107(), this.cacheNode_143(), new ProviderImpl(this, 7), this.cacheNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_254(), this.cacheNode_258(), this.accessNode_280()));
+            this.mNode_214Instance = local;
+          }
+          return (Node_214) local;
+        }
+
+        Node_236 accessNode_236() {
+          return Checks.checkProvisionNotNull(Module_413.Companion.provides_692(new ProviderImpl(this, 3), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_330.accessNode_308(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_330.cacheNode_217(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_280(), this.mComponent_323.cacheNode_11(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.cacheNode_143(), this.mComponent_330.cacheNode_183(), this.mComponent_323.cacheNode_107(), this.accessNode_65(), this.accessNode_284()));
+        }
+
+        Node_253 cacheNode_253() {
+          Object local = this.mNode_253Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_413.Companion.provides_693(this.mComponent_323.mSet_2, this.accessNode_53(), this.mComponent_330.cacheNode_191(), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_260(), this.mComponent_330.cacheNode_183(), this.mComponent_327.cacheNode_177(), this.mComponent_330.accessNode_263(), this.cacheNode_285(), this.accessNode_94(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.cacheNode_278(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.mComponent_330.mDependency_314.ep_0()));
+            this.mNode_253Instance = local;
+          }
+          return (Node_253) local;
+        }
+
+        Node_143 cacheNode_143() {
+          Object local = this.mNode_143Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_413.Companion.provides_694(new Node_109(this.accessNode_269(), this.mComponent_330.cacheNode_244(), new ProviderImpl(this, 5)), this.mComponent_327.mDependency_311.ep_0(), new ProviderImpl(this, 13), new ProviderImpl(this, 1), this.mComponent_323.cacheNode_254(), new Node_42(this.accessNode_272(), this.mComponent_330.cacheNode_244(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_28(), new ProviderImpl(this, 16), this.mComponent_327.cacheNode_16(), this.mComponent_323.cacheNode_257(), this.accessNode_96(), this.mComponent_327.mDependency_311.ep_3(), new ProviderImpl(this, 6), this.mComponent_330.cacheNode_147(), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_6(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_241(), new Component_330Impl.ProviderImpl(this.mComponent_330, 4), this.mComponent_327.mSet_1, this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_133()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.accessNode_65(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_17(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.cacheNode_293(), this.mComponent_330.cacheNode_191(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13)));
+            this.mNode_143Instance = local;
+          }
+          return (Node_143) local;
+        }
+
+        Node_234 cacheNode_234() {
+          Object local = this.mNode_234Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_413.Companion.provides_695(this.accessNode_125(), new ProviderImpl(this, 1), this.mComponent_323.cacheNode_107(), this.accessNode_79(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.accessNode_286(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_258(), this.accessNode_272(), this.mComponent_330.cacheNode_35(), this.mComponent_330.cacheNode_183(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 17), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_108()));
+            this.mNode_234Instance = local;
+          }
+          return (Node_234) local;
+        }
+
+        Node_284 accessNode_284() {
+          return Checks.checkProvisionNotNull(Module_413.Companion.provides_696(this.mComponent_330.cacheNode_217(), this.accessNode_280(), this.mComponent_323.cacheNode_262(), this.cacheNode_214(), this.cacheNode_186(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 16)));
+        }
+
+        Node_79 accessNode_79() {
+          return Checks.checkProvisionNotNull(Module_413.Companion.provides_697(this.accessNode_125(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new CachingProviderImpl(this, 12), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_11(), this.mComponent_330.cacheNode_110(), this.accessNode_94(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_241(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 7), this.accessNode_83(), this.accessNode_269(), this.mComponent_323.cacheNode_102(), this.cacheNode_143()));
+        }
+
+        Node_117 cacheNode_117() {
+          Object local = this.mNode_117Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_413.Companion.provides_698(this.accessNode_280(), new Component_330Impl.ProviderImpl(this.mComponent_330, 6), this.mComponent_323.accessNode_210(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.accessNode_15(), new ProviderImpl(this, 1), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_330.accessNode_308(), Checks.checkProvisionNotNull(Module_413.Companion.provides_701(this.mComponent_323.cacheNode_281(), this.mComponent_327.cacheNode_260(), this.mComponent_330.mDependency_314.ep_0(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 9), new CachingProviderImpl(this, 14), new ProviderImpl(this, 16), new ProviderImpl(this, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 2), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 8), this.mComponent_323.accessNode_210(), new ProviderImpl(this, 4), this.mComponent_330.cacheNode_183(), this.accessNode_269(), this.mComponent_330.cacheNode_191(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_257(), Checks.checkProvisionNotNull(Module_413.Companion.provides_702(this.mComponent_323.mDependency_310.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_330.accessNode_308(), this.mComponent_330.cacheNode_183(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), new ProviderImpl(this, 1), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_262(), this.mComponent_330.cacheNode_191(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.mComponent_327.cacheNode_33(), this.accessNode_83(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 1))), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), new ProviderImpl(this, 5), this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()))), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.cacheNode_186(), this.mComponent_323.cacheNode_107(), new Component_330Impl.ProviderImpl(this.mComponent_330, 10), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_260(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_262(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_244(), this.accessNode_53(), this.accessNode_222()));
+            this.mNode_117Instance = local;
+          }
+          return (Node_117) local;
+        }
+
+        Node_222 accessNode_222() {
+          return Checks.checkProvisionNotNull(Module_413.Companion.provides_699(this.mComponent_330.cacheNode_28(), this.mComponent_323.cacheNode_281()));
+        }
+
+        Node_269 accessNode_269() {
+          return Checks.checkProvisionNotNull(Module_413.Companion.provides_700(this.mComponent_327.cacheNode_293()));
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 15), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_330.cacheNode_183(), this.mComponent_323.accessNode_210(), this.accessNode_125());
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_231 accessNode_231() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_330.accessNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 11), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 15), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_330Impl.ProviderImpl(this.mComponent_330, 13), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_330.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9));
+        }
+
+        Node_258 cacheNode_258() {
+          Object local = this.mNode_258Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_258(this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_147(), this.mComponent_323.cacheNode_262(), this.accessNode_280(), this.accessNode_79(), this.accessNode_280(), this.mComponent_330.accessNode_145(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.accessNode_15(), this.cacheNode_143(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_330.cacheNode_230(), this.cacheNode_253(), this.mComponent_323.cacheNode_133());
+            this.mNode_258Instance = local;
+          }
+          return (Node_258) local;
+        }
+
+        Node_272 accessNode_272() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_330.accessNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+        }
+
+        Node_278 cacheNode_278() {
+          Object local = this.mNode_278Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_278(this.cacheNode_186(), this.mComponent_330.accessNode_263(), new CachingProviderImpl(this, 4), new ProviderImpl(this, 9), this.accessNode_269(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_323.accessNode_15(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.accessNode_125(), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1);
+            this.mNode_278Instance = local;
+          }
+          return (Node_278) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_285 cacheNode_285() {
+          Object local = this.mNode_285Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_285(this.mComponent_330.accessNode_145(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new ProviderImpl(this, 2), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.accessNode_96(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.accessNode_132());
+            this.mNode_285Instance = local;
+          }
+          return (Node_285) local;
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_53 accessNode_53() {
+          return new Node_53(this.mComponent_327.mDependency_311.ep_0(), this.accessNode_222(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_330.cacheNode_244(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new CachingProviderImpl(this, 4), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9), this.mComponent_327.cacheNode_293(), new ProviderImpl(this, 2), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_230(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+        }
+
+        Node_65 accessNode_65() {
+          return new Node_65(this.mComponent_330.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.mComponent_330.cacheNode_183());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 15));
+        }
+
+        Node_94 accessNode_94() {
+          return new Node_94(this.mComponent_330.accessNode_145(), this.accessNode_83(), this.mComponent_323.mDependency_310.ep_3(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.cacheNode_186(), this.mComponent_327.cacheNode_108(), this.accessNode_269(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_327.mSet_1, this.mComponent_330.mDependency_314.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_262(), this.mComponent_330.accessNode_303(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_192(), this.accessNode_280());
+        }
+
+        Node_96 accessNode_96() {
+          return new Node_96(new CachingProviderImpl(this, 10), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.mComponent_330.accessNode_105(), this.mComponent_327.cacheNode_16(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.mComponent_330.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.mComponent_330.accessNode_263(), this.mComponent_323.mSet_0);
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_339Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_339Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_339Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_339Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_339.Creator {
+          Component_327Impl fComponent_327;
+
+          Component_330Impl fComponent_330;
+
+          Yatagan$Component_323 fComponent_323;
+
+          private Node_165 mSet_0;
+
+          private Node_77 mSet_1;
+
+          ComponentFactoryImpl(Component_327Impl fComponent_327, Component_330Impl fComponent_330,
+              Yatagan$Component_323 fComponent_323) {
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_330 = fComponent_330;
+            this.fComponent_323 = fComponent_323;
+          }
+
+          @Override
+          public Component_339.Creator set_0(Node_165 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_339.Creator set_1(Node_77 i) {
+            this.mSet_1 = i;
+            return this;
+          }
+
+          @Override
+          public Component_339 create() {
+            return new Component_339Impl(this.fComponent_327, this.fComponent_330, this.fComponent_323, this.mSet_0, this.mSet_1);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_340Impl implements Component_340 {
+        private Object mNode_234Instance;
+
+        private Object mNode_236Instance;
+
+        private Object mNode_80Instance;
+
+        private Object mNode_222Instance;
+
+        private Object mNode_143Instance;
+
+        private Object mNode_194Instance;
+
+        private Object mNode_186Instance;
+
+        private Object mNode_258Instance;
+
+        private Object mNode_278Instance;
+
+        private Object mNode_282Instance;
+
+        private Object mNode_285Instance;
+
+        final Node_77 mSet_0;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_330Impl mComponent_330;
+
+        final Component_327Impl mComponent_327;
+
+        Component_340Impl(Yatagan$Component_323 pComponent_323, Component_330Impl pComponent_330,
+            Component_327Impl pComponent_327, Node_77 pSet_0) {
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_330 = pComponent_330;
+          this.mComponent_327 = pComponent_327;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        }
+
+        @Override
+        public Node_134 getGet_0() {
+          return this.mComponent_323.mSet_3;
+        }
+
+        @Override
+        public void inject_0(Injectee_379 i) {
+          i.setMember_0(this.accessNode_178());
+          i.setMember_1(this.mComponent_330.accessNode_145());
+          i.setMember_2(this.mComponent_323.mDependency_310.ep_2());
+          i.setMember_3(this.mComponent_327.cacheNode_241());
+          i.setMember_4(this.accessNode_53());
+          i.setMember_5(this.mComponent_327.cacheNode_177());
+          i.setMember_6(this.mComponent_330.mDependency_314.ep_0());
+        }
+
+        @Override
+        public void inject_1(Injectee_380 i) {
+          i.setMember_0(this.mComponent_323.cacheNode_262());
+          i.setMember_1(this.mComponent_330.cacheNode_191());
+          i.setMember_2(this.mComponent_323.cacheNode_257());
+          i.setMember_3(this.mComponent_330.cacheNode_217());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.accessNode_53();
+            case 1: return this.cacheNode_258();
+            case 2: return this.cacheNode_186();
+            case 3: return Checks.checkProvisionNotNull(Module_414.Companion.provides_706(this.mComponent_330.cacheNode_217(), this.accessNode_280(), this.mComponent_323.cacheNode_262(), this.accessNode_214(), this.cacheNode_186(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 16)));
+            case 4: return this.cacheNode_234();
+            case 5: return this.cacheNode_236();
+            case 6: return this.accessNode_253();
+            case 7: return this.accessNode_214();
+            case 8: return this.cacheNode_143();
+            case 9: return this.cacheNode_194();
+            case 10: return this.accessNode_286();
+            case 11: return this.mSet_0;
+            case 12: return this.cacheNode_278();
+            case 13: return this.accessNode_117();
+            case 14: return this.accessNode_142();
+            case 15: return this.accessNode_231();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_178 accessNode_178() {
+          return Checks.checkProvisionNotNull(Module_414.Companion.provides_705(this.mComponent_323.cacheNode_281(), this.mComponent_327.cacheNode_260(), this.mComponent_330.mDependency_314.ep_0(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 1), new CachingProviderImpl(this, 0), new ProviderImpl(this, 2), new ProviderImpl(this, 3), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 2), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 4), this.mComponent_323.accessNode_210(), new ProviderImpl(this, 5), this.mComponent_330.cacheNode_183(), this.accessNode_269(), this.mComponent_330.cacheNode_191(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_257(), this.cacheNode_80(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), new CachingProviderImpl(this, 6), this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547())));
+        }
+
+        Node_234 cacheNode_234() {
+          Object local = this.mNode_234Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_414.Companion.provides_707(this.accessNode_125(), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_107(), this.accessNode_79(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.accessNode_286(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_258(), this.accessNode_272(), this.mComponent_330.cacheNode_35(), this.mComponent_330.cacheNode_183(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 17), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_108()));
+            this.mNode_234Instance = local;
+          }
+          return (Node_234) local;
+        }
+
+        Node_236 cacheNode_236() {
+          Object local = this.mNode_236Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_414.Companion.provides_708(new ProviderImpl(this, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_330.accessNode_308(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_330.cacheNode_217(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_280(), this.mComponent_323.cacheNode_11(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.cacheNode_143(), this.mComponent_330.cacheNode_183(), this.mComponent_323.cacheNode_107(), this.accessNode_65(), new CachingProviderImpl(this, 3)));
+            this.mNode_236Instance = local;
+          }
+          return (Node_236) local;
+        }
+
+        Node_269 accessNode_269() {
+          return Checks.checkProvisionNotNull(Module_414.Companion.provides_709(this.mComponent_327.cacheNode_293()));
+        }
+
+        Node_80 cacheNode_80() {
+          Object local = this.mNode_80Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_414.Companion.provides_710(this.mComponent_323.mDependency_310.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_330.accessNode_308(), this.mComponent_330.cacheNode_183(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.cacheNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_262(), this.mComponent_330.cacheNode_191(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.mComponent_327.cacheNode_33(), this.accessNode_83(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 1)));
+            this.mNode_80Instance = local;
+          }
+          return (Node_80) local;
+        }
+
+        Node_253 accessNode_253() {
+          return Checks.checkProvisionNotNull(Module_414.Companion.provides_711(this.mComponent_323.mSet_2, this.accessNode_53(), this.mComponent_330.cacheNode_191(), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_260(), this.mComponent_330.cacheNode_183(), this.mComponent_327.cacheNode_177(), this.mComponent_330.accessNode_263(), this.cacheNode_285(), this.accessNode_94(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.cacheNode_278(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.mComponent_330.mDependency_314.ep_0()));
+        }
+
+        Node_222 cacheNode_222() {
+          Object local = this.mNode_222Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_414.Companion.provides_712(this.mComponent_330.cacheNode_28(), this.mComponent_323.cacheNode_281()));
+            this.mNode_222Instance = local;
+          }
+          return (Node_222) local;
+        }
+
+        Node_214 accessNode_214() {
+          return Checks.checkProvisionNotNull(Module_414.Companion.provides_713(this.mComponent_330.cacheNode_217(), this.mComponent_327.cacheNode_33(), this.cacheNode_282(), this.accessNode_253(), this.mComponent_323.cacheNode_107(), this.cacheNode_143(), new ProviderImpl(this, 12), this.cacheNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_254(), this.cacheNode_258(), this.accessNode_280()));
+        }
+
+        Node_79 accessNode_79() {
+          return Checks.checkProvisionNotNull(Module_414.Companion.provides_714(this.accessNode_125(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new CachingProviderImpl(this, 3), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_11(), this.mComponent_330.cacheNode_110(), this.accessNode_94(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_241(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 12), this.accessNode_83(), this.accessNode_269(), this.mComponent_323.cacheNode_102(), this.cacheNode_143()));
+        }
+
+        Node_143 cacheNode_143() {
+          Object local = this.mNode_143Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_414.Companion.provides_715(new Node_109(this.accessNode_269(), this.mComponent_330.cacheNode_244(), new CachingProviderImpl(this, 6)), this.mComponent_327.mDependency_311.ep_0(), new CachingProviderImpl(this, 13), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_254(), new Node_42(this.accessNode_272(), this.mComponent_330.cacheNode_244(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_28(), new ProviderImpl(this, 2), this.mComponent_327.cacheNode_16(), this.mComponent_323.cacheNode_257(), this.accessNode_96(), this.mComponent_327.mDependency_311.ep_3(), new ProviderImpl(this, 8), this.mComponent_330.cacheNode_147(), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_6(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_241(), new Component_330Impl.ProviderImpl(this.mComponent_330, 4), this.mComponent_327.mSet_1, this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_133()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.accessNode_65(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_17(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.cacheNode_293(), this.mComponent_330.cacheNode_191(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13)));
+            this.mNode_143Instance = local;
+          }
+          return (Node_143) local;
+        }
+
+        Node_194 cacheNode_194() {
+          Object local = this.mNode_194Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_414.Companion.provides_716(this.mComponent_330.cacheNode_35(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_293(), this.mComponent_323.accessNode_15(), this.mComponent_327.cacheNode_108(), this.mSet_0, new ProviderImpl(this, 5)));
+            this.mNode_194Instance = local;
+          }
+          return (Node_194) local;
+        }
+
+        Node_117 accessNode_117() {
+          return Checks.checkProvisionNotNull(Module_414.Companion.provides_717(this.accessNode_280(), new Component_330Impl.ProviderImpl(this.mComponent_330, 6), this.mComponent_323.accessNode_210(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.accessNode_15(), this.cacheNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_330.accessNode_308(), this.accessNode_178(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.cacheNode_186(), this.mComponent_323.cacheNode_107(), new Component_330Impl.ProviderImpl(this.mComponent_330, 10), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_260(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_262(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_244(), this.accessNode_53(), this.cacheNode_222()));
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 10), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_330.cacheNode_183(), this.mComponent_323.accessNode_210(), this.accessNode_125());
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_231 accessNode_231() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_330.accessNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 14), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 10), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_330Impl.ProviderImpl(this.mComponent_330, 13), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_330.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9));
+        }
+
+        Node_258 cacheNode_258() {
+          Object local = this.mNode_258Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_258(this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_147(), this.mComponent_323.cacheNode_262(), this.accessNode_280(), this.accessNode_79(), this.accessNode_280(), this.mComponent_330.accessNode_145(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.accessNode_15(), this.cacheNode_143(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_330.cacheNode_230(), this.accessNode_253(), this.mComponent_323.cacheNode_133());
+            this.mNode_258Instance = local;
+          }
+          return (Node_258) local;
+        }
+
+        Node_272 accessNode_272() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_330.accessNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+        }
+
+        Node_278 cacheNode_278() {
+          Object local = this.mNode_278Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_278(this.cacheNode_186(), this.mComponent_330.accessNode_263(), new ProviderImpl(this, 5), new ProviderImpl(this, 1), this.accessNode_269(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_323.accessNode_15(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.accessNode_125(), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1);
+            this.mNode_278Instance = local;
+          }
+          return (Node_278) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_282 cacheNode_282() {
+          Object local = this.mNode_282Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_282(new Component_330Impl.CachingProviderImpl(this.mComponent_330, 4), this.mComponent_327.cacheNode_16(), this.mComponent_330.accessNode_31(), this.accessNode_142(), this.mComponent_323.mSet_3, this.accessNode_83(), this.cacheNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new CachingProviderImpl(this, 3), this.mComponent_323.cacheNode_257(), this.accessNode_65(), this.accessNode_280(), this.accessNode_79(), this.mComponent_330.accessNode_303(), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new ProviderImpl(this, 5), this.mComponent_330.cacheNode_217(), this.mComponent_330.cacheNode_230(), this.accessNode_117(), this.mComponent_330.cacheNode_110(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.cacheNode_222());
+            this.mNode_282Instance = local;
+          }
+          return (Node_282) local;
+        }
+
+        Node_285 cacheNode_285() {
+          Object local = this.mNode_285Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_285(this.mComponent_330.accessNode_145(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 7), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.accessNode_96(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.accessNode_132());
+            this.mNode_285Instance = local;
+          }
+          return (Node_285) local;
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_53 accessNode_53() {
+          return new Node_53(this.mComponent_327.mDependency_311.ep_0(), this.cacheNode_222(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_330.cacheNode_244(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new ProviderImpl(this, 5), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 7), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_230(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+        }
+
+        Node_65 accessNode_65() {
+          return new Node_65(this.mComponent_330.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.mComponent_330.cacheNode_183());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 10));
+        }
+
+        Node_94 accessNode_94() {
+          return new Node_94(this.mComponent_330.accessNode_145(), this.accessNode_83(), this.mComponent_323.mDependency_310.ep_3(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.cacheNode_186(), this.mComponent_327.cacheNode_108(), this.accessNode_269(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_327.mSet_1, this.mComponent_330.mDependency_314.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_262(), this.mComponent_330.accessNode_303(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_192(), this.accessNode_280());
+        }
+
+        Node_96 accessNode_96() {
+          return new Node_96(new CachingProviderImpl(this, 15), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.mComponent_330.accessNode_105(), this.mComponent_327.cacheNode_16(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.mComponent_330.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.mComponent_330.accessNode_263(), this.mComponent_323.mSet_0);
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_340Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_340Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_340Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_340Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_340.Creator {
+          Yatagan$Component_323 fComponent_323;
+
+          Component_330Impl fComponent_330;
+
+          Component_327Impl fComponent_327;
+
+          private Node_77 mSet_0;
+
+          ComponentFactoryImpl(Yatagan$Component_323 fComponent_323,
+              Component_330Impl fComponent_330, Component_327Impl fComponent_327) {
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_330 = fComponent_330;
+            this.fComponent_327 = fComponent_327;
+          }
+
+          @Override
+          public Component_340.Creator set_0(Node_77 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_340 create() {
+            return new Component_340Impl(this.fComponent_323, this.fComponent_330, this.fComponent_327, this.mSet_0);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_341Impl implements Component_341 {
+        private Object mNode_222Instance;
+
+        private Object mNode_143Instance;
+
+        private Object mNode_284Instance;
+
+        private Object mNode_194Instance;
+
+        private Object mNode_79Instance;
+
+        private Object mNode_80Instance;
+
+        private Object mNode_186Instance;
+
+        private Object mNode_258Instance;
+
+        private Object mNode_278Instance;
+
+        private Object mNode_282Instance;
+
+        private Object mNode_285Instance;
+
+        private Object mNode_42Instance;
+
+        final Node_77 mSet_0;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_330Impl mComponent_330;
+
+        final Component_327Impl mComponent_327;
+
+        Component_341Impl(Yatagan$Component_323 pComponent_323, Component_330Impl pComponent_330,
+            Component_327Impl pComponent_327, Node_77 pSet_0) {
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_330 = pComponent_330;
+          this.mComponent_327 = pComponent_327;
+          this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        }
+
+        @Override
+        public Node_224 getGet_0() {
+          return this.mComponent_323.mDependency_310.ep_2();
+        }
+
+        @Override
+        public Lazy<Node_31> getGet_1() {
+          return new Component_330Impl.CachingProviderImpl(this.mComponent_330, 1);
+        }
+
+        @Override
+        public Node_257 getGet_2() {
+          return this.mComponent_323.cacheNode_257();
+        }
+
+        @Override
+        public Node_132 getGet_3() {
+          return this.accessNode_132();
+        }
+
+        @Override
+        public Provider<Node_142> getGet_4() {
+          return new ProviderImpl(this, 0);
+        }
+
+        @Override
+        public Provider<Node_130> getGet_5() {
+          return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9);
+        }
+
+        @Override
+        public Node_293 getGet_6() {
+          return this.mComponent_327.cacheNode_293();
+        }
+
+        @Override
+        public Provider<Node_85> getGet_7() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 4);
+        }
+
+        @Override
+        public Node_125 getGet_8() {
+          return this.accessNode_125();
+        }
+
+        @Override
+        public Provider<Node_288> getGet_9() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 17);
+        }
+
+        @Override
+        public void inject_0(Injectee_381 i) {
+          i.setMember_0(this.mComponent_323.mSet_3);
+          i.setMember_1(this.mComponent_330.mDependency_314.ep_1());
+          i.setMember_2(this.mComponent_323.mDependency_310.ep_1());
+          i.setMember_3(this.mComponent_323.cacheNode_133());
+          i.setMember_4(this.mComponent_330.accessNode_31());
+          i.setMember_5(new Node_163(new Component_330Impl.ProviderImpl(this.mComponent_330, 5), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_330.accessNode_145(), this.mComponent_330.accessNode_308(), this.accessNode_280(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 1), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), this.mComponent_323.mSet_3, this.accessNode_83(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_293()));
+          i.setMember_6(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()));
+          i.setMember_7(this.accessNode_53());
+          i.setMember_8(this.mComponent_330.cacheNode_191());
+          i.setMember_9(this.mComponent_327.mSet_0);
+        }
+
+        @Override
+        public void inject_1(Injectee_382 i) {
+          i.setMember_0(this.cacheNode_222());
+          i.setMember_1(this.mComponent_323.cacheNode_30());
+          i.setMember_2(this.mComponent_323.mSet_0);
+        }
+
+        @Override
+        public void inject_2(Injectee_383 i) {
+          i.setMember_0(this.cacheNode_42());
+          i.setMember_1(this.accessNode_96());
+          i.setMember_2(this.cacheNode_285());
+          i.setMember_3(this.mComponent_330.accessNode_145());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.accessNode_142();
+            case 1: return this.accessNode_53();
+            case 2: return this.accessNode_286();
+            case 3: return Checks.checkProvisionNotNull(Module_415.Companion.provides_721(new ProviderImpl(this, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 7), this.mComponent_330.accessNode_308(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_330.cacheNode_217(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.accessNode_280(), this.mComponent_323.cacheNode_11(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.cacheNode_143(), this.mComponent_330.cacheNode_183(), this.mComponent_323.cacheNode_107(), this.accessNode_65(), new ProviderImpl(this, 9)));
+            case 4: return this.accessNode_214();
+            case 5: return this.cacheNode_186();
+            case 6: return this.cacheNode_143();
+            case 7: return this.accessNode_231();
+            case 8: return this.mSet_0;
+            case 9: return this.cacheNode_284();
+            case 10: return this.accessNode_253();
+            case 11: return this.cacheNode_278();
+            case 12: return this.accessNode_234();
+            case 13: return this.cacheNode_258();
+            case 14: return this.cacheNode_194();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_222 cacheNode_222() {
+          Object local = this.mNode_222Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_415.Companion.provides_720(this.mComponent_330.cacheNode_28(), this.mComponent_323.cacheNode_281()));
+            this.mNode_222Instance = local;
+          }
+          return (Node_222) local;
+        }
+
+        Node_214 accessNode_214() {
+          return Checks.checkProvisionNotNull(Module_415.Companion.provides_722(this.mComponent_330.cacheNode_217(), this.mComponent_327.cacheNode_33(), this.cacheNode_282(), this.accessNode_253(), this.mComponent_323.cacheNode_107(), this.cacheNode_143(), new ProviderImpl(this, 11), this.accessNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_254(), this.cacheNode_258(), this.accessNode_280()));
+        }
+
+        Node_143 cacheNode_143() {
+          Object local = this.mNode_143Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_415.Companion.provides_723(new Node_109(this.accessNode_269(), this.mComponent_330.cacheNode_244(), new CachingProviderImpl(this, 10)), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_117(), this.cacheNode_194(), this.mComponent_323.cacheNode_254(), this.cacheNode_42(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.accessNode_65(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_17(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.cacheNode_293(), this.mComponent_330.cacheNode_191(), this.mComponent_323.mSet_0, this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13)));
+            this.mNode_143Instance = local;
+          }
+          return (Node_143) local;
+        }
+
+        Node_284 cacheNode_284() {
+          Object local = this.mNode_284Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_415.Companion.provides_724(this.mComponent_330.cacheNode_217(), this.accessNode_280(), this.mComponent_323.cacheNode_262(), this.accessNode_214(), this.cacheNode_186(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 16)));
+            this.mNode_284Instance = local;
+          }
+          return (Node_284) local;
+        }
+
+        Node_253 accessNode_253() {
+          return Checks.checkProvisionNotNull(Module_415.Companion.provides_725(this.mComponent_323.mSet_2, this.accessNode_53(), this.mComponent_330.cacheNode_191(), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_260(), this.mComponent_330.cacheNode_183(), this.mComponent_327.cacheNode_177(), this.mComponent_330.accessNode_263(), this.cacheNode_285(), this.accessNode_94(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.cacheNode_278(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.mComponent_330.mDependency_314.ep_0()));
+        }
+
+        Node_234 accessNode_234() {
+          return Checks.checkProvisionNotNull(Module_415.Companion.provides_726(this.accessNode_125(), this.cacheNode_194(), this.mComponent_323.cacheNode_107(), this.cacheNode_79(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.accessNode_286(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_258(), this.accessNode_272(), this.mComponent_330.cacheNode_35(), this.mComponent_330.cacheNode_183(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 17), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_108()));
+        }
+
+        Node_117 accessNode_117() {
+          return Checks.checkProvisionNotNull(Module_415.Companion.provides_727(this.accessNode_280(), new Component_330Impl.ProviderImpl(this.mComponent_330, 6), this.mComponent_323.accessNode_210(), this.mComponent_327.mDependency_311.ep_3(), this.mComponent_323.accessNode_15(), this.cacheNode_194(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_330.accessNode_308(), Checks.checkProvisionNotNull(Module_415.Companion.provides_731(this.mComponent_323.cacheNode_281(), this.mComponent_327.cacheNode_260(), this.mComponent_330.mDependency_314.ep_0(), this.mComponent_327.accessNode_185(), this.cacheNode_258(), new CachingProviderImpl(this, 1), new ProviderImpl(this, 5), new ProviderImpl(this, 9), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 2), this.mComponent_323.cacheNode_30(), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 12), this.mComponent_323.accessNode_210(), new ProviderImpl(this, 3), this.mComponent_330.cacheNode_183(), this.accessNode_269(), this.mComponent_330.cacheNode_191(), this.mComponent_323.cacheNode_107(), this.mComponent_323.cacheNode_257(), this.cacheNode_80(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 15), this.accessNode_253(), this.mComponent_323.cacheNode_262(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()))), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), this.cacheNode_186(), this.mComponent_323.cacheNode_107(), new Component_330Impl.ProviderImpl(this.mComponent_330, 10), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_260(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_262(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_244(), this.accessNode_53(), this.cacheNode_222()));
+        }
+
+        Node_194 cacheNode_194() {
+          Object local = this.mNode_194Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_415.Companion.provides_728(this.mComponent_330.cacheNode_35(), this.mComponent_327.cacheNode_16(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_293(), this.mComponent_323.accessNode_15(), this.mComponent_327.cacheNode_108(), this.mSet_0, new CachingProviderImpl(this, 3)));
+            this.mNode_194Instance = local;
+          }
+          return (Node_194) local;
+        }
+
+        Node_79 cacheNode_79() {
+          Object local = this.mNode_79Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_415.Companion.provides_729(this.accessNode_125(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new ProviderImpl(this, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.cacheNode_11(), this.mComponent_330.cacheNode_110(), this.accessNode_94(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_241(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_327.accessNode_185(), new ProviderImpl(this, 11), this.accessNode_83(), this.accessNode_269(), this.mComponent_323.cacheNode_102(), this.cacheNode_143()));
+            this.mNode_79Instance = local;
+          }
+          return (Node_79) local;
+        }
+
+        Node_269 accessNode_269() {
+          return Checks.checkProvisionNotNull(Module_415.Companion.provides_730(this.mComponent_327.cacheNode_293()));
+        }
+
+        Node_80 cacheNode_80() {
+          Object local = this.mNode_80Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_415.Companion.provides_732(this.mComponent_323.mDependency_310.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_330.accessNode_308(), this.mComponent_330.cacheNode_183(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), new ProviderImpl(this, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_262(), this.mComponent_330.cacheNode_191(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.mComponent_327.cacheNode_33(), this.accessNode_83(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 1)));
+            this.mNode_80Instance = local;
+          }
+          return (Node_80) local;
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 2), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_186 cacheNode_186() {
+          Object local = this.mNode_186Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_186(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_330.cacheNode_192(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_30(), this.mComponent_330.cacheNode_183(), this.mComponent_323.accessNode_210(), this.accessNode_125());
+            this.mNode_186Instance = local;
+          }
+          return (Node_186) local;
+        }
+
+        Node_231 accessNode_231() {
+          return new Node_231(this.mComponent_323.mSet_2, new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_330.accessNode_303(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 0), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 12), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 2), this.accessNode_132(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mDependency_310.ep_0(), new Component_330Impl.ProviderImpl(this.mComponent_330, 13), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.mSet_3, this.mComponent_330.cacheNode_244(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9));
+        }
+
+        Node_258 cacheNode_258() {
+          Object local = this.mNode_258Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_258(this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_147(), this.mComponent_323.cacheNode_262(), this.accessNode_280(), this.cacheNode_79(), this.accessNode_280(), this.mComponent_330.accessNode_145(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_323.accessNode_15(), this.cacheNode_143(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_330.cacheNode_230(), this.accessNode_253(), this.mComponent_323.cacheNode_133());
+            this.mNode_258Instance = local;
+          }
+          return (Node_258) local;
+        }
+
+        Node_272 accessNode_272() {
+          return new Node_272(this.mComponent_327.cacheNode_184(), this.mComponent_323.cacheNode_172(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_330.accessNode_303(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.accessNode_231(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_16(), this.accessNode_83());
+        }
+
+        Node_278 cacheNode_278() {
+          Object local = this.mNode_278Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_278(this.cacheNode_186(), this.mComponent_330.accessNode_263(), new CachingProviderImpl(this, 3), new ProviderImpl(this, 13), this.accessNode_269(), new Component_327Impl.ProviderImpl(this.mComponent_327, 4), this.mComponent_323.cacheNode_46(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_323.accessNode_15(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.accessNode_125(), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1);
+            this.mNode_278Instance = local;
+          }
+          return (Node_278) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_282 cacheNode_282() {
+          Object local = this.mNode_282Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_282(new Component_330Impl.CachingProviderImpl(this.mComponent_330, 4), this.mComponent_327.cacheNode_16(), this.mComponent_330.accessNode_31(), this.accessNode_142(), this.mComponent_323.mSet_3, this.accessNode_83(), this.accessNode_234(), this.mComponent_330.cacheNode_251(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_257(), this.accessNode_65(), this.accessNode_280(), this.cacheNode_79(), this.mComponent_330.accessNode_303(), this.mComponent_323.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new CachingProviderImpl(this, 3), this.mComponent_330.cacheNode_217(), this.mComponent_330.cacheNode_230(), this.accessNode_117(), this.mComponent_330.cacheNode_110(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.cacheNode_222());
+            this.mNode_282Instance = local;
+          }
+          return (Node_282) local;
+        }
+
+        Node_285 cacheNode_285() {
+          Object local = this.mNode_285Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_285(this.mComponent_330.accessNode_145(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 4), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_330.accessNode_303(), this.accessNode_96(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.accessNode_132());
+            this.mNode_285Instance = local;
+          }
+          return (Node_285) local;
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_42 cacheNode_42() {
+          Object local = this.mNode_42Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_42(this.accessNode_272(), this.mComponent_330.cacheNode_244(), this.mComponent_323.accessNode_15(), this.mComponent_330.cacheNode_28(), new ProviderImpl(this, 5), this.mComponent_327.cacheNode_16(), this.mComponent_323.cacheNode_257(), this.accessNode_96(), this.mComponent_327.mDependency_311.ep_3(), new ProviderImpl(this, 6), this.mComponent_330.cacheNode_147(), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_6(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_184(), this.mComponent_327.cacheNode_33(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_241(), new Component_330Impl.ProviderImpl(this.mComponent_330, 4), this.mComponent_327.mSet_1, this.mComponent_330.cacheNode_251(), this.mComponent_323.cacheNode_133());
+            this.mNode_42Instance = local;
+          }
+          return (Node_42) local;
+        }
+
+        Node_53 accessNode_53() {
+          return new Node_53(this.mComponent_327.mDependency_311.ep_0(), this.cacheNode_222(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_330.cacheNode_244(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new CachingProviderImpl(this, 3), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_177(), new Component_330Impl.ProviderImpl(this.mComponent_330, 9), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 4), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_230(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11));
+        }
+
+        Node_65 accessNode_65() {
+          return new Node_65(this.mComponent_330.accessNode_308(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_108(), this.mComponent_330.cacheNode_183());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 2));
+        }
+
+        Node_94 accessNode_94() {
+          return new Node_94(this.mComponent_330.accessNode_145(), this.accessNode_83(), this.mComponent_323.mDependency_310.ep_3(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 9), this.cacheNode_186(), this.mComponent_327.cacheNode_108(), this.accessNode_269(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 3), this.mComponent_327.mSet_1, this.mComponent_330.mDependency_314.ep_0(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_262(), this.mComponent_330.accessNode_303(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_330.accessNode_105(), this.mComponent_330.cacheNode_192(), this.accessNode_280());
+        }
+
+        Node_96 accessNode_96() {
+          return new Node_96(new CachingProviderImpl(this, 7), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.mComponent_330.accessNode_105(), this.mComponent_327.cacheNode_16(), new Component_330Impl.CachingProviderImpl(this.mComponent_330, 12), this.mComponent_330.cacheNode_230(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.accessNode_142(), this.accessNode_132(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_327.cacheNode_260(), this.mComponent_330.accessNode_263(), this.mComponent_323.mSet_0);
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_341Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_341Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_341Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_341Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_341.Creator {
+          Yatagan$Component_323 fComponent_323;
+
+          Component_330Impl fComponent_330;
+
+          Component_327Impl fComponent_327;
+
+          private Node_77 mSet_0;
+
+          ComponentFactoryImpl(Yatagan$Component_323 fComponent_323,
+              Component_330Impl fComponent_330, Component_327Impl fComponent_327) {
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_330 = fComponent_330;
+            this.fComponent_327 = fComponent_327;
+          }
+
+          @Override
+          public Component_341.Creator set_0(Node_77 i) {
+            this.mSet_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_341 create() {
+            return new Component_341Impl(this.fComponent_323, this.fComponent_330, this.fComponent_327, this.mSet_0);
+          }
+        }
+      }
+
+      static final class ProviderImpl implements Lazy {
+        private final Component_330Impl mDelegate;
+
+        private final int mIndex;
+
+        ProviderImpl(Component_330Impl delegate, int index) {
+          this.mDelegate = delegate;
+          this.mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          return this.mDelegate.switch$$access(this.mIndex);
+        }
+      }
+
+      private static final class CachingProviderImpl implements Lazy {
+        private final Component_330Impl mDelegate;
+
+        private final int mIndex;
+
+        private Object mValue;
+
+        CachingProviderImpl(Component_330Impl factory, int index) {
+          mDelegate = factory;
+          mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          Object local = mValue;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = mDelegate.switch$$access(mIndex);
+            mValue = local;
+          }
+          return local;
+        }
+      }
+
+      private static final class ComponentFactoryImpl implements Component_330.Creator {
+        Component_327Impl fComponent_327;
+
+        Yatagan$Component_323 fComponent_323;
+
+        private Dependency_314 mSetDep_0;
+
+        ComponentFactoryImpl(Component_327Impl fComponent_327,
+            Yatagan$Component_323 fComponent_323) {
+          this.fComponent_327 = fComponent_327;
+          this.fComponent_323 = fComponent_323;
+        }
+
+        @Override
+        public Component_330.Creator setDep_0(Dependency_314 i) {
+          this.mSetDep_0 = i;
+          return this;
+        }
+
+        @Override
+        public Component_330 create() {
+          return new Component_330Impl(this.fComponent_327, this.fComponent_323, this.mSetDep_0);
+        }
+      }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+    static final class Component_331Impl implements Component_331 {
+      private Object mNode_23Instance;
+
+      private Object mNode_116Instance;
+
+      private Object mNode_211Instance;
+
+      private Object mNode_247Instance;
+
+      private Object mNode_32Instance;
+
+      private Object mNode_131Instance;
+
+      private Object mNode_156Instance;
+
+      private Object mNode_181Instance;
+
+      private Object mNode_206Instance;
+
+      private Object mNode_29Instance;
+
+      private Object mNode_63Instance;
+
+      private Object mNode_64Instance;
+
+      private Object mNode_88Instance;
+
+      final Node_273 mSet_0;
+
+      final Node_299 mSet_1;
+
+      final Node_200 mSet_2;
+
+      final Node_207 mSet_3;
+
+      final Dependency_315 mDependency_315;
+
+      final Yatagan$Component_323 mComponent_323;
+
+      final Component_327Impl mComponent_327;
+
+      Component_331Impl(Yatagan$Component_323 pComponent_323, Component_327Impl pComponent_327,
+          Dependency_315 pSetDep_0, Node_273 pSet_0, Node_299 pSet_1, Node_200 pSet_2,
+          Node_207 pSet_3) {
+        this.mComponent_323 = pComponent_323;
+        this.mComponent_327 = pComponent_327;
+        this.mDependency_315 = Checks.checkInputNotNull(pSetDep_0);
+        this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+        this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+        this.mSet_2 = Checks.checkInputNotNull(pSet_2);
+        this.mSet_3 = Checks.checkInputNotNull(pSet_3);
+      }
+
+      @Override
+      public Component_342.Creator getChildCreator_0() {
+        return new Component_342Impl.ComponentFactoryImpl(this, this.mComponent_323, this.mComponent_327);
+      }
+
+      @Override
+      public Component_343.Creator getChildCreator_1() {
+        return new Component_343Impl.ComponentFactoryImpl(this.mComponent_323, this.mComponent_327, this);
+      }
+
+      @Override
+      public Node_130 getGet_0() {
+        return this.mComponent_323.mSet_2;
+      }
+
+      @Override
+      public Node_257 getGet_1() {
+        return this.mComponent_323.cacheNode_257();
+      }
+
+      @Override
+      public Provider<Node_223> getGet_2() {
+        return new ProviderImpl(this, 24);
+      }
+
+      @Override
+      public Node_306 getGet_3() {
+        return this.accessNode_274();
+      }
+
+      @Override
+      public Node_241 getGet_4() {
+        return this.mComponent_327.cacheNode_241();
+      }
+
+      @Override
+      public Node_193 getGet_5() {
+        return Checks.checkProvisionNotNull(Module_401.Companion.provides_550());
+      }
+
+      @Override
+      public Node_69 getGet_6() {
+        return this.mComponent_327.mSet_0;
+      }
+
+      @Override
+      public Node_197 getGet_7() {
+        return this.accessNode_197();
+      }
+
+      Object switch$$access(int slot) {
+        switch(slot) {
+          case 0: return this.mDependency_315.ep_0();
+          case 1: return this.cacheNode_29();
+          case 2: return this.cacheNode_116();
+          case 3: return this.cacheNode_211();
+          case 4: return this.accessNode_139();
+          case 5: return this.mSet_2;
+          case 6: return this.cacheNode_247();
+          case 7: return this.mSet_1;
+          case 8: return this.cacheNode_32();
+          case 9: return this.cacheNode_23();
+          case 10: return this.cacheNode_88();
+          case 11: return this.mSet_3;
+          case 12: return this.cacheNode_156();
+          case 13: return this.accessNode_73();
+          case 14: return this.cacheNode_206();
+          case 15: return this.accessNode_112();
+          case 16: return this.accessNode_170();
+          case 17: return this.mSet_0;
+          case 18: return this.accessNode_20();
+          case 19: return this.accessNode_274();
+          case 20: return this.cacheNode_131();
+          case 21: return this.accessNode_256();
+          case 22: return this.cacheNode_63();
+          case 23: return this.accessNode_74();
+          case 24: return this.accessNode_223();
+          case 25: return this.accessNode_197();
+          case 26: return this.accessNode_125();
+          case 27: return this.accessNode_280();
+          case 28: return this.accessNode_174();
+          case 29: return this.accessNode_286();
+          case 30: return this.accessNode_158();
+          case 31: return this.accessNode_83();
+          case 32: return this.accessNode_82();
+          case 33: return this.accessNode_245();
+          default: throw new AssertionError();
+        }
+      }
+
+      Node_23 cacheNode_23() {
+        Object local = this.mNode_23Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_405.Companion.provides_614(this.mComponent_327.mSet_0, this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_30(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 7), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), this.accessNode_82()));
+          this.mNode_23Instance = local;
+        }
+        return (Node_23) local;
+      }
+
+      Node_139 accessNode_139() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_615(this.accessNode_256(), this.accessNode_289(), new ProviderImpl(this, 3), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.accessNode_20(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 30), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.mComponent_323.mSet_1, this.mComponent_327.accessNode_185(), this.accessNode_74(), this.mComponent_327.cacheNode_33(), this.mComponent_323.mSet_2, this.accessNode_142(), this.mComponent_323.cacheNode_17()));
+      }
+
+      Node_20 accessNode_20() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_616(this.cacheNode_29(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_281(), this.cacheNode_29(), this.mComponent_323.mSet_1, this.mComponent_327.cacheNode_177(), new ProviderImpl(this, 27), this.accessNode_83(), this.mComponent_323.cacheNode_107(), this.accessNode_286(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.mComponent_327.mDependency_311.ep_1(), new ProviderImpl(this, 10), this.accessNode_112(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.cacheNode_102()));
+      }
+
+      Node_116 cacheNode_116() {
+        Object local = this.mNode_116Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_405.Companion.provides_617(this.mComponent_327.cacheNode_16(), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, new Component_327Impl.CachingProviderImpl(this.mComponent_327, 8), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 9), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_108(), this.cacheNode_88(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_46(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.accessNode_174(), this.accessNode_286(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mDependency_315.ep_0(), this.accessNode_256(), this.mComponent_327.mSet_0, new CachingProviderImpl(this, 4)));
+          this.mNode_116Instance = local;
+        }
+        return (Node_116) local;
+      }
+
+      Node_256 accessNode_256() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_618(new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.accessNode_280(), new CachingProviderImpl(this, 25), this.mComponent_323.cacheNode_254()));
+      }
+
+      Node_211 cacheNode_211() {
+        Object local = this.mNode_211Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_405.Companion.provides_619(this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_327.mSet_0, this.mComponent_323.mSet_1, this.accessNode_286(), this.mComponent_323.cacheNode_17(), this.mComponent_323.accessNode_15(), this.mComponent_323.mSet_0, this.mSet_0, this.mSet_1));
+          this.mNode_211Instance = local;
+        }
+        return (Node_211) local;
+      }
+
+      Node_74 accessNode_74() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_620(this.mComponent_323.mSet_3, new ProviderImpl(this, 25), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_327.cacheNode_241(), this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_254(), this.accessNode_174(), this.accessNode_20(), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_262(), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 19), this.mComponent_327.cacheNode_16(), this.mComponent_327.mSet_1, new ProviderImpl(this, 5)));
+      }
+
+      Node_73 accessNode_73() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_621(this.mComponent_323.cacheNode_46(), this.mComponent_327.mSet_1, this.accessNode_20()));
+      }
+
+      Node_259 accessNode_259() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_622(this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.accessNode_83(), this.mSet_2, this.accessNode_132(), this.mComponent_327.mSet_1, new CachingProviderImpl(this, 32)));
+      }
+
+      Node_112 accessNode_112() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_623(this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 20), this.cacheNode_211(), this.mComponent_327.cacheNode_293(), this.mComponent_327.cacheNode_108(), this.cacheNode_116(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_3()));
+      }
+
+      Node_170 accessNode_170() {
+        return Checks.checkProvisionNotNull(Module_405.Companion.provides_624(this.accessNode_132(), this.cacheNode_211(), this.mComponent_323.cacheNode_107(), this.mDependency_315.ep_0(), this.mComponent_327.mSet_0, new CachingProviderImpl(this, 27), this.mSet_3, new ProviderImpl(this, 12), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new ProviderImpl(this, 9), this.cacheNode_29(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.accessNode_158(), new ProviderImpl(this, 31), this.mComponent_327.mSet_1, this.mComponent_323.cacheNode_46(), this.cacheNode_63(), this.accessNode_142()));
+      }
+
+      Node_247 cacheNode_247() {
+        Object local = this.mNode_247Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_405.Companion.provides_625(this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_323.accessNode_15(), this.mSet_2, this.mComponent_323.cacheNode_17(), this.mComponent_323.cacheNode_254(), this.mComponent_323.cacheNode_257(), this.accessNode_289(), new CachingProviderImpl(this, 27), this.mComponent_327.cacheNode_184(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mSet_0, new CachingProviderImpl(this, 18), this.mComponent_327.cacheNode_260(), new Component_327Impl.ProviderImpl(this.mComponent_327, 0), this.cacheNode_64(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.cacheNode_63(), this.cacheNode_206(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, new CachingProviderImpl(this, 11), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_172(), this.mComponent_327.mDependency_311.ep_0()));
+          this.mNode_247Instance = local;
+        }
+        return (Node_247) local;
+      }
+
+      Node_32 cacheNode_32() {
+        Object local = this.mNode_32Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = Checks.checkProvisionNotNull(Module_405.Companion.provides_626(this.accessNode_286(), new CachingProviderImpl(this, 21), this.mComponent_323.accessNode_210(), this.accessNode_170(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.cacheNode_293(), new CachingProviderImpl(this, 19), this.mComponent_323.mDependency_310.ep_1()));
+          this.mNode_32Instance = local;
+        }
+        return (Node_32) local;
+      }
+
+      Node_125 accessNode_125() {
+        return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+      }
+
+      Node_131 cacheNode_131() {
+        Object local = this.mNode_131Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_131(this.accessNode_245(), this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.accessNode_256(), this.accessNode_170(), this.mComponent_323.cacheNode_102(), this.mComponent_323.cacheNode_46(), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.cacheNode_177(), this.accessNode_280(), new CachingProviderImpl(this, 30), new CachingProviderImpl(this, 13), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_172(), this.mComponent_327.cacheNode_16(), this.mComponent_323.accessNode_15(), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_289(), this.mSet_2, this.mComponent_327.cacheNode_33(), this.mComponent_323.mDependency_310.ep_2(), this.cacheNode_29(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), this.mComponent_327.cacheNode_241(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_262());
+          this.mNode_131Instance = local;
+        }
+        return (Node_131) local;
+      }
+
+      Node_132 accessNode_132() {
+        return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+      }
+
+      Node_142 accessNode_142() {
+        return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 29), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+      }
+
+      Node_156 cacheNode_156() {
+        Object local = this.mNode_156Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_156(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_3(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_327.cacheNode_241(), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_327.cacheNode_177(), this.mComponent_327.cacheNode_33(), new CachingProviderImpl(this, 15), this.mComponent_323.accessNode_210(), this.mComponent_327.accessNode_185(), this.mSet_0, this.accessNode_289(), new CachingProviderImpl(this, 5), new CachingProviderImpl(this, 21), this.accessNode_223(), this.mComponent_323.mSet_3, new CachingProviderImpl(this, 23), this.accessNode_174(), this.cacheNode_32(), this.mSet_1, this.mComponent_323.mDependency_310.ep_1(), this.accessNode_132(), this.mComponent_323.cacheNode_17());
+          this.mNode_156Instance = local;
+        }
+        return (Node_156) local;
+      }
+
+      Node_158 accessNode_158() {
+        return new Node_158(this.mComponent_327.cacheNode_293());
+      }
+
+      Node_174 accessNode_174() {
+        return new Node_174(new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new CachingProviderImpl(this, 4), new ProviderImpl(this, 9), this.mComponent_327.cacheNode_241(), this.mComponent_323.mDependency_310.ep_2(), new CachingProviderImpl(this, 25), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_88(), this.mSet_3, new ProviderImpl(this, 5), new CachingProviderImpl(this, 33), this.cacheNode_247(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_260(), this.cacheNode_32(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()));
+      }
+
+      Node_181 cacheNode_181() {
+        Object local = this.mNode_181Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_181(this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_241(), this.mComponent_327.accessNode_185(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.mSet_2, this.mComponent_323.mSet_3, this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_107(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()));
+          this.mNode_181Instance = local;
+        }
+        return (Node_181) local;
+      }
+
+      Node_197 accessNode_197() {
+        return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new ProviderImpl(this, 2), this.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_23(), this.mComponent_323.mSet_2, new ProviderImpl(this, 17), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+      }
+
+      Node_206 cacheNode_206() {
+        Object local = this.mNode_206Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_206(this.mComponent_327.mSet_0, new CachingProviderImpl(this, 13), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mSet_2, this.accessNode_259(), this.mComponent_327.mDependency_311.ep_0(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.cacheNode_281(), this.accessNode_286(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.accessNode_280(), this.cacheNode_29(), this.cacheNode_63(), this.mComponent_323.mSet_1, this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 9), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.cacheNode_181(), this.mComponent_327.cacheNode_108(), new CachingProviderImpl(this, 28), this.mComponent_327.cacheNode_16());
+          this.mNode_206Instance = local;
+        }
+        return (Node_206) local;
+      }
+
+      Node_223 accessNode_223() {
+        return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new ProviderImpl(this, 9), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 4), this.mComponent_323.mDependency_310.ep_3(), new ProviderImpl(this, 1), new ProviderImpl(this, 10), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.cacheNode_206(), new CachingProviderImpl(this, 19), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new CachingProviderImpl(this, 18), this.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+      }
+
+      Node_245 accessNode_245() {
+        return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.cacheNode_156(), new ProviderImpl(this, 2), this.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new ProviderImpl(this, 14), this.mSet_2, this.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 31));
+      }
+
+      Node_274 accessNode_274() {
+        return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 33), this.cacheNode_88(), this.mSet_0, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+      }
+
+      Node_280 accessNode_280() {
+        return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+      }
+
+      Node_286 accessNode_286() {
+        return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+      }
+
+      Node_289 accessNode_289() {
+        return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+      }
+
+      Node_29 cacheNode_29() {
+        Object local = this.mNode_29Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_29(this.mComponent_327.mDependency_311.ep_1(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.accessNode_142(), new CachingProviderImpl(this, 13), new CachingProviderImpl(this, 21), this.mComponent_327.cacheNode_241(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 15), new CachingProviderImpl(this, 27), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), this.cacheNode_63(), this.accessNode_132(), this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_241());
+          this.mNode_29Instance = local;
+        }
+        return (Node_29) local;
+      }
+
+      Node_63 cacheNode_63() {
+        Object local = this.mNode_63Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_63(this.accessNode_83(), this.accessNode_125(), this.mComponent_323.cacheNode_172(), this.mComponent_323.cacheNode_30(), this.mComponent_323.accessNode_15(), this.accessNode_286(), this.mSet_1, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_327.cacheNode_177(), this.mComponent_327.cacheNode_108(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mSet_1, this.mComponent_327.cacheNode_241());
+          this.mNode_63Instance = local;
+        }
+        return (Node_63) local;
+      }
+
+      Node_64 cacheNode_64() {
+        Object local = this.mNode_64Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_64(this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_254(), this.mComponent_327.cacheNode_184(), this.mComponent_323.accessNode_210(), this.accessNode_125(), new ProviderImpl(this, 6), new CachingProviderImpl(this, 33), this.mDependency_315.ep_0(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 12), this.mComponent_323.cacheNode_11(), this.mComponent_327.accessNode_185());
+          this.mNode_64Instance = local;
+        }
+        return (Node_64) local;
+      }
+
+      Node_82 accessNode_82() {
+        return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new ProviderImpl(this, 2), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 26), this.accessNode_245());
+      }
+
+      Node_83 accessNode_83() {
+        return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 29));
+      }
+
+      Node_88 cacheNode_88() {
+        Object local = this.mNode_88Instance;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = new Node_88(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), new CachingProviderImpl(this, 21), this.mComponent_323.mSet_3, this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_107(), this.accessNode_223(), new CachingProviderImpl(this, 33), this.mComponent_327.mSet_0, this.mComponent_323.mSet_2, this.cacheNode_29(), new Component_327Impl.ProviderImpl(this.mComponent_327, 6), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.accessNode_210(), new Component_327Impl.ProviderImpl(this.mComponent_327, 5), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_83(), this.cacheNode_29());
+          this.mNode_88Instance = local;
+        }
+        return (Node_88) local;
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_342Impl implements Component_342 {
+        private Object mNode_86Instance;
+
+        private Object mNode_167Instance;
+
+        private Object mNode_221Instance;
+
+        private Object mNode_218Instance;
+
+        private Object mNode_104Instance;
+
+        private Object mNode_136Instance;
+
+        private Object mNode_208Instance;
+
+        final Dependency_316 mDependency_316;
+
+        final Component_331Impl mComponent_331;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_327Impl mComponent_327;
+
+        Component_342Impl(Component_331Impl pComponent_331, Yatagan$Component_323 pComponent_323,
+            Component_327Impl pComponent_327, Dependency_316 pSetDep_0) {
+          this.mComponent_331 = pComponent_331;
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_327 = pComponent_327;
+          this.mDependency_316 = Checks.checkInputNotNull(pSetDep_0);
+        }
+
+        @Override
+        public Provider<Node_67> getGet_0() {
+          return new Component_331Impl.ProviderImpl(this.mComponent_331, 0);
+        }
+
+        @Override
+        public Node_46 getGet_1() {
+          return this.mComponent_323.cacheNode_46();
+        }
+
+        @Override
+        public Node_107 getGet_10() {
+          return this.mComponent_323.cacheNode_107();
+        }
+
+        @Override
+        public Lazy<Node_294> getGet_11() {
+          return new Component_327Impl.ProviderImpl(this.mComponent_327, 2);
+        }
+
+        @Override
+        public Node_108 getGet_2() {
+          return this.mComponent_327.cacheNode_108();
+        }
+
+        @Override
+        public Node_177 getGet_3() {
+          return this.mComponent_327.cacheNode_177();
+        }
+
+        @Override
+        public Node_25 getGet_4() {
+          return this.cacheNode_208();
+        }
+
+        @Override
+        public Node_62 getGet_5() {
+          return this.accessNode_62();
+        }
+
+        @Override
+        public Node_176 getGet_6() {
+          return this.mComponent_323.mSet_0;
+        }
+
+        @Override
+        public Node_184 getGet_7() {
+          return this.mComponent_327.cacheNode_184();
+        }
+
+        @Override
+        public Lazy<Node_188> getGet_8() {
+          return new CachingProviderImpl(this, 0);
+        }
+
+        @Override
+        public Node_195 getGet_9() {
+          return this.mComponent_327.mDependency_311.ep_0();
+        }
+
+        @Override
+        public void inject_0(Injectee_384 i) {
+          i.setMember_0(this.mComponent_331.cacheNode_29());
+        }
+
+        @Override
+        public void inject_1(Injectee_385 i) {
+          i.setMember_0(this.accessNode_174());
+          i.setMember_1(this.accessNode_245());
+          i.setMember_10(this.accessNode_286());
+          i.setMember_2(this.accessNode_286());
+          i.setMember_3(this.mComponent_327.mDependency_311.ep_0());
+          i.setMember_4(this.cacheNode_86());
+          i.setMember_5(this.cacheNode_208());
+          i.setMember_6(this.mComponent_323.accessNode_210());
+          i.setMember_7(this.cacheNode_136());
+          i.setMember_8(this.cacheNode_167());
+          i.setMember_9(this.mComponent_331.cacheNode_116());
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return new Node_188(this.mComponent_323.cacheNode_102(), this.accessNode_274(), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.accessNode_39(), this.accessNode_132(), this.accessNode_289(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.mSet_1, this.accessNode_142(), this.accessNode_197(), new CachingProviderImpl(this, 9), this.mComponent_331.cacheNode_32(), Checks.checkProvisionNotNull(Module_416.Companion.provides_742(this.accessNode_83(), this.mComponent_331.accessNode_139(), new Node_158(this.mComponent_327.cacheNode_293()), this.accessNode_125(), this.accessNode_132(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_323.cacheNode_172(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), new ProviderImpl(this, 9), this.accessNode_286(), this.mComponent_323.mSet_0, new ProviderImpl(this, 16), this.cacheNode_208(), this.accessNode_39())));
+            case 1: return this.accessNode_245();
+            case 2: return this.accessNode_286();
+            case 3: return this.cacheNode_86();
+            case 4: return this.cacheNode_136();
+            case 5: return this.cacheNode_167();
+            case 6: return this.accessNode_289();
+            case 7: return this.accessNode_274();
+            case 8: return this.accessNode_197();
+            case 9: return this.accessNode_280();
+            case 10: return this.accessNode_83();
+            case 11: return this.cacheNode_104();
+            case 12: return this.cacheNode_221();
+            case 13: return this.accessNode_82();
+            case 14: return this.accessNode_125();
+            case 15: return this.accessNode_19();
+            case 16: return this.accessNode_240();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_86 cacheNode_86() {
+          Object local = this.mNode_86Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_416.Companion.provides_739(this.mComponent_331.cacheNode_32(), this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 15), this.mComponent_327.accessNode_185(), this.mComponent_327.accessNode_185(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), new Component_331Impl.ProviderImpl(this.mComponent_331, 3), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.mComponent_327.mDependency_311.ep_0(), new ProviderImpl(this, 11), this.cacheNode_208(), this.mComponent_323.mSet_3, this.accessNode_39(), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_327.cacheNode_16(), this.mComponent_331.cacheNode_29(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_107(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_331.accessNode_112()));
+            this.mNode_86Instance = local;
+          }
+          return (Node_86) local;
+        }
+
+        Node_167 cacheNode_167() {
+          Object local = this.mNode_167Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_416.Companion.provides_740(this.mComponent_331.mSet_3, this.mComponent_327.mSet_0, this.mComponent_323.accessNode_15(), this.accessNode_83(), this.cacheNode_221(), this.mComponent_323.accessNode_15(), this.accessNode_132(), this.accessNode_280(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.mSet_1));
+            this.mNode_167Instance = local;
+          }
+          return (Node_167) local;
+        }
+
+        Node_39 accessNode_39() {
+          return Checks.checkProvisionNotNull(Module_416.Companion.provides_741(this.accessNode_82(), this.accessNode_62(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, this.accessNode_19(), this.mComponent_323.accessNode_15(), this.cacheNode_208(), this.mComponent_327.cacheNode_260(), this.mComponent_331.accessNode_73(), this.mComponent_331.accessNode_170(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 2), this.accessNode_245(), this.mComponent_331.accessNode_20(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 0), this.mComponent_323.accessNode_15(), this.mComponent_331.cacheNode_29(), this.mComponent_327.mSet_0, this.accessNode_125(), this.mComponent_331.cacheNode_247(), this.mComponent_327.cacheNode_108()));
+        }
+
+        Node_221 cacheNode_221() {
+          Object local = this.mNode_221Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_416.Companion.provides_743(this.accessNode_197(), this.mComponent_323.mDependency_310.ep_0(), new CachingProviderImpl(this, 0), this.mComponent_331.cacheNode_116()));
+            this.mNode_221Instance = local;
+          }
+          return (Node_221) local;
+        }
+
+        Node_240 accessNode_240() {
+          return Checks.checkProvisionNotNull(Module_416.Companion.provides_744(this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_260()));
+        }
+
+        Node_161 accessNode_161() {
+          return Checks.checkProvisionNotNull(Module_416.Companion.provides_746(this.mComponent_323.mSet_2, this.accessNode_280(), this.cacheNode_167(), this.accessNode_132(), new CachingProviderImpl(this, 8), this.mComponent_331.cacheNode_131(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), this.mComponent_323.cacheNode_257(), this.mComponent_331.cacheNode_29(), this.mComponent_323.mSet_1, new ProviderImpl(this, 3)));
+        }
+
+        Node_218 cacheNode_218() {
+          Object local = this.mNode_218Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_416.Companion.provides_747(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Node_275(this.accessNode_274(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_323.cacheNode_281(), this.accessNode_197(), this.accessNode_83(), this.cacheNode_136(), this.accessNode_223(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_260(), this.accessNode_280(), this.accessNode_174(), this.mComponent_327.mDependency_311.ep_1(), new Component_331Impl.ProviderImpl(this.mComponent_331, 16), new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new CachingProviderImpl(this, 15), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_161(), this.mComponent_327.mSet_1, this.cacheNode_208(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.cacheNode_211(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_323.cacheNode_11()), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 4), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_107(), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550())));
+            this.mNode_218Instance = local;
+          }
+          return (Node_218) local;
+        }
+
+        Node_104 cacheNode_104() {
+          Object local = this.mNode_104Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_104(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), Checks.checkProvisionNotNull(Module_416.Companion.provides_745(this.accessNode_132(), this.accessNode_223(), new ProviderImpl(this, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new ProviderImpl(this, 5), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), this.accessNode_240(), new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_241(), Checks.checkProvisionNotNull(Module_416.Companion.provides_748(this.accessNode_274(), this.mComponent_323.cacheNode_257())), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), this.cacheNode_136(), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.accessNode_197(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.cacheNode_257(), this.cacheNode_104())), this.accessNode_161(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 7), this.mComponent_327.accessNode_185(), this.accessNode_62(), this.mComponent_331.mDependency_315.ep_0(), this.accessNode_132(), this.mComponent_323.cacheNode_17(), this.mComponent_323.mDependency_310.ep_3());
+            this.mNode_104Instance = local;
+          }
+          return (Node_104) local;
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_136 cacheNode_136() {
+          Object local = this.mNode_136Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_136(this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_16(), new Node_302(), this.mComponent_331.cacheNode_23());
+            this.mNode_136Instance = local;
+          }
+          return (Node_136) local;
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 2), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_174 accessNode_174() {
+          return new Node_174(new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_327.cacheNode_241(), this.mComponent_323.mDependency_310.ep_2(), new CachingProviderImpl(this, 8), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_3, new Component_331Impl.ProviderImpl(this.mComponent_331, 5), new CachingProviderImpl(this, 1), this.mComponent_331.cacheNode_247(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_260(), this.mComponent_331.cacheNode_32(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()));
+        }
+
+        Node_19 accessNode_19() {
+          return new Node_19(this.mComponent_327.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 6), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_331.cacheNode_88(), this.mComponent_323.cacheNode_281(), this.accessNode_142(), this.accessNode_161(), this.mComponent_331.accessNode_139(), this.cacheNode_136(), new ProviderImpl(this, 3), this.mComponent_327.cacheNode_33(), this.mComponent_331.cacheNode_206(), new Node_302(), new ProviderImpl(this, 12), this.mComponent_323.mSet_2, this.mComponent_331.cacheNode_181(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_331.mDependency_315.ep_0(), this.cacheNode_218());
+        }
+
+        Node_197 accessNode_197() {
+          return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_23(), this.mComponent_323.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+        }
+
+        Node_208 cacheNode_208() {
+          Object local = this.mNode_208Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_208(this.mComponent_323.cacheNode_172(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_331.cacheNode_116(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Component_331Impl.ProviderImpl(this.mComponent_331, 3), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_327.cacheNode_108(), this.mComponent_331.accessNode_139(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_210(), this.mComponent_323.mDependency_310.ep_3(), new Node_302(), this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10));
+            this.mNode_208Instance = local;
+          }
+          return (Node_208) local;
+        }
+
+        Node_223 accessNode_223() {
+          return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.mDependency_310.ep_1(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 10), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), new CachingProviderImpl(this, 7), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 18), this.mComponent_331.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+        }
+
+        Node_245 accessNode_245() {
+          return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_331.cacheNode_156(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Component_331Impl.ProviderImpl(this.mComponent_331, 14), this.mComponent_331.mSet_2, this.mComponent_331.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 10));
+        }
+
+        Node_274 accessNode_274() {
+          return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_331.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 1), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_0, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_289 accessNode_289() {
+          return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+        }
+
+        Node_62 accessNode_62() {
+          return new Node_62(this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.accessNode_259(), this.mComponent_331.mSet_2, this.mComponent_331.mDependency_315.ep_0(), this.accessNode_289(), this.mComponent_331.cacheNode_247(), this.mComponent_331.cacheNode_29(), this.mComponent_331.cacheNode_29());
+        }
+
+        Node_82 accessNode_82() {
+          return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 14), this.accessNode_245());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 2));
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_342Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_342Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_342Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_342Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_342.Creator {
+          Component_331Impl fComponent_331;
+
+          Yatagan$Component_323 fComponent_323;
+
+          Component_327Impl fComponent_327;
+
+          private Dependency_316 mSetDep_0;
+
+          ComponentFactoryImpl(Component_331Impl fComponent_331,
+              Yatagan$Component_323 fComponent_323, Component_327Impl fComponent_327) {
+            this.fComponent_331 = fComponent_331;
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_327 = fComponent_327;
+          }
+
+          @Override
+          public Component_342.Creator setDep_0(Dependency_316 i) {
+            this.mSetDep_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_342 create() {
+            return new Component_342Impl(this.fComponent_331, this.fComponent_323, this.fComponent_327, this.mSetDep_0);
+          }
+        }
+      }
+
+      @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+      static final class Component_343Impl implements Component_343 {
+        private Object mNode_43Instance;
+
+        private Object mNode_39Instance;
+
+        private Object mNode_104Instance;
+
+        private Object mNode_128Instance;
+
+        private Object mNode_136Instance;
+
+        private Object mNode_208Instance;
+
+        private Object mNode_275Instance;
+
+        final Dependency_316 mDependency_316;
+
+        final Yatagan$Component_323 mComponent_323;
+
+        final Component_327Impl mComponent_327;
+
+        final Component_331Impl mComponent_331;
+
+        Component_343Impl(Yatagan$Component_323 pComponent_323, Component_327Impl pComponent_327,
+            Component_331Impl pComponent_331, Dependency_316 pSetDep_0) {
+          this.mComponent_323 = pComponent_323;
+          this.mComponent_327 = pComponent_327;
+          this.mComponent_331 = pComponent_331;
+          this.mDependency_316 = Checks.checkInputNotNull(pSetDep_0);
+        }
+
+        @Override
+        public Component_344.Creator getChildCreator_0() {
+          return new Component_344Impl.ComponentFactoryImpl(this, this.mComponent_323, this.mComponent_327, this.mComponent_331);
+        }
+
+        @Override
+        public Component_345.Creator getChildCreator_1() {
+          return new Component_345Impl.ComponentFactoryImpl(this.mComponent_323, this.mComponent_331, this.mComponent_327, this);
+        }
+
+        @Override
+        public Component_346.Creator getChildCreator_2() {
+          return new Component_346Impl.ComponentFactoryImpl(this.mComponent_331, this.mComponent_327, this.mComponent_323, this);
+        }
+
+        @Override
+        public Lazy<Node_300> getGet_0() {
+          return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5);
+        }
+
+        @Override
+        public Node_167 getGet_1() {
+          return this.accessNode_167();
+        }
+
+        @Override
+        public void inject_0(Injectee_386 i) {
+          i.setMember_0(this.cacheNode_275());
+          i.setMember_1(this.cacheNode_43());
+          i.setMember_2(this.accessNode_167());
+          i.setMember_3(this.mComponent_331.accessNode_20());
+          i.setMember_4(this.accessNode_280());
+          i.setMember_5(this.mComponent_327.mSet_1);
+          i.setMember_6(this.mComponent_331.cacheNode_116());
+        }
+
+        @Override
+        public void inject_1(Injectee_387 i) {
+          i.setMember_0(this.mComponent_323.accessNode_210());
+          i.setMember_1(this.mComponent_327.mSet_1);
+        }
+
+        Object switch$$access(int slot) {
+          switch(slot) {
+            case 0: return this.cacheNode_39();
+            case 1: return this.accessNode_167();
+            case 2: return this.accessNode_304();
+            case 3: return this.accessNode_86();
+            case 4: return this.accessNode_221();
+            case 5: return this.cacheNode_104();
+            case 6: return this.accessNode_240();
+            case 7: return this.cacheNode_136();
+            case 8: return this.accessNode_280();
+            case 9: return this.accessNode_82();
+            case 10: return this.accessNode_19();
+            case 11: return this.accessNode_286();
+            case 12: return this.accessNode_245();
+            case 13: return this.accessNode_125();
+            case 14: return this.accessNode_132();
+            case 15: return this.accessNode_83();
+            case 16: return this.accessNode_197();
+            case 17: return new Node_188(this.mComponent_323.cacheNode_102(), this.accessNode_274(), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.cacheNode_39(), this.accessNode_132(), this.accessNode_289(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.mSet_1, this.accessNode_142(), this.accessNode_197(), new CachingProviderImpl(this, 8), this.mComponent_331.cacheNode_32(), this.accessNode_304());
+            case 18: return this.accessNode_274();
+            case 19: return this.accessNode_289();
+            default: throw new AssertionError();
+          }
+        }
+
+        Node_167 accessNode_167() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_755(this.mComponent_331.mSet_3, this.mComponent_327.mSet_0, this.mComponent_323.accessNode_15(), this.accessNode_83(), this.accessNode_221(), this.mComponent_323.accessNode_15(), this.accessNode_132(), this.accessNode_280(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.mSet_1));
+        }
+
+        Node_43 cacheNode_43() {
+          Object local = this.mNode_43Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_417.Companion.provides_756(this.accessNode_274(), this.mComponent_323.cacheNode_257()));
+            this.mNode_43Instance = local;
+          }
+          return (Node_43) local;
+        }
+
+        Node_221 accessNode_221() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_757(this.accessNode_197(), this.mComponent_323.mDependency_310.ep_0(), new CachingProviderImpl(this, 17), this.mComponent_331.cacheNode_116()));
+        }
+
+        Node_161 accessNode_161() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_758(this.mComponent_323.mSet_2, this.accessNode_280(), this.accessNode_167(), this.accessNode_132(), new CachingProviderImpl(this, 16), this.mComponent_331.cacheNode_131(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), this.mComponent_323.cacheNode_257(), this.mComponent_331.cacheNode_29(), this.mComponent_323.mSet_1, new CachingProviderImpl(this, 3)));
+        }
+
+        Node_86 accessNode_86() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_759(this.mComponent_331.cacheNode_32(), this.mComponent_323.cacheNode_281(), this.accessNode_286(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 15), this.mComponent_327.accessNode_185(), this.mComponent_327.accessNode_185(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), new Component_331Impl.ProviderImpl(this.mComponent_331, 3), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.mComponent_327.mDependency_311.ep_0(), new ProviderImpl(this, 5), this.cacheNode_208(), this.mComponent_323.mSet_3, this.cacheNode_39(), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), this.mComponent_327.cacheNode_16(), this.mComponent_331.cacheNode_29(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_107(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_331.accessNode_112()));
+        }
+
+        Node_218 accessNode_218() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_760(new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.cacheNode_275(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_323.cacheNode_133(), new ProviderImpl(this, 7), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_107(), this.mComponent_323.accessNode_15(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550())));
+        }
+
+        Node_39 cacheNode_39() {
+          Object local = this.mNode_39Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = Checks.checkProvisionNotNull(Module_417.Companion.provides_761(this.accessNode_82(), this.accessNode_62(), this.mComponent_323.mSet_1, this.mComponent_323.mSet_2, this.accessNode_19(), this.mComponent_323.accessNode_15(), this.cacheNode_208(), this.mComponent_327.cacheNode_260(), this.mComponent_331.accessNode_73(), this.mComponent_331.accessNode_170(), this.mComponent_323.cacheNode_46(), new ProviderImpl(this, 11), this.accessNode_245(), this.mComponent_331.accessNode_20(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 0), this.mComponent_323.accessNode_15(), this.mComponent_331.cacheNode_29(), this.mComponent_327.mSet_0, this.accessNode_125(), this.mComponent_331.cacheNode_247(), this.mComponent_327.cacheNode_108()));
+            this.mNode_39Instance = local;
+          }
+          return (Node_39) local;
+        }
+
+        Node_304 accessNode_304() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_762(this.accessNode_83(), this.mComponent_331.accessNode_139(), new Node_158(this.mComponent_327.cacheNode_293()), this.accessNode_125(), this.accessNode_132(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_323.cacheNode_172(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 6), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), new ProviderImpl(this, 8), this.accessNode_286(), this.mComponent_323.mSet_0, new ProviderImpl(this, 6), this.cacheNode_208(), this.cacheNode_39()));
+        }
+
+        Node_240 accessNode_240() {
+          return Checks.checkProvisionNotNull(Module_417.Companion.provides_763(this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_260()));
+        }
+
+        Node_104 cacheNode_104() {
+          Object local = this.mNode_104Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_104(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), Checks.checkProvisionNotNull(Module_417.Companion.provides_764(this.accessNode_132(), this.accessNode_223(), new ProviderImpl(this, 12), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new ProviderImpl(this, 1), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 1), this.accessNode_240(), new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_241(), this.cacheNode_43(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), this.cacheNode_136(), this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_293(), this.accessNode_197(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.cacheNode_257(), new ProviderImpl(this, 5))), this.accessNode_161(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 7), this.mComponent_327.accessNode_185(), this.accessNode_62(), this.mComponent_331.mDependency_315.ep_0(), this.accessNode_132(), this.mComponent_323.cacheNode_17(), this.mComponent_323.mDependency_310.ep_3());
+            this.mNode_104Instance = local;
+          }
+          return (Node_104) local;
+        }
+
+        Node_125 accessNode_125() {
+          return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+        }
+
+        Node_128 cacheNode_128() {
+          Object local = this.mNode_128Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_128(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 20), new CachingProviderImpl(this, 14), this.accessNode_223(), this.accessNode_221(), new Component_327Impl.ProviderImpl(this.mComponent_327, 8), this.mComponent_331.accessNode_259(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.accessNode_185());
+            this.mNode_128Instance = local;
+          }
+          return (Node_128) local;
+        }
+
+        Node_132 accessNode_132() {
+          return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+        }
+
+        Node_136 cacheNode_136() {
+          Object local = this.mNode_136Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_136(this.mComponent_323.mDependency_310.ep_3(), this.mComponent_327.cacheNode_16(), new Node_302(), this.mComponent_331.cacheNode_23());
+            this.mNode_136Instance = local;
+          }
+          return (Node_136) local;
+        }
+
+        Node_142 accessNode_142() {
+          return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 11), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+        }
+
+        Node_19 accessNode_19() {
+          return new Node_19(this.mComponent_327.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 19), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_331.cacheNode_88(), this.mComponent_323.cacheNode_281(), this.accessNode_142(), this.accessNode_161(), this.mComponent_331.accessNode_139(), this.cacheNode_136(), new CachingProviderImpl(this, 3), this.mComponent_327.cacheNode_33(), this.mComponent_331.cacheNode_206(), new Node_302(), new ProviderImpl(this, 4), this.mComponent_323.mSet_2, this.mComponent_331.cacheNode_181(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_331.mDependency_315.ep_0(), this.accessNode_218());
+        }
+
+        Node_197 accessNode_197() {
+          return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_23(), this.mComponent_323.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+        }
+
+        Node_208 cacheNode_208() {
+          Object local = this.mNode_208Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_208(this.mComponent_323.cacheNode_172(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 18), this.mComponent_331.cacheNode_116(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Component_331Impl.ProviderImpl(this.mComponent_331, 3), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_327.cacheNode_108(), this.mComponent_331.accessNode_139(), this.mComponent_327.accessNode_185(), this.mComponent_323.accessNode_210(), this.mComponent_323.mDependency_310.ep_3(), new Node_302(), this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10));
+            this.mNode_208Instance = local;
+          }
+          return (Node_208) local;
+        }
+
+        Node_223 accessNode_223() {
+          return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.mDependency_310.ep_1(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 10), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), new CachingProviderImpl(this, 18), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 18), this.mComponent_331.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+        }
+
+        Node_245 accessNode_245() {
+          return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_331.cacheNode_156(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Component_331Impl.ProviderImpl(this.mComponent_331, 14), this.mComponent_331.mSet_2, this.mComponent_331.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 15));
+        }
+
+        Node_274 accessNode_274() {
+          return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_331.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 12), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_0, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+        }
+
+        Node_275 cacheNode_275() {
+          Object local = this.mNode_275Instance;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = new Node_275(this.accessNode_274(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_323.cacheNode_281(), this.accessNode_197(), this.accessNode_83(), this.cacheNode_136(), this.accessNode_223(), this.mComponent_323.cacheNode_46(), this.mComponent_327.cacheNode_260(), this.accessNode_280(), new Node_174(new Component_327Impl.ProviderImpl(this.mComponent_327, 0), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_327.cacheNode_241(), this.mComponent_323.mDependency_310.ep_2(), new CachingProviderImpl(this, 16), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_3, new Component_331Impl.ProviderImpl(this.mComponent_331, 5), new CachingProviderImpl(this, 12), this.mComponent_331.cacheNode_247(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_260(), this.mComponent_331.cacheNode_32(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554())), this.mComponent_327.mDependency_311.ep_1(), new Component_331Impl.ProviderImpl(this.mComponent_331, 16), new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new CachingProviderImpl(this, 10), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_161(), this.mComponent_327.mSet_1, this.cacheNode_208(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.cacheNode_211(), new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.mComponent_323.cacheNode_11());
+            this.mNode_275Instance = local;
+          }
+          return (Node_275) local;
+        }
+
+        Node_280 accessNode_280() {
+          return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+        }
+
+        Node_286 accessNode_286() {
+          return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+        }
+
+        Node_289 accessNode_289() {
+          return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+        }
+
+        Node_62 accessNode_62() {
+          return new Node_62(this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.accessNode_259(), this.mComponent_331.mSet_2, this.mComponent_331.mDependency_315.ep_0(), this.accessNode_289(), this.mComponent_331.cacheNode_247(), this.mComponent_331.cacheNode_29(), this.mComponent_331.cacheNode_29());
+        }
+
+        Node_82 accessNode_82() {
+          return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 13), this.accessNode_245());
+        }
+
+        Node_83 accessNode_83() {
+          return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 11));
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+        static final class Component_344Impl implements Component_344 {
+          private Object mNode_150Instance;
+
+          private Object mNode_203Instance;
+
+          private Object mNode_12Instance;
+
+          private Object mNode_151Instance;
+
+          private Object mNode_154Instance;
+
+          private Object mNode_264Instance;
+
+          private Object mNode_49Instance;
+
+          final Node_22 mSet_0;
+
+          final Node_38 mSet_1;
+
+          final Component_343Impl mComponent_343;
+
+          final Yatagan$Component_323 mComponent_323;
+
+          final Component_327Impl mComponent_327;
+
+          final Component_331Impl mComponent_331;
+
+          Component_344Impl(Component_343Impl pComponent_343, Yatagan$Component_323 pComponent_323,
+              Component_327Impl pComponent_327, Component_331Impl pComponent_331, Node_22 pSet_0,
+              Node_38 pSet_1) {
+            this.mComponent_343 = pComponent_343;
+            this.mComponent_323 = pComponent_323;
+            this.mComponent_327 = pComponent_327;
+            this.mComponent_331 = pComponent_331;
+            this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+            this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+          }
+
+          @Override
+          public Lazy<Node_12> getGet_0() {
+            return new ProviderImpl(this, 0);
+          }
+
+          @Override
+          public Node_39 getGet_1() {
+            return this.mComponent_343.cacheNode_39();
+          }
+
+          @Override
+          public Node_224 getGet_10() {
+            return this.mComponent_323.mDependency_310.ep_2();
+          }
+
+          @Override
+          public Node_286 getGet_11() {
+            return this.accessNode_286();
+          }
+
+          @Override
+          public Node_17 getGet_2() {
+            return this.mComponent_323.cacheNode_17();
+          }
+
+          @Override
+          public Node_254 getGet_3() {
+            return this.mComponent_323.cacheNode_254();
+          }
+
+          @Override
+          public Provider<Node_11> getGet_4() {
+            return new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4);
+          }
+
+          @Override
+          public Provider<Node_237> getGet_5() {
+            return new ProviderImpl(this, 1);
+          }
+
+          @Override
+          public Lazy<Node_184> getGet_6() {
+            return new Component_327Impl.ProviderImpl(this.mComponent_327, 13);
+          }
+
+          @Override
+          public Node_128 getGet_7() {
+            return this.mComponent_343.cacheNode_128();
+          }
+
+          @Override
+          public Node_27 getGet_8() {
+            return this.mComponent_323.mDependency_310.ep_0();
+          }
+
+          @Override
+          public Node_156 getGet_9() {
+            return this.mComponent_331.cacheNode_156();
+          }
+
+          @Override
+          public void inject_0(Injectee_388 i) {
+            i.setMember_0(this.mComponent_343.accessNode_167());
+            i.setMember_1(this.mComponent_323.cacheNode_17());
+          }
+
+          @Override
+          public void inject_1(Injectee_389 i) {
+            i.setMember_0(this.mComponent_323.cacheNode_107());
+            i.setMember_1(this.mComponent_331.accessNode_256());
+            i.setMember_10(this.cacheNode_150());
+            i.setMember_2(this.mComponent_343.accessNode_304());
+            i.setMember_3(this.mComponent_343.accessNode_86());
+            i.setMember_4(this.mComponent_323.mSet_0);
+            i.setMember_5(this.mComponent_323.mSet_1);
+            i.setMember_6(this.accessNode_188());
+            i.setMember_7(this.mComponent_331.mSet_1);
+            i.setMember_8(this.mComponent_323.mDependency_310.ep_0());
+            i.setMember_9(this.accessNode_280());
+          }
+
+          Object switch$$access(int slot) {
+            switch(slot) {
+              case 0: return this.cacheNode_12();
+              case 1: return this.accessNode_237();
+              case 2: return this.accessNode_286();
+              case 3: return this.accessNode_280();
+              case 4: return this.cacheNode_150();
+              case 5: return this.accessNode_93();
+              case 6: return this.accessNode_215();
+              case 7: return this.accessNode_125();
+              case 8: return this.accessNode_83();
+              case 9: return this.cacheNode_264();
+              case 10: return this.mSet_0;
+              case 11: return this.accessNode_274();
+              case 12: return this.accessNode_132();
+              case 13: return this.accessNode_289();
+              case 14: return this.accessNode_142();
+              case 15: return this.cacheNode_151();
+              case 16: return this.accessNode_61();
+              case 17: return new Node_302();
+              case 18: return this.cacheNode_49();
+              case 19: return this.accessNode_245();
+              case 20: return Checks.checkProvisionNotNull(Module_418.Companion.provides_778(this.mComponent_323.accessNode_15(), this.accessNode_197(), this.mComponent_331.cacheNode_29(), this.accessNode_93(), this.mSet_1, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), new ProviderImpl(this, 4), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_331.accessNode_73(), this.accessNode_245()));
+              default: throw new AssertionError();
+            }
+          }
+
+          Node_237 accessNode_237() {
+            return Checks.checkProvisionNotNull(Module_418.Companion.provides_771(this.mComponent_331.cacheNode_156(), this.mComponent_331.cacheNode_64(), new ProviderImpl(this, 7), this.mComponent_323.cacheNode_172(), this.accessNode_83(), this.mComponent_327.cacheNode_184(), this.mComponent_331.mDependency_315.ep_0(), new Component_331Impl.ProviderImpl(this.mComponent_331, 22), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 13), this.cacheNode_264(), this.mSet_0, this.mComponent_327.mDependency_311.ep_0(), new Component_343Impl.ProviderImpl(this.mComponent_343, 0), this.mComponent_323.cacheNode_30()));
+          }
+
+          Node_150 cacheNode_150() {
+            Object local = this.mNode_150Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_418.Companion.provides_772(this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.accessNode_91(), this.accessNode_280(), this.accessNode_289(), this.cacheNode_151(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2)));
+              this.mNode_150Instance = local;
+            }
+            return (Node_150) local;
+          }
+
+          Node_226 accessNode_226() {
+            return Checks.checkProvisionNotNull(Module_418.Companion.provides_773(this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 6), this.mComponent_343.cacheNode_275(), this.mComponent_343.accessNode_304(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.mSet_2, this.mComponent_331.accessNode_259(), this.mComponent_323.mSet_3, this.mComponent_343.accessNode_240(), this.mSet_0, this.mComponent_331.accessNode_74(), this.mComponent_323.accessNode_210(), this.accessNode_158(), this.accessNode_188(), this.accessNode_289(), new ProviderImpl(this, 17)));
+          }
+
+          Node_215 accessNode_215() {
+            return Checks.checkProvisionNotNull(Module_418.Companion.provides_775(this.mComponent_343.cacheNode_208(), this.cacheNode_49()));
+          }
+
+          Node_91 accessNode_91() {
+            return Checks.checkProvisionNotNull(Module_418.Companion.provides_776(this.mComponent_323.mSet_2, this.mComponent_327.mDependency_311.ep_1(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_323.mSet_0, new Component_343Impl.ProviderImpl(this.mComponent_343, 1), new ProviderImpl(this, 18), this.mComponent_323.accessNode_15(), new ProviderImpl(this, 9), this.mComponent_323.cacheNode_102(), this.mComponent_323.cacheNode_30(), this.mComponent_331.accessNode_112(), this.mComponent_331.accessNode_139(), this.mComponent_331.cacheNode_206(), this.accessNode_82(), this.mComponent_331.accessNode_74(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 5), new ProviderImpl(this, 2), this.mComponent_343.cacheNode_208(), this.mComponent_323.cacheNode_133(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 15), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_16(), this.mComponent_331.cacheNode_156(), this.mComponent_323.cacheNode_11(), this.accessNode_132()));
+          }
+
+          Node_203 cacheNode_203() {
+            Object local = this.mNode_203Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_418.Companion.provides_777(new Component_331Impl.CachingProviderImpl(this.mComponent_331, 15), this.mComponent_327.cacheNode_260(), this.mComponent_331.accessNode_73(), this.mComponent_331.cacheNode_206(), this.mComponent_343.cacheNode_275(), this.mComponent_331.cacheNode_29(), this.mComponent_343.cacheNode_136(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_331.accessNode_170(), this.mSet_1, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.mComponent_327.cacheNode_177(), this.accessNode_19(), this.accessNode_188(), this.mComponent_323.mDependency_310.ep_3()));
+              this.mNode_203Instance = local;
+            }
+            return (Node_203) local;
+          }
+
+          Node_12 cacheNode_12() {
+            Object local = this.mNode_12Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_12(new Component_343Impl.ProviderImpl(this.mComponent_343, 4), this.mComponent_323.cacheNode_262(), new Component_331Impl.ProviderImpl(this.mComponent_331, 8), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_323.cacheNode_30(), this.mComponent_331.cacheNode_247(), new ProviderImpl(this, 5), this.accessNode_226(), this.mComponent_327.cacheNode_184(), Checks.checkProvisionNotNull(Module_418.Companion.provides_774(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.accessNode_15(), this.mComponent_331.mDependency_315.ep_0(), new Node_302(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_177(), this.mComponent_323.mDependency_310.ep_3(), this.accessNode_91(), this.mComponent_331.mSet_2, this.accessNode_166(), this.mComponent_327.cacheNode_108())), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.mComponent_343.cacheNode_43(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_256(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_327.cacheNode_241(), this.mComponent_331.mDependency_315.ep_0(), new CachingProviderImpl(this, 6), new ProviderImpl(this, 4), this.mComponent_323.cacheNode_17(), this.accessNode_280());
+              this.mNode_12Instance = local;
+            }
+            return (Node_12) local;
+          }
+
+          Node_125 accessNode_125() {
+            return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+          }
+
+          Node_132 accessNode_132() {
+            return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+          }
+
+          Node_142 accessNode_142() {
+            return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 2), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+          }
+
+          Node_151 cacheNode_151() {
+            Object local = this.mNode_151Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_151(this.mComponent_327.cacheNode_184(), new Component_343Impl.ProviderImpl(this.mComponent_343, 2), new CachingProviderImpl(this, 20), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_133());
+              this.mNode_151Instance = local;
+            }
+            return (Node_151) local;
+          }
+
+          Node_154 cacheNode_154() {
+            Object local = this.mNode_154Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_154(this.accessNode_83());
+              this.mNode_154Instance = local;
+            }
+            return (Node_154) local;
+          }
+
+          Node_158 accessNode_158() {
+            return new Node_158(this.mComponent_327.cacheNode_293());
+          }
+
+          Node_166 accessNode_166() {
+            return new Node_166(this.accessNode_125(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new CachingProviderImpl(this, 1), this.mComponent_323.accessNode_15(), new Node_302(), this.accessNode_83(), this.mComponent_331.cacheNode_88(), this.mComponent_331.cacheNode_63(), this.mComponent_331.cacheNode_131(), new ProviderImpl(this, 3), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_107(), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_17(), this.accessNode_61(), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_257(), this.mComponent_331.accessNode_259(), this.accessNode_82(), this.mComponent_323.mSet_3, this.mComponent_331.mSet_0, this.mComponent_323.cacheNode_17(), new ProviderImpl(this, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.cacheNode_30(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_17());
+          }
+
+          Node_188 accessNode_188() {
+            return new Node_188(this.mComponent_323.cacheNode_102(), this.accessNode_274(), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.mComponent_343.cacheNode_39(), this.accessNode_132(), this.accessNode_289(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.mSet_1, this.accessNode_142(), this.accessNode_197(), new CachingProviderImpl(this, 3), this.mComponent_331.cacheNode_32(), this.mComponent_343.accessNode_304());
+          }
+
+          Node_19 accessNode_19() {
+            return new Node_19(this.mComponent_327.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 13), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_331.cacheNode_88(), this.mComponent_323.cacheNode_281(), this.accessNode_142(), this.mComponent_343.accessNode_161(), this.mComponent_331.accessNode_139(), this.mComponent_343.cacheNode_136(), new Component_343Impl.CachingProviderImpl(this.mComponent_343, 3), this.mComponent_327.cacheNode_33(), this.mComponent_331.cacheNode_206(), new Node_302(), new Component_343Impl.ProviderImpl(this.mComponent_343, 4), this.mComponent_323.mSet_2, this.mComponent_331.cacheNode_181(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_343.accessNode_218());
+          }
+
+          Node_197 accessNode_197() {
+            return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_23(), this.mComponent_323.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+          }
+
+          Node_223 accessNode_223() {
+            return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.mDependency_310.ep_1(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 10), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), new CachingProviderImpl(this, 11), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 18), this.mComponent_331.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+          }
+
+          Node_245 accessNode_245() {
+            return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_331.cacheNode_156(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Component_331Impl.ProviderImpl(this.mComponent_331, 14), this.mComponent_331.mSet_2, this.mComponent_331.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 8));
+          }
+
+          Node_264 cacheNode_264() {
+            Object local = this.mNode_264Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_264(this.mComponent_331.cacheNode_131(), new Component_343Impl.ProviderImpl(this.mComponent_343, 5), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), Checks.checkProvisionNotNull(Module_418.Companion.provides_779(this.mComponent_327.accessNode_185(), this.mComponent_331.mDependency_315.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.cacheNode_12(), new CachingProviderImpl(this, 11), this.mComponent_331.accessNode_20(), this.accessNode_166(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_257(), new Component_343Impl.ProviderImpl(this.mComponent_343, 0), Checks.checkProvisionNotNull(Module_418.Companion.provides_780(this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_203(), this.mComponent_331.mSet_3, new CachingProviderImpl(this, 17), new ProviderImpl(this, 10), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_323.accessNode_15(), this.mComponent_343.accessNode_218(), this.mComponent_327.accessNode_185(), this.mComponent_331.mSet_2, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.accessNode_83(), this.mComponent_327.cacheNode_241(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_331.accessNode_73(), this.accessNode_274(), this.accessNode_19(), this.accessNode_166(), this.accessNode_158(), this.mComponent_323.cacheNode_257(), this.accessNode_142(), this.mComponent_331.accessNode_20(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3))), this.mComponent_323.cacheNode_107(), new ProviderImpl(this, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_343.accessNode_86(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_116(), this.accessNode_142())), this.accessNode_197(), this.mComponent_331.accessNode_259());
+              this.mNode_264Instance = local;
+            }
+            return (Node_264) local;
+          }
+
+          Node_274 accessNode_274() {
+            return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_331.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 19), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_0, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+          }
+
+          Node_280 accessNode_280() {
+            return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+          }
+
+          Node_286 accessNode_286() {
+            return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+          }
+
+          Node_289 accessNode_289() {
+            return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+          }
+
+          Node_49 cacheNode_49() {
+            Object local = this.mNode_49Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_49(this.mComponent_343.cacheNode_208(), new Component_327Impl.ProviderImpl(this.mComponent_327, 7), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_33(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), this.mComponent_343.cacheNode_275(), this.cacheNode_154(), this.accessNode_286(), new CachingProviderImpl(this, 12), this.accessNode_237(), this.mComponent_331.cacheNode_206(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_331.cacheNode_156(), this.accessNode_61());
+              this.mNode_49Instance = local;
+            }
+            return (Node_49) local;
+          }
+
+          Node_61 accessNode_61() {
+            return new Node_61(this.mComponent_323.mSet_2, this.mComponent_343.accessNode_221(), this.mComponent_323.mSet_0);
+          }
+
+          Node_82 accessNode_82() {
+            return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 7), this.accessNode_245());
+          }
+
+          Node_83 accessNode_83() {
+            return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 2));
+          }
+
+          Node_93 accessNode_93() {
+            return new Node_93(this.accessNode_132(), this.cacheNode_203(), this.accessNode_226(), this.accessNode_215(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.mSet_0, new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.cacheNode_154(), this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 16), this.mComponent_323.accessNode_210(), this.mComponent_343.accessNode_221(), this.accessNode_223(), this.accessNode_83(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.accessNode_280(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_331.cacheNode_211(), this.mComponent_331.mSet_1, this.accessNode_125(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_331.mSet_3, this.mComponent_343.cacheNode_104(), this.mComponent_331.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 8), this.mComponent_327.cacheNode_260(), this.mComponent_327.mDependency_311.ep_0());
+          }
+
+          static final class ProviderImpl implements Lazy {
+            private final Component_344Impl mDelegate;
+
+            private final int mIndex;
+
+            ProviderImpl(Component_344Impl delegate, int index) {
+              this.mDelegate = delegate;
+              this.mIndex = index;
+            }
+
+            @Override
+            public Object get() {
+              return this.mDelegate.switch$$access(this.mIndex);
+            }
+          }
+
+          private static final class CachingProviderImpl implements Lazy {
+            private final Component_344Impl mDelegate;
+
+            private final int mIndex;
+
+            private Object mValue;
+
+            CachingProviderImpl(Component_344Impl factory, int index) {
+              mDelegate = factory;
+              mIndex = index;
+            }
+
+            @Override
+            public Object get() {
+              Object local = mValue;
+              if (local == null) {
+                ThreadAssertions.assertThreadAccess();
+                local = mDelegate.switch$$access(mIndex);
+                mValue = local;
+              }
+              return local;
+            }
+          }
+
+          private static final class ComponentFactoryImpl implements Component_344.Creator {
+            Component_343Impl fComponent_343;
+
+            Yatagan$Component_323 fComponent_323;
+
+            Component_327Impl fComponent_327;
+
+            Component_331Impl fComponent_331;
+
+            private Node_22 mSet_0;
+
+            private Node_38 mSet_1;
+
+            ComponentFactoryImpl(Component_343Impl fComponent_343,
+                Yatagan$Component_323 fComponent_323, Component_327Impl fComponent_327,
+                Component_331Impl fComponent_331) {
+              this.fComponent_343 = fComponent_343;
+              this.fComponent_323 = fComponent_323;
+              this.fComponent_327 = fComponent_327;
+              this.fComponent_331 = fComponent_331;
+            }
+
+            @Override
+            public Component_344.Creator set_0(Node_22 i) {
+              this.mSet_0 = i;
+              return this;
+            }
+
+            @Override
+            public Component_344.Creator set_1(Node_38 i) {
+              this.mSet_1 = i;
+              return this;
+            }
+
+            @Override
+            public Component_344 create() {
+              return new Component_344Impl(this.fComponent_343, this.fComponent_323, this.fComponent_327, this.fComponent_331, this.mSet_0, this.mSet_1);
+            }
+          }
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+        static final class Component_345Impl implements Component_345 {
+          private Object mNode_203Instance;
+
+          private Object mNode_91Instance;
+
+          private Object mNode_237Instance;
+
+          private Object mNode_12Instance;
+
+          private Object mNode_151Instance;
+
+          private Object mNode_154Instance;
+
+          private Object mNode_264Instance;
+
+          private Object mNode_49Instance;
+
+          final Node_38 mSet_0;
+
+          final Node_22 mSet_1;
+
+          final Yatagan$Component_323 mComponent_323;
+
+          final Component_331Impl mComponent_331;
+
+          final Component_327Impl mComponent_327;
+
+          final Component_343Impl mComponent_343;
+
+          Component_345Impl(Yatagan$Component_323 pComponent_323, Component_331Impl pComponent_331,
+              Component_327Impl pComponent_327, Component_343Impl pComponent_343, Node_38 pSet_0,
+              Node_22 pSet_1) {
+            this.mComponent_323 = pComponent_323;
+            this.mComponent_331 = pComponent_331;
+            this.mComponent_327 = pComponent_327;
+            this.mComponent_343 = pComponent_343;
+            this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+            this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+          }
+
+          @Override
+          public Node_122 getGet_0() {
+            return this.mComponent_323.mSet_2;
+          }
+
+          @Override
+          public Node_134 getGet_1() {
+            return this.mComponent_323.mSet_3;
+          }
+
+          @Override
+          public Node_156 getGet_2() {
+            return this.mComponent_331.cacheNode_156();
+          }
+
+          @Override
+          public Node_132 getGet_3() {
+            return this.accessNode_132();
+          }
+
+          @Override
+          public Node_177 getGet_4() {
+            return this.mComponent_327.cacheNode_177();
+          }
+
+          @Override
+          public Provider<Node_151> getGet_5() {
+            return new ProviderImpl(this, 1);
+          }
+
+          @Override
+          public void inject_0(Injectee_390 i) {
+            i.setMember_0(this.cacheNode_12());
+            i.setMember_1(this.mComponent_327.accessNode_185());
+            i.setMember_2(this.accessNode_142());
+          }
+
+          Object switch$$access(int slot) {
+            switch(slot) {
+              case 0: return this.accessNode_132();
+              case 1: return this.cacheNode_151();
+              case 2: return this.accessNode_142();
+              case 3: return Checks.checkProvisionNotNull(Module_419.Companion.provides_787(this.mComponent_323.accessNode_15(), this.accessNode_197(), this.mComponent_331.cacheNode_29(), this.accessNode_93(), this.mSet_0, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.accessNode_150(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_331.accessNode_73(), this.accessNode_245()));
+              case 4: return this.accessNode_93();
+              case 5: return this.accessNode_215();
+              case 6: return this.accessNode_150();
+              case 7: return this.accessNode_280();
+              case 8: return this.accessNode_286();
+              case 9: return this.accessNode_245();
+              case 10: return this.accessNode_61();
+              case 11: return this.accessNode_83();
+              case 12: return this.accessNode_125();
+              case 13: return this.mSet_1;
+              case 14: return this.accessNode_289();
+              case 15: return new Node_302();
+              case 16: return this.cacheNode_49();
+              case 17: return this.accessNode_274();
+              case 18: return this.cacheNode_264();
+              case 19: return this.cacheNode_237();
+              default: throw new AssertionError();
+            }
+          }
+
+          Node_226 accessNode_226() {
+            return Checks.checkProvisionNotNull(Module_419.Companion.provides_788(this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 5), this.mComponent_343.cacheNode_275(), this.mComponent_343.accessNode_304(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.mSet_2, this.mComponent_331.accessNode_259(), this.mComponent_323.mSet_3, this.mComponent_343.accessNode_240(), this.mSet_1, this.mComponent_331.accessNode_74(), this.mComponent_323.accessNode_210(), this.accessNode_158(), this.accessNode_188(), this.accessNode_289(), new ProviderImpl(this, 15)));
+          }
+
+          Node_215 accessNode_215() {
+            return Checks.checkProvisionNotNull(Module_419.Companion.provides_790(this.mComponent_343.cacheNode_208(), this.cacheNode_49()));
+          }
+
+          Node_150 accessNode_150() {
+            return Checks.checkProvisionNotNull(Module_419.Companion.provides_791(this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.cacheNode_91(), this.accessNode_280(), this.accessNode_289(), new ProviderImpl(this, 1), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2)));
+          }
+
+          Node_203 cacheNode_203() {
+            Object local = this.mNode_203Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_419.Companion.provides_792(new Component_331Impl.CachingProviderImpl(this.mComponent_331, 15), this.mComponent_327.cacheNode_260(), this.mComponent_331.accessNode_73(), this.mComponent_331.cacheNode_206(), this.mComponent_343.cacheNode_275(), this.mComponent_331.cacheNode_29(), this.mComponent_343.cacheNode_136(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_331.accessNode_170(), this.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.mComponent_327.cacheNode_177(), this.accessNode_19(), this.accessNode_188(), this.mComponent_323.mDependency_310.ep_3()));
+              this.mNode_203Instance = local;
+            }
+            return (Node_203) local;
+          }
+
+          Node_91 cacheNode_91() {
+            Object local = this.mNode_91Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_419.Companion.provides_793(this.mComponent_323.mSet_2, this.mComponent_327.mDependency_311.ep_1(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_323.mSet_0, new Component_343Impl.ProviderImpl(this.mComponent_343, 1), new ProviderImpl(this, 16), this.mComponent_323.accessNode_15(), new ProviderImpl(this, 18), this.mComponent_323.cacheNode_102(), this.mComponent_323.cacheNode_30(), this.mComponent_331.accessNode_112(), this.mComponent_331.accessNode_139(), this.mComponent_331.cacheNode_206(), this.accessNode_82(), this.mComponent_331.accessNode_74(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 5), new ProviderImpl(this, 8), this.mComponent_343.cacheNode_208(), this.mComponent_323.cacheNode_133(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_0(), new ProviderImpl(this, 1), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_16(), this.mComponent_331.cacheNode_156(), this.mComponent_323.cacheNode_11(), this.accessNode_132()));
+              this.mNode_91Instance = local;
+            }
+            return (Node_91) local;
+          }
+
+          Node_237 cacheNode_237() {
+            Object local = this.mNode_237Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_419.Companion.provides_794(this.mComponent_331.cacheNode_156(), this.mComponent_331.cacheNode_64(), new ProviderImpl(this, 12), this.mComponent_323.cacheNode_172(), this.accessNode_83(), this.mComponent_327.cacheNode_184(), this.mComponent_331.mDependency_315.ep_0(), new Component_331Impl.ProviderImpl(this.mComponent_331, 22), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 13), this.cacheNode_264(), this.mSet_1, this.mComponent_327.mDependency_311.ep_0(), new Component_343Impl.ProviderImpl(this.mComponent_343, 0), this.mComponent_323.cacheNode_30()));
+              this.mNode_237Instance = local;
+            }
+            return (Node_237) local;
+          }
+
+          Node_12 cacheNode_12() {
+            Object local = this.mNode_12Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_12(new Component_343Impl.ProviderImpl(this.mComponent_343, 4), this.mComponent_323.cacheNode_262(), new Component_331Impl.ProviderImpl(this.mComponent_331, 8), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_323.cacheNode_30(), this.mComponent_331.cacheNode_247(), new ProviderImpl(this, 4), this.accessNode_226(), this.mComponent_327.cacheNode_184(), Checks.checkProvisionNotNull(Module_419.Companion.provides_789(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.accessNode_15(), this.mComponent_331.mDependency_315.ep_0(), new Node_302(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_177(), this.mComponent_323.mDependency_310.ep_3(), this.cacheNode_91(), this.mComponent_331.mSet_2, this.accessNode_166(), this.mComponent_327.cacheNode_108())), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.mComponent_343.cacheNode_43(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_256(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_327.cacheNode_241(), this.mComponent_331.mDependency_315.ep_0(), new CachingProviderImpl(this, 5), new CachingProviderImpl(this, 6), this.mComponent_323.cacheNode_17(), this.accessNode_280());
+              this.mNode_12Instance = local;
+            }
+            return (Node_12) local;
+          }
+
+          Node_125 accessNode_125() {
+            return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+          }
+
+          Node_132 accessNode_132() {
+            return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+          }
+
+          Node_142 accessNode_142() {
+            return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 8), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+          }
+
+          Node_151 cacheNode_151() {
+            Object local = this.mNode_151Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_151(this.mComponent_327.cacheNode_184(), new Component_343Impl.ProviderImpl(this.mComponent_343, 2), new CachingProviderImpl(this, 3), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_133());
+              this.mNode_151Instance = local;
+            }
+            return (Node_151) local;
+          }
+
+          Node_154 cacheNode_154() {
+            Object local = this.mNode_154Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_154(this.accessNode_83());
+              this.mNode_154Instance = local;
+            }
+            return (Node_154) local;
+          }
+
+          Node_158 accessNode_158() {
+            return new Node_158(this.mComponent_327.cacheNode_293());
+          }
+
+          Node_166 accessNode_166() {
+            return new Node_166(this.accessNode_125(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new ProviderImpl(this, 19), this.mComponent_323.accessNode_15(), new Node_302(), this.accessNode_83(), this.mComponent_331.cacheNode_88(), this.mComponent_331.cacheNode_63(), this.mComponent_331.cacheNode_131(), new ProviderImpl(this, 7), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_107(), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_17(), this.accessNode_61(), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_257(), this.mComponent_331.accessNode_259(), this.accessNode_82(), this.mComponent_323.mSet_3, this.mComponent_331.mSet_0, this.mComponent_323.cacheNode_17(), new ProviderImpl(this, 18), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.cacheNode_30(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_17());
+          }
+
+          Node_188 accessNode_188() {
+            return new Node_188(this.mComponent_323.cacheNode_102(), this.accessNode_274(), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.mComponent_343.cacheNode_39(), this.accessNode_132(), this.accessNode_289(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.mSet_1, this.accessNode_142(), this.accessNode_197(), new CachingProviderImpl(this, 7), this.mComponent_331.cacheNode_32(), this.mComponent_343.accessNode_304());
+          }
+
+          Node_19 accessNode_19() {
+            return new Node_19(this.mComponent_327.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 14), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_331.cacheNode_88(), this.mComponent_323.cacheNode_281(), this.accessNode_142(), this.mComponent_343.accessNode_161(), this.mComponent_331.accessNode_139(), this.mComponent_343.cacheNode_136(), new Component_343Impl.CachingProviderImpl(this.mComponent_343, 3), this.mComponent_327.cacheNode_33(), this.mComponent_331.cacheNode_206(), new Node_302(), new Component_343Impl.ProviderImpl(this.mComponent_343, 4), this.mComponent_323.mSet_2, this.mComponent_331.cacheNode_181(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_343.accessNode_218());
+          }
+
+          Node_197 accessNode_197() {
+            return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_23(), this.mComponent_323.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+          }
+
+          Node_223 accessNode_223() {
+            return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.mDependency_310.ep_1(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 10), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), new CachingProviderImpl(this, 17), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 18), this.mComponent_331.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+          }
+
+          Node_245 accessNode_245() {
+            return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_331.cacheNode_156(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Component_331Impl.ProviderImpl(this.mComponent_331, 14), this.mComponent_331.mSet_2, this.mComponent_331.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 11));
+          }
+
+          Node_264 cacheNode_264() {
+            Object local = this.mNode_264Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_264(this.mComponent_331.cacheNode_131(), new Component_343Impl.ProviderImpl(this.mComponent_343, 5), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), Checks.checkProvisionNotNull(Module_419.Companion.provides_795(this.mComponent_327.accessNode_185(), this.mComponent_331.mDependency_315.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.cacheNode_12(), new CachingProviderImpl(this, 17), this.mComponent_331.accessNode_20(), this.accessNode_166(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_257(), new Component_343Impl.ProviderImpl(this.mComponent_343, 0), Checks.checkProvisionNotNull(Module_419.Companion.provides_796(this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_203(), this.mComponent_331.mSet_3, new CachingProviderImpl(this, 15), new ProviderImpl(this, 13), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_323.accessNode_15(), this.mComponent_343.accessNode_218(), this.mComponent_327.accessNode_185(), this.mComponent_331.mSet_2, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.accessNode_83(), this.mComponent_327.cacheNode_241(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_331.accessNode_73(), this.accessNode_274(), this.accessNode_19(), this.accessNode_166(), this.accessNode_158(), this.mComponent_323.cacheNode_257(), this.accessNode_142(), this.mComponent_331.accessNode_20(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3))), this.mComponent_323.cacheNode_107(), new ProviderImpl(this, 18), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_343.accessNode_86(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_116(), this.accessNode_142())), this.accessNode_197(), this.mComponent_331.accessNode_259());
+              this.mNode_264Instance = local;
+            }
+            return (Node_264) local;
+          }
+
+          Node_274 accessNode_274() {
+            return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_331.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 9), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_0, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+          }
+
+          Node_280 accessNode_280() {
+            return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+          }
+
+          Node_286 accessNode_286() {
+            return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+          }
+
+          Node_289 accessNode_289() {
+            return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+          }
+
+          Node_49 cacheNode_49() {
+            Object local = this.mNode_49Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_49(this.mComponent_343.cacheNode_208(), new Component_327Impl.ProviderImpl(this.mComponent_327, 7), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_33(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), this.mComponent_343.cacheNode_275(), this.cacheNode_154(), this.accessNode_286(), new CachingProviderImpl(this, 0), this.cacheNode_237(), this.mComponent_331.cacheNode_206(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_331.cacheNode_156(), this.accessNode_61());
+              this.mNode_49Instance = local;
+            }
+            return (Node_49) local;
+          }
+
+          Node_61 accessNode_61() {
+            return new Node_61(this.mComponent_323.mSet_2, this.mComponent_343.accessNode_221(), this.mComponent_323.mSet_0);
+          }
+
+          Node_82 accessNode_82() {
+            return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 12), this.accessNode_245());
+          }
+
+          Node_83 accessNode_83() {
+            return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 8));
+          }
+
+          Node_93 accessNode_93() {
+            return new Node_93(this.accessNode_132(), this.cacheNode_203(), this.accessNode_226(), this.accessNode_215(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.mSet_0, new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.cacheNode_154(), this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 10), this.mComponent_323.accessNode_210(), this.mComponent_343.accessNode_221(), this.accessNode_223(), this.accessNode_83(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.accessNode_280(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_331.cacheNode_211(), this.mComponent_331.mSet_1, this.accessNode_125(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_331.mSet_3, this.mComponent_343.cacheNode_104(), this.mComponent_331.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 8), this.mComponent_327.cacheNode_260(), this.mComponent_327.mDependency_311.ep_0());
+          }
+
+          static final class ProviderImpl implements Lazy {
+            private final Component_345Impl mDelegate;
+
+            private final int mIndex;
+
+            ProviderImpl(Component_345Impl delegate, int index) {
+              this.mDelegate = delegate;
+              this.mIndex = index;
+            }
+
+            @Override
+            public Object get() {
+              return this.mDelegate.switch$$access(this.mIndex);
+            }
+          }
+
+          private static final class CachingProviderImpl implements Lazy {
+            private final Component_345Impl mDelegate;
+
+            private final int mIndex;
+
+            private Object mValue;
+
+            CachingProviderImpl(Component_345Impl factory, int index) {
+              mDelegate = factory;
+              mIndex = index;
+            }
+
+            @Override
+            public Object get() {
+              Object local = mValue;
+              if (local == null) {
+                ThreadAssertions.assertThreadAccess();
+                local = mDelegate.switch$$access(mIndex);
+                mValue = local;
+              }
+              return local;
+            }
+          }
+
+          private static final class ComponentFactoryImpl implements Component_345.Creator {
+            Yatagan$Component_323 fComponent_323;
+
+            Component_331Impl fComponent_331;
+
+            Component_327Impl fComponent_327;
+
+            Component_343Impl fComponent_343;
+
+            private Node_38 mSet_0;
+
+            private Node_22 mSet_1;
+
+            ComponentFactoryImpl(Yatagan$Component_323 fComponent_323,
+                Component_331Impl fComponent_331, Component_327Impl fComponent_327,
+                Component_343Impl fComponent_343) {
+              this.fComponent_323 = fComponent_323;
+              this.fComponent_331 = fComponent_331;
+              this.fComponent_327 = fComponent_327;
+              this.fComponent_343 = fComponent_343;
+            }
+
+            @Override
+            public Component_345.Creator set_0(Node_38 i) {
+              this.mSet_0 = i;
+              return this;
+            }
+
+            @Override
+            public Component_345.Creator set_1(Node_22 i) {
+              this.mSet_1 = i;
+              return this;
+            }
+
+            @Override
+            public Component_345 create() {
+              return new Component_345Impl(this.fComponent_323, this.fComponent_331, this.fComponent_327, this.fComponent_343, this.mSet_0, this.mSet_1);
+            }
+          }
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+        static final class Component_346Impl implements Component_346 {
+          private Object mNode_89Instance;
+
+          private Object mNode_150Instance;
+
+          private Object mNode_203Instance;
+
+          private Object mNode_226Instance;
+
+          private Object mNode_237Instance;
+
+          private Object mNode_151Instance;
+
+          private Object mNode_154Instance;
+
+          private Object mNode_264Instance;
+
+          private Object mNode_49Instance;
+
+          final Node_38 mSet_0;
+
+          final Node_22 mSet_1;
+
+          final Component_331Impl mComponent_331;
+
+          final Component_327Impl mComponent_327;
+
+          final Yatagan$Component_323 mComponent_323;
+
+          final Component_343Impl mComponent_343;
+
+          Component_346Impl(Component_331Impl pComponent_331, Component_327Impl pComponent_327,
+              Yatagan$Component_323 pComponent_323, Component_343Impl pComponent_343,
+              Node_38 pSet_0, Node_22 pSet_1) {
+            this.mComponent_331 = pComponent_331;
+            this.mComponent_327 = pComponent_327;
+            this.mComponent_323 = pComponent_323;
+            this.mComponent_343 = pComponent_343;
+            this.mSet_0 = Checks.checkInputNotNull(pSet_0);
+            this.mSet_1 = Checks.checkInputNotNull(pSet_1);
+          }
+
+          @Override
+          public Provider<Node_29> getGet_0() {
+            return new Component_331Impl.ProviderImpl(this.mComponent_331, 1);
+          }
+
+          @Override
+          public Node_293 getGet_1() {
+            return this.mComponent_327.cacheNode_293();
+          }
+
+          @Override
+          public Node_89 getGet_2() {
+            return this.cacheNode_89();
+          }
+
+          @Override
+          public Node_241 getGet_3() {
+            return this.mComponent_327.cacheNode_241();
+          }
+
+          Object switch$$access(int slot) {
+            switch(slot) {
+              case 0: return this.cacheNode_89();
+              case 1: return this.accessNode_93();
+              case 2: return this.cacheNode_150();
+              case 3: return this.accessNode_245();
+              case 4: return this.accessNode_142();
+              case 5: return this.accessNode_132();
+              case 6: return this.accessNode_215();
+              case 7: return this.accessNode_61();
+              case 8: return this.accessNode_83();
+              case 9: return this.accessNode_280();
+              case 10: return this.accessNode_125();
+              case 11: return this.accessNode_91();
+              case 12: return this.accessNode_289();
+              case 13: return this.accessNode_286();
+              case 14: return this.mSet_1;
+              case 15: return new Node_302();
+              case 16: return this.accessNode_274();
+              case 17: return this.cacheNode_237();
+              case 18: return Checks.checkProvisionNotNull(Module_420.Companion.provides_810());
+              default: throw new AssertionError();
+            }
+          }
+
+          Node_89 cacheNode_89() {
+            Object local = this.mNode_89Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_420.Companion.provides_802(this.mComponent_323.accessNode_15(), this.accessNode_197(), this.mComponent_331.cacheNode_29(), this.accessNode_93(), this.mSet_0, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 9), this.cacheNode_150(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_331.accessNode_73(), this.accessNode_245()));
+              this.mNode_89Instance = local;
+            }
+            return (Node_89) local;
+          }
+
+          Node_150 cacheNode_150() {
+            Object local = this.mNode_150Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_420.Companion.provides_803(this.mComponent_323.mDependency_310.ep_2(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 7), this.accessNode_91(), this.accessNode_280(), this.accessNode_289(), this.cacheNode_151(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 0), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2)));
+              this.mNode_150Instance = local;
+            }
+            return (Node_150) local;
+          }
+
+          Node_203 cacheNode_203() {
+            Object local = this.mNode_203Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_420.Companion.provides_804(new Component_331Impl.CachingProviderImpl(this.mComponent_331, 15), this.mComponent_327.cacheNode_260(), this.mComponent_331.accessNode_73(), this.mComponent_331.cacheNode_206(), this.mComponent_343.cacheNode_275(), this.mComponent_331.cacheNode_29(), this.mComponent_343.cacheNode_136(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), this.mComponent_331.accessNode_170(), this.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), this.mComponent_327.cacheNode_177(), this.accessNode_19(), this.accessNode_188(), this.mComponent_323.mDependency_310.ep_3()));
+              this.mNode_203Instance = local;
+            }
+            return (Node_203) local;
+          }
+
+          Node_226 cacheNode_226() {
+            Object local = this.mNode_226Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_420.Companion.provides_805(this.mComponent_327.cacheNode_184(), this.accessNode_215(), this.mComponent_343.cacheNode_275(), this.mComponent_343.accessNode_304(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_323.mSet_2, this.mComponent_331.accessNode_259(), this.mComponent_323.mSet_3, this.mComponent_343.accessNode_240(), this.mSet_1, this.mComponent_331.accessNode_74(), this.mComponent_323.accessNode_210(), this.accessNode_158(), this.accessNode_188(), this.accessNode_289(), new ProviderImpl(this, 15)));
+              this.mNode_226Instance = local;
+            }
+            return (Node_226) local;
+          }
+
+          Node_215 accessNode_215() {
+            return Checks.checkProvisionNotNull(Module_420.Companion.provides_806(this.mComponent_343.cacheNode_208(), this.cacheNode_49()));
+          }
+
+          Node_91 accessNode_91() {
+            return Checks.checkProvisionNotNull(Module_420.Companion.provides_807(this.mComponent_323.mSet_2, this.mComponent_327.mDependency_311.ep_1(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_323.mSet_0, new Component_343Impl.ProviderImpl(this.mComponent_343, 1), this.cacheNode_49(), this.mComponent_323.accessNode_15(), this.cacheNode_264(), this.mComponent_323.cacheNode_102(), this.mComponent_323.cacheNode_30(), this.mComponent_331.accessNode_112(), this.mComponent_331.accessNode_139(), this.mComponent_331.cacheNode_206(), this.accessNode_82(), this.mComponent_331.accessNode_74(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 5), new ProviderImpl(this, 13), this.mComponent_343.cacheNode_208(), this.mComponent_323.cacheNode_133(), this.mComponent_327.mSet_1, this.mComponent_323.mDependency_310.ep_0(), this.cacheNode_151(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_16(), this.mComponent_331.cacheNode_156(), this.mComponent_323.cacheNode_11(), this.accessNode_132()));
+          }
+
+          Node_237 cacheNode_237() {
+            Object local = this.mNode_237Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = Checks.checkProvisionNotNull(Module_420.Companion.provides_808(this.mComponent_331.cacheNode_156(), this.mComponent_331.cacheNode_64(), new ProviderImpl(this, 10), this.mComponent_323.cacheNode_172(), this.accessNode_83(), this.mComponent_327.cacheNode_184(), this.mComponent_331.mDependency_315.ep_0(), new Component_331Impl.ProviderImpl(this.mComponent_331, 22), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 13), Checks.checkProvisionNotNull(Module_420.Companion.provides_810()), this.mSet_1, this.mComponent_327.mDependency_311.ep_0(), new Component_343Impl.ProviderImpl(this.mComponent_343, 0), this.mComponent_323.cacheNode_30()));
+              this.mNode_237Instance = local;
+            }
+            return (Node_237) local;
+          }
+
+          Node_125 accessNode_125() {
+            return new Node_125(this.accessNode_286(), this.mComponent_323.accessNode_15(), this.mComponent_327.mSet_0, this.mComponent_323.cacheNode_257(), this.mComponent_327.cacheNode_108(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 4), new Component_327Impl.ProviderImpl(this.mComponent_327, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.mDependency_310.ep_2(), this.accessNode_280(), this.accessNode_142(), this.mComponent_323.cacheNode_254());
+          }
+
+          Node_132 accessNode_132() {
+            return new Node_132(this.mComponent_327.accessNode_185(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 21), this.mComponent_327.mDependency_311.ep_0());
+          }
+
+          Node_142 accessNode_142() {
+            return new Node_142(new Component_327Impl.ProviderImpl(this.mComponent_327, 7), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_17(), this.mComponent_327.cacheNode_184(), new CachingProviderImpl(this, 13), this.mComponent_323.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.mSet_1, this.mComponent_327.mSet_0, this.accessNode_280(), this.mComponent_323.accessNode_15(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_293(), this.mComponent_323.cacheNode_262(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.accessNode_210(), this.mComponent_327.cacheNode_108(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4));
+          }
+
+          Node_151 cacheNode_151() {
+            Object local = this.mNode_151Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_151(this.mComponent_327.cacheNode_184(), new Component_343Impl.ProviderImpl(this.mComponent_343, 2), new ProviderImpl(this, 0), this.mComponent_323.cacheNode_262(), this.mComponent_323.cacheNode_133());
+              this.mNode_151Instance = local;
+            }
+            return (Node_151) local;
+          }
+
+          Node_154 cacheNode_154() {
+            Object local = this.mNode_154Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_154(this.accessNode_83());
+              this.mNode_154Instance = local;
+            }
+            return (Node_154) local;
+          }
+
+          Node_158 accessNode_158() {
+            return new Node_158(this.mComponent_327.cacheNode_293());
+          }
+
+          Node_166 accessNode_166() {
+            return new Node_166(this.accessNode_125(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new ProviderImpl(this, 17), this.mComponent_323.accessNode_15(), new Node_302(), this.accessNode_83(), this.mComponent_331.cacheNode_88(), this.mComponent_331.cacheNode_63(), this.mComponent_331.cacheNode_131(), new ProviderImpl(this, 9), new Component_327Impl.ProviderImpl(this.mComponent_327, 2), this.mComponent_323.cacheNode_107(), this.mComponent_327.cacheNode_260(), this.mComponent_323.cacheNode_11(), this.mComponent_323.cacheNode_17(), this.accessNode_61(), this.mComponent_323.accessNode_210(), this.mComponent_323.cacheNode_257(), this.mComponent_331.accessNode_259(), this.accessNode_82(), this.mComponent_323.mSet_3, this.mComponent_331.mSet_0, this.mComponent_323.cacheNode_17(), new CachingProviderImpl(this, 18), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 20), this.mComponent_323.cacheNode_30(), this.mComponent_327.accessNode_185(), this.mComponent_323.cacheNode_17());
+          }
+
+          Node_188 accessNode_188() {
+            return new Node_188(this.mComponent_323.cacheNode_102(), this.accessNode_274(), this.mComponent_327.cacheNode_241(), this.mComponent_323.mSet_2, this.mComponent_343.cacheNode_39(), this.accessNode_132(), this.accessNode_289(), new Component_327Impl.ProviderImpl(this.mComponent_327, 3), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_331.mSet_1, this.accessNode_142(), this.accessNode_197(), new CachingProviderImpl(this, 9), this.mComponent_331.cacheNode_32(), this.mComponent_343.accessNode_304());
+          }
+
+          Node_19 accessNode_19() {
+            return new Node_19(this.mComponent_327.mSet_1, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_102(), new CachingProviderImpl(this, 12), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_327.cacheNode_293(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), this.mComponent_331.cacheNode_88(), this.mComponent_323.cacheNode_281(), this.accessNode_142(), this.mComponent_343.accessNode_161(), this.mComponent_331.accessNode_139(), this.mComponent_343.cacheNode_136(), new Component_343Impl.CachingProviderImpl(this.mComponent_343, 3), this.mComponent_327.cacheNode_33(), this.mComponent_331.cacheNode_206(), new Node_302(), new Component_343Impl.ProviderImpl(this.mComponent_343, 4), this.mComponent_323.mSet_2, this.mComponent_331.cacheNode_181(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 3), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_343.accessNode_218());
+          }
+
+          Node_197 accessNode_197() {
+            return new Node_197(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.cacheNode_29(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 16), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_331.cacheNode_23(), this.mComponent_323.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 17), this.accessNode_142(), this.mComponent_327.cacheNode_16());
+          }
+
+          Node_223 accessNode_223() {
+            return new Node_223(this.mComponent_327.cacheNode_108(), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.mDependency_310.ep_1(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_33(), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.mDependency_310.ep_1(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 4), this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 1), new Component_331Impl.ProviderImpl(this.mComponent_331, 10), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_206(), new CachingProviderImpl(this, 16), this.mComponent_327.cacheNode_177(), this.mComponent_323.cacheNode_281(), this.mComponent_323.cacheNode_17(), new Component_331Impl.CachingProviderImpl(this.mComponent_331, 18), this.mComponent_331.cacheNode_29(), this.accessNode_280(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_323.cacheNode_257());
+          }
+
+          Node_245 accessNode_245() {
+            return new Node_245(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 21), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_331.cacheNode_156(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_331.accessNode_73(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Component_331Impl.ProviderImpl(this.mComponent_331, 14), this.mComponent_331.mSet_2, this.mComponent_331.cacheNode_181(), this.mComponent_323.cacheNode_11(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Component_327Impl.ProviderImpl(this.mComponent_327, 10), this.accessNode_280(), this.mComponent_323.mSet_2, this.mComponent_327.cacheNode_108(), this.accessNode_142(), new CachingProviderImpl(this, 8));
+          }
+
+          Node_264 cacheNode_264() {
+            Object local = this.mNode_264Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_264(this.mComponent_331.cacheNode_131(), new Component_343Impl.ProviderImpl(this.mComponent_343, 5), this.mComponent_327.mDependency_311.ep_0(), this.mComponent_323.cacheNode_257(), Checks.checkProvisionNotNull(Module_420.Companion.provides_809(this.mComponent_327.accessNode_185(), this.mComponent_331.mDependency_315.ep_0(), Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), new Node_12(new Component_343Impl.ProviderImpl(this.mComponent_343, 4), this.mComponent_323.cacheNode_262(), new Component_331Impl.ProviderImpl(this.mComponent_331, 8), this.mComponent_327.mDependency_311.ep_1(), this.mComponent_323.cacheNode_30(), this.mComponent_331.cacheNode_247(), new ProviderImpl(this, 1), this.cacheNode_226(), this.mComponent_327.cacheNode_184(), Checks.checkProvisionNotNull(Module_420.Companion.provides_812(Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), new Component_331Impl.ProviderImpl(this.mComponent_331, 9), this.mComponent_323.accessNode_15(), this.mComponent_331.mDependency_315.ep_0(), new Node_302(), this.mComponent_327.cacheNode_260(), this.mComponent_327.cacheNode_177(), this.mComponent_323.mDependency_310.ep_3(), new CachingProviderImpl(this, 11), this.mComponent_331.mSet_2, this.accessNode_166(), this.mComponent_327.cacheNode_108())), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 6), this.mComponent_343.cacheNode_43(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_256(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3), this.mComponent_327.cacheNode_241(), this.mComponent_331.mDependency_315.ep_0(), new CachingProviderImpl(this, 6), new ProviderImpl(this, 2), this.mComponent_323.cacheNode_17(), this.accessNode_280()), new CachingProviderImpl(this, 16), this.mComponent_331.accessNode_20(), this.accessNode_166(), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_327.cacheNode_108(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.cacheNode_257(), new Component_343Impl.ProviderImpl(this.mComponent_343, 0), Checks.checkProvisionNotNull(Module_420.Companion.provides_811(this.mComponent_323.mDependency_310.ep_1(), this.cacheNode_203(), this.mComponent_331.mSet_3, new CachingProviderImpl(this, 15), new ProviderImpl(this, 14), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_323.accessNode_15(), this.mComponent_343.accessNode_218(), this.mComponent_327.accessNode_185(), this.mComponent_331.mSet_2, Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.accessNode_83(), this.mComponent_327.cacheNode_241(), this.mComponent_343.mDependency_316.ep_0(), this.mComponent_331.accessNode_73(), this.accessNode_274(), this.accessNode_19(), this.accessNode_166(), this.accessNode_158(), this.mComponent_323.cacheNode_257(), this.accessNode_142(), this.mComponent_331.accessNode_20(), new Component_327Impl.CachingProviderImpl(this.mComponent_327, 3))), this.mComponent_323.cacheNode_107(), new CachingProviderImpl(this, 18), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 2), this.mComponent_343.accessNode_86(), this.mComponent_327.mSet_0, this.mComponent_331.cacheNode_116(), this.accessNode_142())), this.accessNode_197(), this.mComponent_331.accessNode_259());
+              this.mNode_264Instance = local;
+            }
+            return (Node_264) local;
+          }
+
+          Node_274 accessNode_274() {
+            return new Node_274(this.mComponent_327.cacheNode_293(), this.accessNode_223(), this.mComponent_323.accessNode_15(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 17), this.mComponent_327.mDependency_311.ep_0(), this.accessNode_125(), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_102(), this.mComponent_331.cacheNode_206(), this.mComponent_323.cacheNode_107(), this.accessNode_289(), this.mComponent_323.cacheNode_133(), this.mComponent_323.cacheNode_257(), this.mComponent_323.cacheNode_172(), this.mComponent_323.accessNode_15(), this.mComponent_331.accessNode_170(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_327.cacheNode_260(), new CachingProviderImpl(this, 3), this.mComponent_331.cacheNode_88(), this.mComponent_331.mSet_0, Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_327.cacheNode_108());
+          }
+
+          Node_280 accessNode_280() {
+            return new Node_280(Checks.checkProvisionNotNull(Module_401.Companion.provides_554()), this.mComponent_327.cacheNode_184(), this.mComponent_323.mSet_1, new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_323.mDependency_310.ep_0(), this.mComponent_323.mDependency_310.ep_3());
+          }
+
+          Node_286 accessNode_286() {
+            return new Node_286(new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 13), this.mComponent_323.cacheNode_257(), this.mComponent_323.mSet_1, new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 8), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 4), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.cacheNode_133(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 14), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5));
+          }
+
+          Node_289 accessNode_289() {
+            return new Node_289(new Component_327Impl.ProviderImpl(this.mComponent_327, 1), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.accessNode_280(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), this.mComponent_323.mSet_2, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 10), this.mComponent_323.cacheNode_46());
+          }
+
+          Node_49 cacheNode_49() {
+            Object local = this.mNode_49Instance;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = new Node_49(this.mComponent_343.cacheNode_208(), new Component_327Impl.ProviderImpl(this.mComponent_327, 7), this.mComponent_323.mSet_3, this.mComponent_327.cacheNode_33(), new Component_327Impl.ProviderImpl(this.mComponent_327, 9), this.mComponent_343.cacheNode_275(), this.cacheNode_154(), this.accessNode_286(), new CachingProviderImpl(this, 5), this.cacheNode_237(), this.mComponent_331.cacheNode_206(), Checks.checkProvisionNotNull(Module_401.Companion.provides_547()), this.mComponent_331.cacheNode_156(), this.accessNode_61());
+              this.mNode_49Instance = local;
+            }
+            return (Node_49) local;
+          }
+
+          Node_61 accessNode_61() {
+            return new Node_61(this.mComponent_323.mSet_2, this.mComponent_343.accessNode_221(), this.mComponent_323.mSet_0);
+          }
+
+          Node_82 accessNode_82() {
+            return new Node_82(this.mComponent_323.mDependency_310.ep_3(), new Component_331Impl.ProviderImpl(this.mComponent_331, 2), this.mComponent_323.cacheNode_11(), this.mComponent_327.mSet_0, new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), this.mComponent_323.mDependency_310.ep_2(), this.mComponent_323.cacheNode_102(), this.mComponent_327.cacheNode_184(), this.mComponent_323.mDependency_310.ep_0(), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 1), this.mComponent_323.cacheNode_46(), this.mComponent_323.accessNode_15(), this.mComponent_323.cacheNode_254(), this.accessNode_132(), this.accessNode_280(), new ProviderImpl(this, 10), this.accessNode_245());
+          }
+
+          Node_83 accessNode_83() {
+            return new Node_83(this.mComponent_323.cacheNode_257(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 5), this.mComponent_323.mSet_2, this.mComponent_323.cacheNode_17(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 9), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 19), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 11), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 0), new Yatagan$Component_323.CachingProviderImpl(this.mComponent_323, 10), this.mComponent_323.mDependency_310.ep_1(), new CachingProviderImpl(this, 13));
+          }
+
+          Node_93 accessNode_93() {
+            return new Node_93(this.accessNode_132(), this.cacheNode_203(), this.cacheNode_226(), this.accessNode_215(), Checks.checkProvisionNotNull(Module_401.Companion.provides_550()), this.mComponent_327.mSet_0, new Component_327Impl.ProviderImpl(this.mComponent_327, 13), this.cacheNode_154(), this.mComponent_323.cacheNode_11(), new ProviderImpl(this, 7), this.mComponent_323.accessNode_210(), this.mComponent_343.accessNode_221(), this.accessNode_223(), this.accessNode_83(), new Yatagan$Component_323.ProviderImpl(this.mComponent_323, 8), this.accessNode_280(), this.mComponent_331.mDependency_315.ep_0(), this.mComponent_331.cacheNode_211(), this.mComponent_331.mSet_1, this.accessNode_125(), new Component_327Impl.ProviderImpl(this.mComponent_327, 11), this.mComponent_331.mSet_3, this.mComponent_343.cacheNode_104(), this.mComponent_331.mSet_2, new Component_331Impl.ProviderImpl(this.mComponent_331, 8), this.mComponent_327.cacheNode_260(), this.mComponent_327.mDependency_311.ep_0());
+          }
+
+          static final class ProviderImpl implements Lazy {
+            private final Component_346Impl mDelegate;
+
+            private final int mIndex;
+
+            ProviderImpl(Component_346Impl delegate, int index) {
+              this.mDelegate = delegate;
+              this.mIndex = index;
+            }
+
+            @Override
+            public Object get() {
+              return this.mDelegate.switch$$access(this.mIndex);
+            }
+          }
+
+          private static final class CachingProviderImpl implements Lazy {
+            private final Component_346Impl mDelegate;
+
+            private final int mIndex;
+
+            private Object mValue;
+
+            CachingProviderImpl(Component_346Impl factory, int index) {
+              mDelegate = factory;
+              mIndex = index;
+            }
+
+            @Override
+            public Object get() {
+              Object local = mValue;
+              if (local == null) {
+                ThreadAssertions.assertThreadAccess();
+                local = mDelegate.switch$$access(mIndex);
+                mValue = local;
+              }
+              return local;
+            }
+          }
+
+          private static final class ComponentFactoryImpl implements Component_346.Creator {
+            Component_331Impl fComponent_331;
+
+            Component_327Impl fComponent_327;
+
+            Yatagan$Component_323 fComponent_323;
+
+            Component_343Impl fComponent_343;
+
+            private Node_38 mSet_0;
+
+            private Node_22 mSet_1;
+
+            ComponentFactoryImpl(Component_331Impl fComponent_331, Component_327Impl fComponent_327,
+                Yatagan$Component_323 fComponent_323, Component_343Impl fComponent_343) {
+              this.fComponent_331 = fComponent_331;
+              this.fComponent_327 = fComponent_327;
+              this.fComponent_323 = fComponent_323;
+              this.fComponent_343 = fComponent_343;
+            }
+
+            @Override
+            public Component_346.Creator set_0(Node_38 i) {
+              this.mSet_0 = i;
+              return this;
+            }
+
+            @Override
+            public Component_346.Creator set_1(Node_22 i) {
+              this.mSet_1 = i;
+              return this;
+            }
+
+            @Override
+            public Component_346 create() {
+              return new Component_346Impl(this.fComponent_331, this.fComponent_327, this.fComponent_323, this.fComponent_343, this.mSet_0, this.mSet_1);
+            }
+          }
+        }
+
+        static final class ProviderImpl implements Lazy {
+          private final Component_343Impl mDelegate;
+
+          private final int mIndex;
+
+          ProviderImpl(Component_343Impl delegate, int index) {
+            this.mDelegate = delegate;
+            this.mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            return this.mDelegate.switch$$access(this.mIndex);
+          }
+        }
+
+        private static final class CachingProviderImpl implements Lazy {
+          private final Component_343Impl mDelegate;
+
+          private final int mIndex;
+
+          private Object mValue;
+
+          CachingProviderImpl(Component_343Impl factory, int index) {
+            mDelegate = factory;
+            mIndex = index;
+          }
+
+          @Override
+          public Object get() {
+            Object local = mValue;
+            if (local == null) {
+              ThreadAssertions.assertThreadAccess();
+              local = mDelegate.switch$$access(mIndex);
+              mValue = local;
+            }
+            return local;
+          }
+        }
+
+        private static final class ComponentFactoryImpl implements Component_343.Creator {
+          Yatagan$Component_323 fComponent_323;
+
+          Component_327Impl fComponent_327;
+
+          Component_331Impl fComponent_331;
+
+          private Dependency_316 mSetDep_0;
+
+          ComponentFactoryImpl(Yatagan$Component_323 fComponent_323,
+              Component_327Impl fComponent_327, Component_331Impl fComponent_331) {
+            this.fComponent_323 = fComponent_323;
+            this.fComponent_327 = fComponent_327;
+            this.fComponent_331 = fComponent_331;
+          }
+
+          @Override
+          public Component_343.Creator setDep_0(Dependency_316 i) {
+            this.mSetDep_0 = i;
+            return this;
+          }
+
+          @Override
+          public Component_343 create() {
+            return new Component_343Impl(this.fComponent_323, this.fComponent_327, this.fComponent_331, this.mSetDep_0);
+          }
+        }
+      }
+
+      static final class ProviderImpl implements Lazy {
+        private final Component_331Impl mDelegate;
+
+        private final int mIndex;
+
+        ProviderImpl(Component_331Impl delegate, int index) {
+          this.mDelegate = delegate;
+          this.mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          return this.mDelegate.switch$$access(this.mIndex);
+        }
+      }
+
+      private static final class CachingProviderImpl implements Lazy {
+        private final Component_331Impl mDelegate;
+
+        private final int mIndex;
+
+        private Object mValue;
+
+        CachingProviderImpl(Component_331Impl factory, int index) {
+          mDelegate = factory;
+          mIndex = index;
+        }
+
+        @Override
+        public Object get() {
+          Object local = mValue;
+          if (local == null) {
+            ThreadAssertions.assertThreadAccess();
+            local = mDelegate.switch$$access(mIndex);
+            mValue = local;
+          }
+          return local;
+        }
+      }
+
+      private static final class ComponentFactoryImpl implements Component_331.Creator {
+        Yatagan$Component_323 fComponent_323;
+
+        Component_327Impl fComponent_327;
+
+        private Dependency_315 mSetDep_0;
+
+        private Node_273 mSet_0;
+
+        private Node_299 mSet_1;
+
+        private Node_200 mSet_2;
+
+        private Node_207 mSet_3;
+
+        ComponentFactoryImpl(Yatagan$Component_323 fComponent_323,
+            Component_327Impl fComponent_327) {
+          this.fComponent_323 = fComponent_323;
+          this.fComponent_327 = fComponent_327;
+        }
+
+        @Override
+        public Component_331.Creator setDep_0(Dependency_315 i) {
+          this.mSetDep_0 = i;
+          return this;
+        }
+
+        @Override
+        public Component_331.Creator set_0(Node_273 i) {
+          this.mSet_0 = i;
+          return this;
+        }
+
+        @Override
+        public Component_331.Creator set_1(Node_299 i) {
+          this.mSet_1 = i;
+          return this;
+        }
+
+        @Override
+        public Component_331.Creator set_2(Node_200 i) {
+          this.mSet_2 = i;
+          return this;
+        }
+
+        @Override
+        public Component_331.Creator set_3(Node_207 i) {
+          this.mSet_3 = i;
+          return this;
+        }
+
+        @Override
+        public Component_331 create() {
+          return new Component_331Impl(this.fComponent_323, this.fComponent_327, this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+        }
+      }
+    }
+
+    static final class ProviderImpl implements Lazy {
+      private final Component_327Impl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(Component_327Impl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+
+    private static final class CachingProviderImpl implements Lazy {
+      private final Component_327Impl mDelegate;
+
+      private final int mIndex;
+
+      private Object mValue;
+
+      CachingProviderImpl(Component_327Impl factory, int index) {
+        mDelegate = factory;
+        mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        Object local = mValue;
+        if (local == null) {
+          ThreadAssertions.assertThreadAccess();
+          local = mDelegate.switch$$access(mIndex);
+          mValue = local;
+        }
+        return local;
+      }
+    }
+
+    private static final class ComponentFactoryImpl implements Component_327.Creator {
+      Yatagan$Component_323 fComponent_323;
+
+      private Dependency_311 mSetDep_0;
+
+      private Node_69 mSet_0;
+
+      private Node_92 mSet_1;
+
+      ComponentFactoryImpl(Yatagan$Component_323 fComponent_323) {
+        this.fComponent_323 = fComponent_323;
+      }
+
+      @Override
+      public Component_327.Creator setDep_0(Dependency_311 i) {
+        this.mSetDep_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_327.Creator set_0(Node_69 i) {
+        this.mSet_0 = i;
+        return this;
+      }
+
+      @Override
+      public Component_327.Creator set_1(Node_92 i) {
+        this.mSet_1 = i;
+        return this;
+      }
+
+      @Override
+      public Component_327 create() {
+        return new Component_327Impl(this.fComponent_323, this.mSetDep_0, this.mSet_0, this.mSet_1);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$Component_323 mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$Component_323 delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$Component_323 mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$Component_323 factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements Component_323.Creator {
+    private Dependency_310 mSetDep_0;
+
+    private Node_176 mSet_0;
+
+    private Node_238 mSet_1;
+
+    private Node_130 mSet_2;
+
+    private Node_134 mSet_3;
+
+    @Override
+    public Component_323.Creator setDep_0(Dependency_310 i) {
+      this.mSetDep_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_323.Creator set_0(Node_176 i) {
+      this.mSet_0 = i;
+      return this;
+    }
+
+    @Override
+    public Component_323.Creator set_1(Node_238 i) {
+      this.mSet_1 = i;
+      return this;
+    }
+
+    @Override
+    public Component_323.Creator set_2(Node_130 i) {
+      this.mSet_2 = i;
+      return this;
+    }
+
+    @Override
+    public Component_323.Creator set_3(Node_134 i) {
+      this.mSet_3 = i;
+      return this;
+    }
+
+    @Override
+    public Component_323 create() {
+      return new Yatagan$Component_323(this.mSetDep_0, this.mSet_0, this.mSet_1, this.mSet_2, this.mSet_3);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/IntoMap-basic-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/IntoMap-basic-test.golden-code.txt
@@ -1,0 +1,261 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public JavaConsumer getConsumer() {
+    return new JavaConsumer(this.accessMapIntegerString(), this.accessJavaxInjectNamedValueNameMapClassAnyInteger(), this.accessMapClassAnyInteger(), this.accessMapClassMyApiMyApi(), this.accessMapMyEnumMyApi(), new ProviderImpl(this, 0), new ProviderImpl(this, 1), new ProviderImpl(this, 2), new CachingProviderImpl(this, 3), new CachingProviderImpl(this, 4), this.accessMapClassMyApiProviderMyApi());
+  }
+
+  @Override
+  public Map<String, Object> getEmptyMap() {
+    return this.mapOfMapStringObject();
+  }
+
+  @Override
+  public Map<String, Object> getEmptyMap2() {
+    return this.mapOfJavaUtilMapStringObject();
+  }
+
+  @Override
+  public KotlinConsumer getKotlinConsumer() {
+    return new KotlinConsumer(this.accessMapIntegerString(), this.accessJavaxInjectNamedValueNameMapClassAnyInteger(), this.accessMapClassAnyInteger(), this.accessMapClassMyApiMyApi(), this.accessMapMyEnumMyApi(), new ProviderImpl(this, 0), new ProviderImpl(this, 1), new ProviderImpl(this, 2), new CachingProviderImpl(this, 3), new CachingProviderImpl(this, 4), this.accessMapClassMyApiProviderMyApi(), new ProviderImpl(this, 10));
+  }
+
+  @Override
+  public Map<Integer, String> getMap() {
+    return this.accessMapIntegerString();
+  }
+
+  @Override
+  public Map<Integer, String> getMap1Java() {
+    return this.accessMapIntegerString();
+  }
+
+  @Override
+  public Map<Class<?>, Integer> getMap2() {
+    return this.accessJavaxInjectNamedValueNameMapClassAnyInteger();
+  }
+
+  @Override
+  public Map<Class<?>, Integer> getMap2Java() {
+    return this.accessJavaxInjectNamedValueNameMapClassAnyInteger();
+  }
+
+  @Override
+  public Map<Class<?>, Integer> getMap3() {
+    return this.accessMapClassAnyInteger();
+  }
+
+  @Override
+  public Map<Class<?>, Integer> getMap3Java() {
+    return this.accessMapClassAnyInteger();
+  }
+
+  @Override
+  public Map<Class<? extends MyApi>, MyApi> getMap4() {
+    return this.accessMapClassMyApiMyApi();
+  }
+
+  @Override
+  public Map<Class<? extends MyApi>, MyApi> getMap4Java() {
+    return this.accessMapClassMyApiMyApi();
+  }
+
+  @Override
+  public Map<MyEnum, MyApi> getMap5() {
+    return this.accessMapMyEnumMyApi();
+  }
+
+  @Override
+  public Map<MyEnum, MyApi> getMap5Java() {
+    return this.accessMapMyEnumMyApi();
+  }
+
+  @Override
+  public Map<Class<? extends MyApi>, Provider<MyApi>> getMapOfProviders() {
+    return this.accessMapClassMyApiProviderMyApi();
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessMapIntegerString();
+      case 1: return this.accessJavaxInjectNamedValueNameMapClassAnyInteger();
+      case 2: return this.accessMapClassAnyInteger();
+      case 3: return this.accessMapClassMyApiMyApi();
+      case 4: return this.accessMapMyEnumMyApi();
+      case 5: return Checks.checkProvisionNotNull(TestModule.INSTANCE.int1());
+      case 6: return Checks.checkProvisionNotNull(TestModule.INSTANCE.int2());
+      case 7: return Checks.checkProvisionNotNull(TestModule.INSTANCE.apiImpl1());
+      case 8: return new Impl2();
+      case 9: return new Impl3();
+      case 10: return this.mapOfMapClassAnyProviderInteger();
+      default: throw new AssertionError();
+    }
+  }
+
+  Map<Class<?>, Integer> accessMapClassAnyInteger() {
+    return this.mapOfJavaUtilMapClassAnyInteger();
+  }
+
+  Map<Class<?>, Integer> accessJavaxInjectNamedValueNameMapClassAnyInteger() {
+    return this.mapOfMapClassAnyInteger();
+  }
+
+  Map<Integer, String> accessMapIntegerString() {
+    return this.mapOfMapIntegerString();
+  }
+
+  Map<Class<? extends MyApi>, MyApi> accessMapClassMyApiMyApi() {
+    return this.mapOfMapClassMyApiMyApi();
+  }
+
+  Map<Class<? extends MyApi>, Provider<MyApi>> accessMapClassMyApiProviderMyApi() {
+    return this.mapOfMapClassMyApiProviderMyApi();
+  }
+
+  Map<MyEnum, MyApi> accessMapMyEnumMyApi() {
+    return this.mapOfMapMyEnumMyApi();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  Map<String, Object> mapOfMapStringObject() {
+    final Map<String, Object> map = new HashMap<>(0);
+    return map;
+  }
+
+  Map<String, Object> mapOfJavaUtilMapStringObject() {
+    final Map<String, Object> map = new HashMap<>(0);
+    return map;
+  }
+
+  Map<Class<?>, Integer> mapOfJavaUtilMapClassAnyInteger() {
+    final Map<Class<?>, Integer> map = new HashMap<>(1);
+    map.put(TestModule.class, Checks.checkProvisionNotNull(TestModule.INSTANCE.int3()));
+    return map;
+  }
+
+  Map<Class<?>, Integer> mapOfMapClassAnyInteger() {
+    final Map<Class<?>, Integer> map = new HashMap<>(2);
+    map.put(Object.class, Checks.checkProvisionNotNull(TestModule.INSTANCE.int1()));
+    map.put(String.class, Checks.checkProvisionNotNull(TestModule.INSTANCE.int2()));
+    return map;
+  }
+
+  Map<Class<?>, Provider<Integer>> mapOfMapClassAnyProviderInteger() {
+    final Map<Class<?>, Provider<Integer>> map = new HashMap<>(2);
+    map.put(Object.class, new ProviderImpl(this, 5));
+    map.put(String.class, new ProviderImpl(this, 6));
+    return map;
+  }
+
+  Map<Integer, String> mapOfMapIntegerString() {
+    final Map<Integer, String> map = new HashMap<>(2);
+    map.put(1, Checks.checkProvisionNotNull(TestModule.INSTANCE.string1()));
+    map.put(2, Checks.checkProvisionNotNull(TestModule.INSTANCE.string2()));
+    return map;
+  }
+
+  Map<Class<? extends MyApi>, MyApi> mapOfMapClassMyApiMyApi() {
+    final Map<Class<? extends MyApi>, MyApi> map = new HashMap<>(3);
+    map.put(Impl1.class, Checks.checkProvisionNotNull(TestModule.INSTANCE.apiImpl1()));
+    map.put(Impl2.class, new Impl2());
+    map.put(Impl3.class, new Impl3());
+    return map;
+  }
+
+  Map<Class<? extends MyApi>, Provider<MyApi>> mapOfMapClassMyApiProviderMyApi() {
+    final Map<Class<? extends MyApi>, Provider<MyApi>> map = new HashMap<>(3);
+    map.put(Impl1.class, new ProviderImpl(this, 7));
+    map.put(Impl2.class, new ProviderImpl(this, 8));
+    map.put(Impl3.class, new ProviderImpl(this, 9));
+    return map;
+  }
+
+  Map<MyEnum, MyApi> mapOfMapMyEnumMyApi() {
+    final Map<MyEnum, MyApi> map = new HashMap<>(3);
+    map.put(MyEnum.ONE, Checks.checkProvisionNotNull(TestModule.INSTANCE.one()));
+    map.put(MyEnum.TWO, Checks.checkProvisionNotNull(TestModule.INSTANCE.two()));
+    map.put(MyEnum.THREE, Checks.checkProvisionNotNull(TestModule.INSTANCE.three()));
+    return map;
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/basic-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/basic-test.golden-code.txt
@@ -1,0 +1,133 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mClassAInstance;
+
+  private Object mClassBInstance;
+
+  private Object mClassCInstance;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public List<Create> bootstrap() {
+    return this.accessListCreate();
+  }
+
+  @Override
+  public Provider<List<Create>> bootstrapLater() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Consumer getC() {
+    return new Consumer(this.accessListCreate(), new ProviderImpl(this, 0));
+  }
+
+  @Override
+  public ConsumerJava getC2() {
+    return new ConsumerJava(this.accessListCreate(), new ProviderImpl(this, 0));
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.accessListCreate();
+      default: throw new AssertionError();
+    }
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA(this.cacheClassB());
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  ClassB cacheClassB() {
+    Object local = this.mClassBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassB();
+      this.mClassBInstance = local;
+    }
+    return (ClassB) local;
+  }
+
+  ClassC cacheClassC() {
+    Object local = this.mClassCInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassC(this.cacheClassA());
+      this.mClassCInstance = local;
+    }
+    return (ClassC) local;
+  }
+
+  List<Create> accessListCreate() {
+    return this.manyOfListCreate();
+  }
+
+  List<Create> manyOfListCreate() {
+    final List<Create> c = new ArrayList<>(3);
+    c.add(this.cacheClassB());
+    c.add(this.cacheClassA());
+    c.add(this.cacheClassC());
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/default-binding-ordering-for-list-bindings.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/default-binding-ordering-for-list-bindings.golden-code.txt
@@ -1,0 +1,153 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyComponent.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MyComponent implements MyComponent {
+  private Object mCreateBInstance;
+
+  private Object mCreateDestroyAInstance;
+
+  private Object mCreateDestroyBInstance;
+
+  private Object mCreateDestroyCInstance;
+
+  private Object mDestroyAInstance;
+
+  final CreateX mX;
+
+  final MyDependency mMyDependency;
+
+  Yatagan$MyComponent(CreateX pX, MyDependency pDep) {
+    this.mX = Checks.checkInputNotNull(pX);
+    this.mMyDependency = Checks.checkInputNotNull(pDep);
+  }
+
+  @Override
+  public List<List<?>> getAllLists() {
+    return this.manyOfListListObject();
+  }
+
+  @Override
+  public List<Create> getBootstrapCreate() {
+    return this.accessListCreate();
+  }
+
+  @Override
+  public List<Destroy> getBootstrapDestroy() {
+    return this.accessListDestroy();
+  }
+
+  CreateB cacheCreateB() {
+    Object local = this.mCreateBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new CreateB(new CreateA());
+      this.mCreateBInstance = local;
+    }
+    return (CreateB) local;
+  }
+
+  CreateDestroyA cacheCreateDestroyA() {
+    Object local = this.mCreateDestroyAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new CreateDestroyA();
+      this.mCreateDestroyAInstance = local;
+    }
+    return (CreateDestroyA) local;
+  }
+
+  CreateDestroyB cacheCreateDestroyB() {
+    Object local = this.mCreateDestroyBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new CreateDestroyB();
+      this.mCreateDestroyBInstance = local;
+    }
+    return (CreateDestroyB) local;
+  }
+
+  CreateDestroyC cacheCreateDestroyC() {
+    Object local = this.mCreateDestroyCInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new CreateDestroyC();
+      this.mCreateDestroyCInstance = local;
+    }
+    return (CreateDestroyC) local;
+  }
+
+  DestroyA cacheDestroyA() {
+    Object local = this.mDestroyAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new DestroyA();
+      this.mDestroyAInstance = local;
+    }
+    return (DestroyA) local;
+  }
+
+  List<Destroy> accessListDestroy() {
+    return this.manyOfListDestroy();
+  }
+
+  List<Create> accessListCreate() {
+    return this.manyOfListCreate();
+  }
+
+  List<List<?>> manyOfListListObject() {
+    final List<List<?>> c = new ArrayList<>(3);
+    c.add(Checks.checkProvisionNotNull(MyModule.Companion.myListOfNumbers()));
+    c.add(this.accessListDestroy());
+    c.add(this.accessListCreate());
+    return c;
+  }
+
+  List<Destroy> manyOfListDestroy() {
+    final List<Destroy> c = new ArrayList<>(5);
+    c.add(Checks.checkProvisionNotNull(MyModule.Companion.createDestroyD()));
+    c.add(this.cacheCreateDestroyA());
+    c.add(this.cacheCreateDestroyB());
+    c.add(this.cacheCreateDestroyC());
+    c.add(this.cacheDestroyA());
+    return c;
+  }
+
+  List<Create> manyOfListCreate() {
+    final List<Create> c = new ArrayList<>(11);
+    c.add(Checks.checkProvisionNotNull(MyModule.Companion.createDestroyD()));
+    c.add(new CreateA());
+    c.add(this.cacheCreateB());
+    c.add(this.cacheCreateDestroyA());
+    c.add(this.cacheCreateDestroyB());
+    c.add(this.cacheCreateDestroyC());
+    c.add(this.mMyDependency);
+    c.add(this.mMyDependency.getMyNewCreate1());
+    c.add(this.mMyDependency.getMyNewCreate2());
+    c.add(this);
+    c.add(this.mX);
+    return c;
+  }
+
+  public static MyComponent.Builder builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private static final class ComponentFactoryImpl implements MyComponent.Builder {
+    @Override
+    public MyComponent create(CreateX x, MyDependency dep) {
+      return new Yatagan$MyComponent(x, dep);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/flattening-contribution.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/flattening-contribution.golden-code.txt
@@ -1,0 +1,70 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  final TestModule mTestModule;
+
+  final TestModuleKotlin mTestModuleKotlin;
+
+  private Yatagan$TestComponent(TestModule pTestModule, TestModuleKotlin pTestModuleKotlin) {
+    this.mTestModule = pTestModule != null ? pTestModule : new TestModule();
+    this.mTestModuleKotlin = pTestModuleKotlin != null ? pTestModuleKotlin : new TestModuleKotlin();
+  }
+
+  @Override
+  public List<Integer> getInts() {
+    return this.manyOfListInteger();
+  }
+
+  List<Integer> manyOfListInteger() {
+    final List<Integer> c = new ArrayList<>(6);
+    c.addAll(Checks.checkProvisionNotNull(this.mTestModule.collectionOfInts()));
+    c.addAll(Checks.checkProvisionNotNull(this.mTestModuleKotlin.collectionOfInts()));
+    c.addAll(Checks.checkProvisionNotNull(this.mTestModule.listOfInts()));
+    c.addAll(Checks.checkProvisionNotNull(this.mTestModuleKotlin.listOfInts()));
+    c.addAll(Checks.checkProvisionNotNull(TestModule.setOfInts()));
+    c.addAll(Checks.checkProvisionNotNull(this.mTestModuleKotlin.setOfInts()));
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    private TestModule mTestModule;
+
+    private TestModuleKotlin mTestModuleKotlin;
+
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      if (inputClass == TestModule.class) {
+        this.mTestModule = (TestModule) input;
+      } else if (inputClass == TestModuleKotlin.class) {
+        this.mTestModuleKotlin = (TestModuleKotlin) input;
+      } else {
+        Checks.reportUnexpectedAutoBuilderInput(inputClass, Arrays.asList(TestModule.class, TestModuleKotlin.class));
+      }
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent(this.mTestModule, this.mTestModuleKotlin);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/list-bindings-are-inherited-from-super-components.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/list-bindings-are-inherited-from-super-components.golden-code.txt
@@ -1,0 +1,183 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$RootComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Number;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$RootComponent implements RootComponent {
+  private Yatagan$RootComponent() {
+  }
+
+  @Override
+  public List<Integer> getQInts() {
+    return this.accessJavaxInjectNamedValueQualifiedListInteger();
+  }
+
+  @Override
+  public SubComponent.Builder getSub() {
+    return new SubComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public SubComponent2.Builder getSub2() {
+    return new SubComponent2Impl.ComponentFactoryImpl(this);
+  }
+
+  List<Integer> accessJavaxInjectNamedValueQualifiedListInteger() {
+    return this.manyOfListInteger();
+  }
+
+  List<Number> accessListNumber() {
+    return this.manyOfListNumber();
+  }
+
+  List<Integer> manyOfListInteger() {
+    final List<Integer> c = new ArrayList<>(3);
+    c.add(Checks.checkProvisionNotNull(RootModule.INSTANCE.qInt1()));
+    c.add(Checks.checkProvisionNotNull(RootModule.INSTANCE.qInt2()));
+    c.add(Checks.checkProvisionNotNull(RootModule.INSTANCE.qInt3()));
+    return c;
+  }
+
+  List<Number> manyOfListNumber() {
+    final List<Number> c = new ArrayList<>(3);
+    c.add(Checks.checkProvisionNotNull(RootModule.INSTANCE.three()));
+    c.add(Checks.checkProvisionNotNull(RootModule.INSTANCE.two()));
+    c.addAll(Checks.checkProvisionNotNull(RootModule.INSTANCE.zeroAndOne()));
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$RootComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponentImpl implements SubComponent {
+    final Yatagan$RootComponent mRootComponent;
+
+    SubComponentImpl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public List<Number> getNumbers() {
+      return this.accessListNumber();
+    }
+
+    @Override
+    public List<Integer> getQInts() {
+      return this.mRootComponent.accessJavaxInjectNamedValueQualifiedListInteger();
+    }
+
+    List<Number> accessListNumber() {
+      return this.manyOfListNumber();
+    }
+
+    List<Number> manyOfListNumber() {
+      final List<Number> c = new ArrayList<>(3);
+      c.addAll(this.mRootComponent.accessListNumber());
+      c.add(Checks.checkProvisionNotNull(SubModule.INSTANCE.five()));
+      c.add(Checks.checkProvisionNotNull(SubModule.INSTANCE.four()));
+      c.addAll(Checks.checkProvisionNotNull(SubModule.INSTANCE.sixAndSeven()));
+      return c;
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent.Builder {
+      Yatagan$RootComponent fRootComponent;
+
+      ComponentFactoryImpl(Yatagan$RootComponent fRootComponent) {
+        this.fRootComponent = fRootComponent;
+      }
+
+      @Override
+      public SubComponent create() {
+        return new SubComponentImpl(this.fRootComponent);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponent2Impl implements SubComponent2 {
+    final Yatagan$RootComponent mRootComponent;
+
+    SubComponent2Impl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public Consumer getConsumer() {
+      return new Consumer(this.accessListNumber());
+    }
+
+    @Override
+    public List<Number> getNumbers() {
+      return this.accessListNumber();
+    }
+
+    @Override
+    public List<Integer> getQInts() {
+      return this.accessJavaxInjectNamedValueQualifiedListInteger();
+    }
+
+    List<Integer> accessJavaxInjectNamedValueQualifiedListInteger() {
+      return this.manyOfListInteger();
+    }
+
+    List<Number> accessListNumber() {
+      return this.manyOfListNumber();
+    }
+
+    List<Integer> manyOfListInteger() {
+      final List<Integer> c = new ArrayList<>(1);
+      c.addAll(this.mRootComponent.accessJavaxInjectNamedValueQualifiedListInteger());
+      c.add(Checks.checkProvisionNotNull(SubModule2.INSTANCE.qInt1()));
+      return c;
+    }
+
+    List<Number> manyOfListNumber() {
+      final List<Number> c = new ArrayList<>(2);
+      c.addAll(this.mRootComponent.accessListNumber());
+      c.add(Checks.checkProvisionNotNull(SubModule2.INSTANCE.p0()));
+      c.add(Checks.checkProvisionNotNull(SubModule2.INSTANCE.p1()));
+      return c;
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent2.Builder {
+      Yatagan$RootComponent fRootComponent;
+
+      ComponentFactoryImpl(Yatagan$RootComponent fRootComponent) {
+        this.fRootComponent = fRootComponent;
+      }
+
+      @Override
+      public SubComponent2 create() {
+        return new SubComponent2Impl(this.fRootComponent);
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$RootComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$RootComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$RootComponent create() {
+      return new Yatagan$RootComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/list-declaration-binds-empty-list.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/list-declaration-binds-empty-list.golden-code.txt
@@ -1,0 +1,47 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public List<Create> bootstrap() {
+    return this.manyOfListCreate();
+  }
+
+  List<Create> manyOfListCreate() {
+    final List<Create> c = new ArrayList<>(0);
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/map-bindings-are-inherited-from-super-components.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/map-bindings-are-inherited-from-super-components.golden-code.txt
@@ -1,0 +1,175 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$RootComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$RootComponent implements RootComponent {
+  private Yatagan$RootComponent() {
+  }
+
+  @Override
+  public Map<Integer, Integer> getQInts() {
+    return this.accessJavaxInjectNamedValueQualifiedMapIntegerInteger();
+  }
+
+  @Override
+  public SubComponent.Builder getSub() {
+    return new SubComponentImpl.ComponentFactoryImpl(this);
+  }
+
+  @Override
+  public SubComponent2.Builder getSub2() {
+    return new SubComponent2Impl.ComponentFactoryImpl(this);
+  }
+
+  Map<Integer, String> accessMapIntegerString() {
+    return this.mapOfMapIntegerString();
+  }
+
+  Map<Integer, Integer> accessJavaxInjectNamedValueQualifiedMapIntegerInteger() {
+    return this.mapOfMapIntegerInteger();
+  }
+
+  public static AutoBuilder<Yatagan$RootComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  Map<Integer, String> mapOfMapIntegerString() {
+    final Map<Integer, String> map = new HashMap<>(2);
+    map.put(1, Checks.checkProvisionNotNull(RootModule.INSTANCE.one()));
+    map.put(2, Checks.checkProvisionNotNull(RootModule.INSTANCE.two()));
+    return map;
+  }
+
+  Map<Integer, Integer> mapOfMapIntegerInteger() {
+    final Map<Integer, Integer> map = new HashMap<>(2);
+    map.put(1, Checks.checkProvisionNotNull(RootModule.INSTANCE.qInt1()));
+    map.put(2, Checks.checkProvisionNotNull(RootModule.INSTANCE.qInt2()));
+    return map;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponentImpl implements SubComponent {
+    final Yatagan$RootComponent mRootComponent;
+
+    SubComponentImpl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public Map<Integer, String> getMap() {
+      return this.accessMapIntegerString();
+    }
+
+    @Override
+    public Map<Integer, Integer> getQInts() {
+      return this.mRootComponent.accessJavaxInjectNamedValueQualifiedMapIntegerInteger();
+    }
+
+    Map<Integer, String> accessMapIntegerString() {
+      return this.mapOfMapIntegerString();
+    }
+
+    Map<Integer, String> mapOfMapIntegerString() {
+      final Map<Integer, String> map = new HashMap<>(2);
+      map.putAll(this.mRootComponent.accessMapIntegerString());
+      map.put(3, Checks.checkProvisionNotNull(SubModule.INSTANCE.three()));
+      map.put(4, Checks.checkProvisionNotNull(SubModule.INSTANCE.four()));
+      return map;
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent.Builder {
+      Yatagan$RootComponent fRootComponent;
+
+      ComponentFactoryImpl(Yatagan$RootComponent fRootComponent) {
+        this.fRootComponent = fRootComponent;
+      }
+
+      @Override
+      public SubComponent create() {
+        return new SubComponentImpl(this.fRootComponent);
+      }
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubComponent2Impl implements SubComponent2 {
+    final Yatagan$RootComponent mRootComponent;
+
+    SubComponent2Impl(Yatagan$RootComponent pRootComponent) {
+      this.mRootComponent = pRootComponent;
+    }
+
+    @Override
+    public Map<Integer, String> getMap() {
+      return this.accessMapIntegerString();
+    }
+
+    @Override
+    public Map<Integer, Integer> getQInts() {
+      return this.accessJavaxInjectNamedValueQualifiedMapIntegerInteger();
+    }
+
+    Map<Integer, Integer> accessJavaxInjectNamedValueQualifiedMapIntegerInteger() {
+      return this.mapOfMapIntegerInteger();
+    }
+
+    Map<Integer, String> accessMapIntegerString() {
+      return this.mapOfMapIntegerString();
+    }
+
+    Map<Integer, Integer> mapOfMapIntegerInteger() {
+      final Map<Integer, Integer> map = new HashMap<>(1);
+      map.putAll(this.mRootComponent.accessJavaxInjectNamedValueQualifiedMapIntegerInteger());
+      map.put(3, Checks.checkProvisionNotNull(SubModule2.INSTANCE.qInt1()));
+      return map;
+    }
+
+    Map<Integer, String> mapOfMapIntegerString() {
+      final Map<Integer, String> map = new HashMap<>(2);
+      map.putAll(this.mRootComponent.accessMapIntegerString());
+      map.put(3, Checks.checkProvisionNotNull(SubModule2.INSTANCE.p0()));
+      map.put(20, Checks.checkProvisionNotNull(SubModule2.INSTANCE.p1()));
+      return map;
+    }
+
+    private static final class ComponentFactoryImpl implements SubComponent2.Builder {
+      Yatagan$RootComponent fRootComponent;
+
+      ComponentFactoryImpl(Yatagan$RootComponent fRootComponent) {
+        this.fRootComponent = fRootComponent;
+      }
+
+      @Override
+      public SubComponent2 create() {
+        return new SubComponent2Impl(this.fRootComponent);
+      }
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$RootComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$RootComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$RootComponent create() {
+      return new Yatagan$RootComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/multi-bound-list-with-conditional-entries.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/multi-bound-list-with-conditional-entries.golden-code.txt
@@ -1,0 +1,97 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mClassAInstance;
+
+  private Object mClassBInstance;
+
+  private Object mClassCInstance;
+
+  final boolean mFeaturesCompanion_isEnabled = Features.Companion.isEnabled();
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public List<Create> bootstrap() {
+    return this.manyOfListCreate();
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA(this.optOfClassB());
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  ClassB cacheClassB() {
+    Object local = this.mClassBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassB();
+      this.mClassBInstance = local;
+    }
+    return (ClassB) local;
+  }
+
+  Optional optOfClassB() {
+    return this.mFeaturesCompanion_isEnabled ? Optional.of(this.cacheClassB()) : Optional.empty();
+  }
+
+  ClassC cacheClassC() {
+    Object local = this.mClassCInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassC(this.cacheClassA());
+      this.mClassCInstance = local;
+    }
+    return (ClassC) local;
+  }
+
+  List<Create> manyOfListCreate() {
+    final List<Create> c = new ArrayList<>(3);
+    if (this.mFeaturesCompanion_isEnabled)  {
+      c.add(this.cacheClassB());
+    }
+    c.add(this.cacheClassA());
+    c.add(this.cacheClassC());
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/MultibindingsTest/multi-bound-set-basic-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/MultibindingsTest/multi-bound-set-basic-test.golden-code.txt
@@ -1,0 +1,129 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Optional;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Number;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mClassAInstance;
+
+  private Object mClassBInstance;
+
+  private Object mClassCInstance;
+
+  final boolean mFeaturesCompanion_isEnabled = Features.Companion.isEnabled();
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return this.cacheClassA();
+  }
+
+  @Override
+  public ClassC getC() {
+    return this.cacheClassC();
+  }
+
+  @Override
+  public Consumer getConsumer() {
+    return new Consumer(this.accessSetHandler());
+  }
+
+  @Override
+  public Set<Number> getNumbers() {
+    return this.manyOfSetNumber();
+  }
+
+  @Override
+  public Set<Handler> handlers() {
+    return this.accessSetHandler();
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA(this.optOfClassB());
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  ClassB cacheClassB() {
+    Object local = this.mClassBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassB();
+      this.mClassBInstance = local;
+    }
+    return (ClassB) local;
+  }
+
+  Optional optOfClassB() {
+    return this.mFeaturesCompanion_isEnabled ? Optional.of(this.cacheClassB()) : Optional.empty();
+  }
+
+  ClassC cacheClassC() {
+    Object local = this.mClassCInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassC(this.cacheClassA());
+      this.mClassCInstance = local;
+    }
+    return (ClassC) local;
+  }
+
+  Set<Handler> accessSetHandler() {
+    return this.manyOfSetHandler();
+  }
+
+  Set<Number> manyOfSetNumber() {
+    final Set<Number> c = new HashSet<>(0);
+    return c;
+  }
+
+  Set<Handler> manyOfSetHandler() {
+    final Set<Handler> c = new HashSet<>(5);
+    c.add(this.cacheClassA());
+    if (this.mFeaturesCompanion_isEnabled)  {
+      c.add(this.cacheClassB());
+    }
+    c.add(this.cacheClassC());
+    c.addAll(Checks.checkProvisionNotNull(MyModule.Companion.collection1()));
+    c.addAll(Checks.checkProvisionNotNull(MyModule.Companion.collection2()));
+    return c;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/RuntimeTest/basic-component-included-modules-are-deduplicated.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/RuntimeTest/basic-component-included-modules-are-deduplicated.golden-code.txt
@@ -1,0 +1,50 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Simple bye() {
+    return Checks.checkProvisionNotNull(MyModuleBye.bye());
+  }
+
+  @Override
+  public Simple foo() {
+    return Checks.checkProvisionNotNull(MyModuleFoo.foo());
+  }
+
+  @Override
+  public Simple hello() {
+    return Checks.checkProvisionNotNull(MyModuleHello.hello());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/RuntimeTest/check-Provides-used-instead-of-Inject-constructor-if-exists.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/RuntimeTest/check-Provides-used-instead-of-Inject-constructor-if-exists.golden-code.txt
@@ -1,0 +1,45 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Impl impl() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.impl());
+  }
+
+  @Override
+  public Wrapper wrapper() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.wrapper());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/RuntimeTest/check-qualified-providings-are-correct.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/RuntimeTest/check-qualified-providings-are-correct.golden-code.txt
@@ -1,0 +1,50 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public Simple one() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.one());
+  }
+
+  @Override
+  public Simple simple() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.simple());
+  }
+
+  @Override
+  public Simple two() {
+    return Checks.checkProvisionNotNull(MyModule.INSTANCE.two());
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/RuntimeTest/thread-assertions.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/RuntimeTest/thread-assertions.golden-code.txt
@@ -1,0 +1,143 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MySTComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$MySTComponent implements MySTComponent {
+  private Object mMyClassAInstance;
+
+  private Object mMyClassBInstance;
+
+  private Object mMyClassCInstance;
+
+  private Yatagan$MySTComponent() {
+  }
+
+  @Override
+  public Lazy<MyClassA> getA() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public MyClassB getB() {
+    return this.cacheMyClassB();
+  }
+
+  @Override
+  public MyClassC getC() {
+    return this.cacheMyClassC();
+  }
+
+  @Override
+  public Lazy<MyClassD> getD() {
+    return new CachingProviderImpl(this, 1);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheMyClassA();
+      case 1: return new MyClassD();
+      default: throw new AssertionError();
+    }
+  }
+
+  MyClassA cacheMyClassA() {
+    Object local = this.mMyClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClassA();
+      this.mMyClassAInstance = local;
+    }
+    return (MyClassA) local;
+  }
+
+  MyClassB cacheMyClassB() {
+    Object local = this.mMyClassBInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClassB();
+      this.mMyClassBInstance = local;
+    }
+    return (MyClassB) local;
+  }
+
+  MyClassC cacheMyClassC() {
+    Object local = this.mMyClassCInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClassC();
+      this.mMyClassCInstance = local;
+    }
+    return (MyClassC) local;
+  }
+
+  public static AutoBuilder<Yatagan$MySTComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$MySTComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MySTComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class CachingProviderImpl implements Lazy {
+    private final Yatagan$MySTComponent mDelegate;
+
+    private final int mIndex;
+
+    private Object mValue;
+
+    CachingProviderImpl(Yatagan$MySTComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = mDelegate.switch$$access(mIndex);
+        mValue = local;
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MySTComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MySTComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MySTComponent create() {
+      return new Yatagan$MySTComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ScopesTest/multi-threaded-mode.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ScopesTest/multi-threaded-mode.golden-code.txt
@@ -1,0 +1,169 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private volatile Object mClassAInstance = new UninitializedLock();
+
+  private volatile Object mClassBInstance = new UninitializedLock();
+
+  private volatile Object mClassCInstance = new UninitializedLock();
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return this.cacheClassA();
+  }
+
+  @Override
+  public Lazy<ClassB> getB() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<ClassC> getC() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Provider<ClassD> getD() {
+    return new ProviderImpl(this, 2);
+  }
+
+  @Override
+  public Lazy<ClassE> getE() {
+    return new DoubleCheck(this, 3);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheClassB();
+      case 1: return this.cacheClassC();
+      case 2: return new ClassD(this.cacheClassB());
+      case 3: return new ClassE(this.cacheClassB());
+      default: throw new AssertionError();
+    }
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local instanceof UninitializedLock) {
+      synchronized (local) {
+        local = this.mClassAInstance;
+        if (local instanceof UninitializedLock) {
+          local = new ClassA();
+          this.mClassAInstance = local;
+        }
+      }
+    }
+    return (ClassA) local;
+  }
+
+  ClassB cacheClassB() {
+    Object local = this.mClassBInstance;
+    if (local instanceof UninitializedLock) {
+      synchronized (local) {
+        local = this.mClassBInstance;
+        if (local instanceof UninitializedLock) {
+          local = new ClassB(this.cacheClassA());
+          this.mClassBInstance = local;
+        }
+      }
+    }
+    return (ClassB) local;
+  }
+
+  ClassC cacheClassC() {
+    Object local = this.mClassCInstance;
+    if (local instanceof UninitializedLock) {
+      synchronized (local) {
+        local = this.mClassCInstance;
+        if (local instanceof UninitializedLock) {
+          local = new ClassC(this.cacheClassA());
+          this.mClassCInstance = local;
+        }
+      }
+    }
+    return (ClassC) local;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class UninitializedLock {
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$TestComponent delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class DoubleCheck implements Lazy {
+    private final Yatagan$TestComponent mDelegate;
+
+    private final int mIndex;
+
+    private volatile Object mValue;
+
+    DoubleCheck(Yatagan$TestComponent factory, int index) {
+      mDelegate = factory;
+      mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      Object local = mValue;
+      if (local == null) {
+        synchronized (this) {
+          local = mValue;
+          if (local == null) {
+            local = mDelegate.switch$$access(mIndex);
+            mValue = local;
+          }
+        }
+      }
+      return local;
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ScopesTest/reusable-scope-is-compatible-with-every-scope-and-is-cached.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ScopesTest/reusable-scope-is-compatible-with-every-scope-and-is-cached.golden-code.txt
@@ -1,0 +1,209 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$ComponentA.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$ComponentA implements ComponentA {
+  private Object mMyClassInstance;
+
+  private Yatagan$ComponentA() {
+  }
+
+  @Override
+  public Provider<MyClass> getMy() {
+    return new ProviderImpl(this, 0);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheMyClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  MyClass cacheMyClass() {
+    Object local = this.mMyClassInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClass();
+      this.mMyClassInstance = local;
+    }
+    return (MyClass) local;
+  }
+
+  public static AutoBuilder<Yatagan$ComponentA> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$ComponentA mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$ComponentA delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$ComponentA> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$ComponentA> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$ComponentA create() {
+      return new Yatagan$ComponentA();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$ComponentB.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.Lazy;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.AssertionError;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$ComponentB implements ComponentB {
+  private Object mObjectInstance;
+
+  private Object mMyClassInstance;
+
+  private Yatagan$ComponentB() {
+  }
+
+  @Override
+  public Provider<Object> getAny() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Provider<MyClass> getMy() {
+    return new ProviderImpl(this, 1);
+  }
+
+  @Override
+  public Subcomponent.Builder getSub() {
+    return new SubcomponentImpl.ComponentFactoryImpl(this);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheObject();
+      case 1: return this.cacheMyClass();
+      default: throw new AssertionError();
+    }
+  }
+
+  Object cacheObject() {
+    Object local = this.mObjectInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = Checks.checkProvisionNotNull(MyModule.INSTANCE.provide());
+      this.mObjectInstance = local;
+    }
+    return (Object) local;
+  }
+
+  MyClass cacheMyClass() {
+    Object local = this.mMyClassInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new MyClass();
+      this.mMyClassInstance = local;
+    }
+    return (MyClass) local;
+  }
+
+  public static AutoBuilder<Yatagan$ComponentB> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+  static final class SubcomponentImpl implements Subcomponent {
+    final Yatagan$ComponentB mComponentB;
+
+    SubcomponentImpl(Yatagan$ComponentB pComponentB) {
+      this.mComponentB = pComponentB;
+    }
+
+    @Override
+    public Object getAny() {
+      return this.mComponentB.cacheObject();
+    }
+
+    private static final class ComponentFactoryImpl implements Subcomponent.Builder {
+      Yatagan$ComponentB fComponentB;
+
+      ComponentFactoryImpl(Yatagan$ComponentB fComponentB) {
+        this.fComponentB = fComponentB;
+      }
+
+      @Override
+      public Subcomponent create() {
+        return new SubcomponentImpl(this.fComponentB);
+      }
+    }
+  }
+
+  static final class ProviderImpl implements Lazy {
+    private final Yatagan$ComponentB mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$ComponentB delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$ComponentB> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$ComponentB> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$ComponentB create() {
+      return new Yatagan$ComponentB();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ScopesTest/singleton-implicit-binding-is-cached.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ScopesTest/singleton-implicit-binding-is-cached.golden-code.txt
@@ -1,0 +1,54 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Object mClassAInstance;
+
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return this.cacheClassA();
+  }
+
+  ClassA cacheClassA() {
+    Object local = this.mClassAInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new ClassA();
+      this.mClassAInstance = local;
+    }
+    return (ClassA) local;
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/tests/src/test/resources/golden/ScopesTest/unscoped-implicit-binding-is-not-cached.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/ScopesTest/unscoped-implicit-binding-is-not-cached.golden-code.txt
@@ -1,0 +1,40 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$TestComponent.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.Collections;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+public final class Yatagan$TestComponent implements TestComponent {
+  private Yatagan$TestComponent() {
+  }
+
+  @Override
+  public ClassA getA() {
+    return new ClassA();
+  }
+
+  public static AutoBuilder<Yatagan$TestComponent> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$TestComponent> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$TestComponent> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$TestComponent create() {
+      return new Yatagan$TestComponent();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Closes #2

#### Testing: Introduce validation against "golden" generated code.

#### Testing: Remove ambiguity from complex conditions test case.

Old Conditions API is soon-to-be-deprecated, partially because
 of the heavy reliance on annotations order, which is not stable
 across backends and tool versions (very sadly).

So replace repeatable annotations with explicit container usage.

#### Testing: Split `HeavyTest`s into separate tests instead of parameterizing.

This way it's possible to generate a golden file for each case.

#### Testing, Codegen: Support stable generation order for tests.

KSP yields declarations (methods, properties, etc.) in undefined
 order (!). There is an API to get declarations in source-order,
 but it is limited and explicitly stated to be very slow.

So, use explicit sorting for preparation for verifying "golden" code output
 in integration tests.

#### Api (lang): Make `Field` comparable.

Add extensions for comparing `Member`s.

#### Testing: Use `JAP` as "golden" backend.

Some tests are off for KSP and that might be a problem for
 golden files generation.

#### Testing: Use `-java-parameters` for all compilation tests.

Previously it was used only for RT.

---------------------------

It's better to review by commits