### PR TITLE
Fix: Move alias duplicate check to GraphBindingsManager.

### DIFF
--- a/core/graph/impl/src/main/kotlin/GraphBindingsManager.kt
+++ b/core/graph/impl/src/main/kotlin/GraphBindingsManager.kt
@@ -336,7 +336,9 @@ internal class GraphBindingsManager(
             }
 
             if (bindings.size > 1) {
-                val distinct = bindings.toSet()
+                val distinct = bindings
+                        .map { it.maybeUnwrapSyntheticAlias() }
+                        .distinctBy { it.accept(AliasEquivalenceSelector) }
                 if (distinct.size > 1) {
 
                     // We tolerate multibinding duplicates, because of the "extends" behavior.
@@ -478,6 +480,14 @@ internal class GraphBindingsManager(
         val keyType: Type,
         val valueType: NodeModel,
     )
+
+    private object AliasEquivalenceSelector : BaseBinding.Visitor<Any> {
+        override fun visitAlias(alias: AliasBinding): Pair<NodeModel, NodeModel> {
+            // We compare aliases only as a pair {source; target} in terms of duplicate check.
+            return alias.source to alias.target
+        }
+        override fun visitBinding(binding: Binding) = binding
+    }
 
     companion object Key : Extensible.Key<GraphBindingsManager> {
         override val keyType get() = GraphBindingsManager::class.java

--- a/core/graph/impl/src/main/kotlin/bindings/AliasBindingImpl.kt
+++ b/core/graph/impl/src/main/kotlin/bindings/AliasBindingImpl.kt
@@ -39,17 +39,6 @@ internal class AliasBindingImpl(
 
     override val source get() = impl.sources.single()
 
-    override fun equals(other: Any?): Boolean {
-        return this === other || (other is AliasBinding &&
-                source == other.source && target == other.target)
-    }
-
-    override fun hashCode(): Int {
-        var result = target.hashCode()
-        result = 31 * result + source.hashCode()
-        return result
-    }
-
     override fun toString(childContext: MayBeInvalid?) = bindingModelRepresentation(
         modelClassName = "alias",
         childContext = childContext,

--- a/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
+++ b/testing/tests/src/test/kotlin/CoreBindingsFailureTest.kt
@@ -909,4 +909,38 @@ class CoreBindingsFailureTest(
 
         compileRunAndValidate()
     }
+
+    @Test
+    fun `case for #88`() {
+        givenKotlinSource("test.TestCase", """
+            import com.yandex.yatagan.*
+            import javax.inject.*
+            interface Api
+            interface Api2
+            class Impl @Inject constructor(api2: Api2): Api
+            class Impl2 @Inject constructor(): Api2
+
+            @Module interface MyModule1 {
+                @Binds fun api(i: Impl): Api
+                @Binds fun api2(i: Impl2): Api2
+            }
+            @Module interface MyModule2 {
+                @Binds fun api(i: Impl): Api
+            }
+
+            @Component interface RootComponent {
+                fun createSub2(): SubComponent2
+                fun createSub1(): SubComponent1
+            }
+
+            @Component(isRoot = false, modules = [MyModule1::class]) interface SubComponent1 {
+                val api: Api
+            }
+            @Component(isRoot = false, modules = [MyModule2::class]) interface SubComponent2 {
+                val api: Api
+            }
+        """.trimIndent())
+
+        compileRunAndValidate()
+    }
 }

--- a/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/case-for-88.golden.txt
+++ b/testing/tests/src/test/resources/golden/CoreBindingsFailureTest/case-for-88.golden.txt
@@ -1,0 +1,13 @@
+error: Missing binding for test.Api2
+NOTE: No known way to infer the binding
+Encountered:
+  in graph for root-component test.RootComponent
+  in graph for component test.SubComponent2
+  in entry-point getApi: test.Api
+                         ^-[*1]--
+  in [1*] alias test.MyModule2::api(test.Impl)
+                                    ^-[*2]---
+  in [2*] inject-constructor test.Impl(test.Api2)
+                                       ^-[*3]---
+  here: [3*] <missing>
+             ^~~~~~~~~


### PR DESCRIPTION
Before this was implemented as equals/hashCode in AliasBindingImpl,
 which was affecting the correct work of the validation pipeline.
So this CL moves the alias comparison logic to GraphBindingsManager.

Fixes #88