### PR TITLE
Update logicng to 2.5.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -27,10 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Check
-        uses: gradle/gradle-build-action@v3.3.1
-        with:
-          arguments: check -Penable_coverage=${{ matrix.os == 'ubuntu-latest' }} --no-configuration-cache --stacktrace
+        run: ./gradlew check -Penable_coverage=${{ matrix.os == 'ubuntu-latest' }} --no-configuration-cache --stacktrace
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ autoCommon = "com.google.auto:auto-common:1.2.2"
 poets-java = "com.squareup:javapoet:1.13.0"
 poets-kotlin = "com.squareup:kotlinpoet:1.16.0"
 
-logicng = "org.logicng:logicng-j11:2.4.3"
+logicng = "org.logicng:logicng:2.5.0"
 
 yataganDogFood-api = { module = "com.yandex.yatagan:api-compiled", version.ref = "yataganDogFood" }
 yataganDogFood-ksp = { module = "com.yandex.yatagan:processor-ksp", version.ref = "yataganDogFood" }


### PR DESCRIPTION
### Fix: Update logicng to 2.5.0.
new version is lighter and does not depend on the ANTLR library which may cause conflicts at runtime.

Closes #145 

### CI: Replace `gradle-build-action`.
`gradle-build-action` is replaced with `gradle/actions/setup-gradle`, as per it migration guide. The former is deprecated.