### PR TITLE
Testing: Update room-compiler-processing-testing to 2.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,6 @@ yataganDogFood-api = { module = "com.yandex.yatagan:api-compiled", version.ref =
 yataganDogFood-ksp = { module = "com.yandex.yatagan:processor-ksp", version.ref = "yataganDogFood" }
 
 # Testing libraries
-testing-roomCompileTesting = "androidx.room:room-compiler-processing-testing:2.6.0-alpha01"
+testing-roomCompileTesting = "androidx.room:room-compiler-processing-testing:2.6.0"
 testing-junit4 = "junit:junit:4.13.2"
 testing-assertj = "org.assertj:assertj-core:3.24.2"

--- a/lang/jap/src/main/kotlin/com/yandex/yatagan/lang/jap/JavaxAnnotatedImpl.kt
+++ b/lang/jap/src/main/kotlin/com/yandex/yatagan/lang/jap/JavaxAnnotatedImpl.kt
@@ -26,13 +26,7 @@ internal class JavaxAnnotatedImpl(
 ) : CtAnnotated {
 
     override val annotations: Sequence<CtAnnotationBase> by lazy {
-        val annotations = impl.annotationMirrors.map { JavaxAnnotationImpl(it) }
-        if (impl.isFromKotlin()) {
-            // Means this is from KAPT, and it's known to be reversing annotations order.
-            annotations.asReversed()
-        } else {
-            annotations
-        }.asSequence()
+        impl.annotationMirrors.map { JavaxAnnotationImpl(it) }.asSequence()
     }
 
     override fun <A : Annotation> isAnnotatedWith(type: Class<A>): Boolean {


### PR DESCRIPTION
This update bumps the internal Kotlin version used to compile test cases to 1.9.0, which has KAPT annotation reversing fixed (see #74 for more info) So, as nice version-dependent solution is almost impossible, we just unconditionally use normal annotation order.