### PR TITLE
Tests: Remove mockito usage from heavy tests.

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -138,33 +138,6 @@ limitations under the License.
 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
-org.mockito.kotlin:mockito-kotlin
-
-MIT License
-
-Copyright (c) 2016 Niek Haarman
-Copyright (c) 2007 Mockito contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
 io.github.gradle-nexus:publish-plugin
 
 Copyright (c) Marcin Zajączkowski

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,5 +34,4 @@ yataganDogFood-ksp = { module = "com.yandex.yatagan:processor-ksp", version.ref 
 # Testing libraries
 testing-roomCompileTesting = "androidx.room:room-compiler-processing-testing:2.6.0-alpha01"
 testing-junit4 = "junit:junit:4.13.2"
-testing-mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:5.1.0"
 testing-assertj = "org.assertj:assertj-core:3.24.2"

--- a/testing/procedural/src/main/kotlin/ClassNames.kt
+++ b/testing/procedural/src/main/kotlin/ClassNames.kt
@@ -17,7 +17,6 @@
 package com.yandex.yatagan.testing.procedural
 
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.MemberName
 
 internal object ClassNames {
     val BindsInstance = ClassName("com.yandex.yatagan", "BindsInstance")
@@ -35,9 +34,6 @@ internal object ClassNames {
     val Scope = ClassName("javax.inject", "Scope")
     val Inject = ClassName("javax.inject", "Inject")
     val Provider = ClassName("javax.inject", "Provider")
-
-    val mock = MemberName("org.mockito.kotlin", "mock")
-    val Answers = ClassName("org.mockito", "Answers")
 
     val Any = ClassName("kotlin", "Any")
     val Suppress = ClassName("kotlin", "Suppress")

--- a/testing/tests/build.gradle.kts
+++ b/testing/tests/build.gradle.kts
@@ -61,7 +61,6 @@ dependencies {
     // For strings
     testImplementation(project(":validation:format"))
 
-    baseTestRuntime(libs.testing.mockito.kotlin.get())  // required for heavy tests
     dynamicTestRuntime(project(":api:dynamic"))
     compiledTestRuntime(project(":api:public"))
 


### PR DESCRIPTION
Mockito drastically slows the tests down, so replace heavy mockito machinery with a naive custom implementation, as it is enough for the tests.