### PR TITLE
Api: Move `Provides.conditionals` API.

### DIFF
--- a/api/public/api/public.api
+++ b/api/public/api/public.api
@@ -151,7 +151,6 @@ public abstract interface class com/yandex/yatagan/Optional$Function {
 }
 
 public abstract interface annotation class com/yandex/yatagan/Provides : java/lang/annotation/Annotation {
-	public abstract fun value ()[Lcom/yandex/yatagan/Conditional;
 }
 
 public abstract interface annotation class com/yandex/yatagan/Reusable : java/lang/annotation/Annotation {

--- a/api/public/src/main/kotlin/com/yandex/yatagan/Conditional.kt
+++ b/api/public/src/main/kotlin/com/yandex/yatagan/Conditional.kt
@@ -64,6 +64,11 @@ import kotlin.reflect.KClass
  *   val a: UnderA,
  *   val b: UnderB,
  * )
+ *
+ * // Can be specified on a provision also.
+ * @Provides
+ * @Conditional(FeatureA::class)
+ * fun someProvision(): SomeClass
  * ```
  *
  * @see value
@@ -75,7 +80,7 @@ import kotlin.reflect.KClass
 @MustBeDocumented
 @JvmRepeatable(Conditionals::class)
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.CLASS)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
 public annotation class Conditional(
     /**
      * A list of **feature declarations** - annotation types, annotated with

--- a/api/public/src/main/kotlin/com/yandex/yatagan/Conditionals.kt
+++ b/api/public/src/main/kotlin/com/yandex/yatagan/Conditionals.kt
@@ -22,7 +22,7 @@ package com.yandex.yatagan
 @ConditionsApi
 @MustBeDocumented
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.CLASS)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
 public annotation class Conditionals(
     vararg val value: Conditional,
 )

--- a/api/public/src/main/kotlin/com/yandex/yatagan/Provides.kt
+++ b/api/public/src/main/kotlin/com/yandex/yatagan/Provides.kt
@@ -27,10 +27,4 @@ package com.yandex.yatagan
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY_GETTER,
 )
-@OptIn(ConditionsApi::class)
-public annotation class Provides(
-    /**
-     * One or more [Conditional] specifiers for this provision.
-     */
-    vararg val value: Conditional = [],
-)
+public annotation class Provides

--- a/core/model/impl/src/main/kotlin/com/yandex/yatagan/core/model/impl/bindingModelsImpl.kt
+++ b/core/model/impl/src/main/kotlin/com/yandex/yatagan/core/model/impl/bindingModelsImpl.kt
@@ -238,7 +238,7 @@ internal class ProvidesImpl(
 
     private val conditionalsModel by lazy {
         ConditionalHoldingModelImpl(
-            checkNotNull(method.getAnnotation(BuiltinAnnotation.Provides)) { "Not reached" }.conditionals
+            method.getAnnotations(BuiltinAnnotation.Conditional)
         )
     }
 

--- a/lang/api/src/main/kotlin/com/yandex/yatagan/lang/BuiltinAnnotation.kt
+++ b/lang/api/src/main/kotlin/com/yandex/yatagan/lang/BuiltinAnnotation.kt
@@ -142,13 +142,8 @@ public sealed interface BuiltinAnnotation {
      * Models `com.yandex.yatagan.Provides` annotation.
      */
     @Internal
-    public interface Provides : OnMethod {
-        public val conditionals: List<Conditional>
-
-        @Internal
-        public companion object : Target.OnMethod<Provides> {
-            override val modelClass: Class<Provides> get() = Provides::class.java
-        }
+    public object Provides : OnMethod, Target.OnMethod<Provides> {
+        override val modelClass: Class<Provides> get() = Provides::class.java
     }
 
     /**
@@ -236,12 +231,12 @@ public sealed interface BuiltinAnnotation {
      * Represents `com.yandex.yatagan.Conditional` annotation.
      */
     @Internal
-    public interface Conditional : OnClassRepeatable {
+    public interface Conditional : OnClassRepeatable, OnMethodRepeatable {
         public val featureTypes: List<Type>
         public val onlyIn: List<Type>
 
         @Internal
-        public companion object : Target.OnClassRepeatable<Conditional> {
+        public companion object : Target.OnClassRepeatable<Conditional>, Target.OnMethodRepeatable<Conditional> {
             override val modelClass: Class<Conditional> get() = Conditional::class.java
         }
     }

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtTypeNameModel.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtTypeNameModel.kt
@@ -115,9 +115,6 @@ sealed interface InvalidNameModel : CtTypeNameModel {
     }
 
     class TypeVariable(private val typeVar: String) : InvalidNameModel {
-        init {
-            print("dsd")
-        }
         override fun toString() = "<unresolved-type-var: $typeVar>"
     }
 }

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/builtinAnnotationImpls.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/builtinAnnotationImpls.kt
@@ -97,12 +97,6 @@ internal class CtComponentFlavorAnnotationImpl(
     override val dimension get() = impl.getType("dimension")
 }
 
-internal class CtProvidesAnnotationImpl(
-    impl: CtAnnotationBase,
-) : CtBuiltinAnnotationBase(impl), BuiltinAnnotation.Provides {
-    override val conditionals get() = impl.getAnnotations("value").map { CtConditionalAnnotationImpl(it) }
-}
-
 internal class CtIntoListAnnotationImpl(
     impl: CtAnnotationBase,
 ) : CtBuiltinAnnotationBase(impl), BuiltinAnnotation.IntoCollectionFamily.IntoList {

--- a/lang/rt/src/main/kotlin/com/yandex/yatagan/lang/rt/builtinAnnotationImpls.kt
+++ b/lang/rt/src/main/kotlin/com/yandex/yatagan/lang/rt/builtinAnnotationImpls.kt
@@ -86,19 +86,6 @@ internal class RtConditionalAnnotationImpl private constructor(
     }
 }
 
-internal class RtProvidesAnnotationImpl private constructor(
-    lexicalScope: LexicalScope,
-    impl: Provides,
-) : RtAnnotationImplBase<Provides>(impl), BuiltinAnnotation.Provides, LexicalScope by lexicalScope {
-    override val conditionals get() = impl.value.map {
-        RtConditionalAnnotationImpl(it)
-    }
-
-    companion object Factory : FactoryKey<Provides, RtProvidesAnnotationImpl> {
-        override fun LexicalScope.factory() = ::RtProvidesAnnotationImpl
-    }
-}
-
 internal class RtIntoListAnnotationImpl(
     impl: IntoList,
 ) : RtAnnotationImplBase<IntoList>(impl), BuiltinAnnotation.IntoCollectionFamily.IntoList {

--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/CompileTestDriverBase.kt
@@ -19,7 +19,6 @@ package com.yandex.yatagan.testing.tests
 import androidx.room.compiler.processing.util.compiler.TestCompilationArguments
 import androidx.room.compiler.processing.util.compiler.compile
 import com.yandex.yatagan.generated.CompiledApiClasspath
-import com.yandex.yatagan.generated.DynamicApiClasspath
 import com.yandex.yatagan.processor.common.BooleanOption
 import com.yandex.yatagan.processor.common.IntOption
 import com.yandex.yatagan.processor.common.LoggerDecorator
@@ -37,7 +36,7 @@ import kotlin.io.path.deleteIfExists
 import kotlin.io.path.writeText
 
 abstract class CompileTestDriverBase private constructor(
-    private val apiType: ApiType,
+    private val apiClasspath: String,
     private val mainSourceSet: SourceSet,
 ) : CompileTestDriver, SourceSet by mainSourceSet {
     private var precompiledModuleOutputDirs: List<File>? = null
@@ -48,8 +47,8 @@ abstract class CompileTestDriverBase private constructor(
     )
 
     protected constructor(
-        apiType: ApiType = ApiType.Compiled,
-    ) : this(apiType, SourceSet())
+        apiClasspath: String = CompiledApiClasspath,
+    ) : this(apiClasspath, SourceSet())
 
     override val testNameRule = TestNameRule()
 
@@ -200,10 +199,7 @@ abstract class CompileTestDriverBase private constructor(
     private fun createBaseCompilationArguments() = TestCompilationArguments(
         sources = sourceFiles,
         classpath = buildList {
-            when (apiType) {
-                ApiType.Compiled -> CompiledApiClasspath
-                ApiType.Dynamic -> DynamicApiClasspath
-            }.split(File.pathSeparatorChar).forEach { add(File(it)) }
+            apiClasspath.split(File.pathSeparatorChar).forEach { add(File(it)) }
             precompiledModuleOutputDirs?.let { addAll(it) }
         },
         inheritClasspath = false,

--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/DynamicCompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/DynamicCompileTestDriver.kt
@@ -18,6 +18,7 @@ package com.yandex.yatagan.testing.tests
 
 import com.squareup.javapoet.ClassName
 import com.yandex.yatagan.Component
+import com.yandex.yatagan.generated.DynamicApiClasspath
 import com.yandex.yatagan.lang.jap.asTypeElement
 import com.yandex.yatagan.lang.jap.isAnnotatedWith
 import com.yandex.yatagan.processor.common.IntOption
@@ -37,9 +38,7 @@ import javax.lang.model.element.TypeElement
 
 private const val TEST_DELEGATE = "test.TestValidationDelegate"
 
-class DynamicCompileTestDriver(
-    apiType: ApiType = ApiType.Dynamic,
-) : CompileTestDriverBase(apiType) {
+class DynamicCompileTestDriver() : CompileTestDriverBase(DynamicApiClasspath) {
     private val accumulator = ComponentBootstrapperGenerator()
     private val options = mutableMapOf<Option<*>, Any>(
         IntOption.MaxIssueEncounterPaths to 100,

--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/JapCompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/JapCompileTestDriver.kt
@@ -16,6 +16,7 @@
 
 package com.yandex.yatagan.testing.tests
 
+import com.yandex.yatagan.generated.CompiledApiClasspath
 import com.yandex.yatagan.processor.jap.JapYataganProcessor
 import java.io.File
 import java.net.URLClassLoader
@@ -24,7 +25,10 @@ import javax.annotation.processing.Processor
 class JapCompileTestDriver(
     private val customProcessorClasspath: String? = null,
     override val checkGoldenOutput: Boolean = true,
-): CompileTestDriverBase() {
+    apiClasspath: String = CompiledApiClasspath,
+): CompileTestDriverBase(
+    apiClasspath = apiClasspath,
+) {
     override fun createCompilationArguments() = super.createCompilationArguments().copy(
         kaptProcessors = listOf(loadProcessorFromCustomClasspath() ?: JapYataganProcessor()),
     )

--- a/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/ConditionsTest.kt
+++ b/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/ConditionsTest.kt
@@ -504,19 +504,16 @@ class ConditionsTest(
             
             @Module
             object MyModule {
-                @Provides(
-                    Conditional(Conditions.FeatureA::class, onlyIn = [ActivityType.Main::class]),
-                    Conditional(Conditions.FeatureB::class), // in the rest
-                )
+                @Conditional(Conditions.FeatureA::class, onlyIn = [ActivityType.Main::class])
+                @Conditional(Conditions.FeatureB::class) // in the rest
+                @Provides
                 fun provideApi(): Api {
                     return Impl()
                 }
                 
                 @Named
-                @Provides(
-                    Conditional(onlyIn = [ActivityType.Main::class]),
-                    // Nowhere else
-                )
+                @Conditional(onlyIn = [ActivityType.Main::class]) // Nowhere else
+                @Provides
                 fun provideNamedApi(): Api {
                     return Impl()
                 }

--- a/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/CoreBindingsFailureTest.kt
+++ b/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/CoreBindingsFailureTest.kt
@@ -295,7 +295,7 @@ class CoreBindingsFailureTest(
                 fun provideObject(c: UnderA): Any = c
                 @Provides @Named("ok1")
                 fun provideObject2(c: Optional<Provider<UnderA>>): Any = c
-                @Provides(Conditional(A::class)) @Named("ok2")
+                @Provides @Conditional(A::class) @Named("ok2")
                 fun provideObject3(c: UnderA): Any = c
             }
             

--- a/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/LoaderCompatibilityTest.kt
+++ b/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/LoaderCompatibilityTest.kt
@@ -16,10 +16,16 @@
 
 package com.yandex.yatagan.testing.tests
 
+import com.yandex.yatagan.generated.ApiClasspathForCompatCheck1_0_0
+import com.yandex.yatagan.generated.ApiClasspathForCompatCheck1_1_0
+import com.yandex.yatagan.generated.ApiClasspathForCompatCheck1_2_0
+import com.yandex.yatagan.generated.ApiClasspathForCompatCheck1_3_0
+import com.yandex.yatagan.generated.ApiClasspathForCompatCheck1_5_0
 import com.yandex.yatagan.generated.KaptClasspathForCompatCheck1_0_0
 import com.yandex.yatagan.generated.KaptClasspathForCompatCheck1_1_0
 import com.yandex.yatagan.generated.KaptClasspathForCompatCheck1_2_0
 import com.yandex.yatagan.generated.KaptClasspathForCompatCheck1_3_0
+import com.yandex.yatagan.generated.KaptClasspathForCompatCheck1_5_0
 import org.junit.Assume
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,24 +34,30 @@ import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
 class LoaderCompatibilityTest(
-    @Suppress("unused")
-    private val version: String,
-    private val kaptClasspath: String,
+    private val version: Version,
 ) {
+    @Suppress("EnumEntryName")
+    enum class Version(
+        val kaptClasspath: String,
+        val apiClasspath: String,
+    ) {
+        v1_0_0(KaptClasspathForCompatCheck1_0_0, ApiClasspathForCompatCheck1_0_0),
+        v1_1_0(KaptClasspathForCompatCheck1_1_0, ApiClasspathForCompatCheck1_1_0),
+        v1_2_0(KaptClasspathForCompatCheck1_2_0, ApiClasspathForCompatCheck1_2_0),
+        v1_3_0(KaptClasspathForCompatCheck1_3_0, ApiClasspathForCompatCheck1_3_0),
+        v1_5_0(KaptClasspathForCompatCheck1_5_0, ApiClasspathForCompatCheck1_5_0),
+    }
+
     companion object {
         @JvmStatic
         @Parameters(name = "with {0}")
-        fun parameters() = listOf(
-            arrayOf("1.0.0", KaptClasspathForCompatCheck1_0_0),
-            arrayOf("1.1.0", KaptClasspathForCompatCheck1_1_0),
-            arrayOf("1.2.0", KaptClasspathForCompatCheck1_2_0),
-            arrayOf("1.3.0", KaptClasspathForCompatCheck1_3_0),
-        )
+        fun parameters() = Version.entries
     }
 
     @Test
     fun `'create' is compatible with code generated with `() = with(JapCompileTestDriver(
-        customProcessorClasspath = kaptClasspath,
+        customProcessorClasspath = version.kaptClasspath,
+        apiClasspath = version.apiClasspath,
         checkGoldenOutput = false,
     )) {
         givenKotlinSource("test.TestCase", """
@@ -70,7 +82,8 @@ class LoaderCompatibilityTest(
 
     @Test
     fun `'builder' is compatible with code generated `() = with(JapCompileTestDriver(
-        customProcessorClasspath = kaptClasspath,
+        customProcessorClasspath = version.kaptClasspath,
+        apiClasspath = version.apiClasspath,
         checkGoldenOutput = false,
     )) {
         givenKotlinSource("test.TestCase", """
@@ -99,10 +112,11 @@ class LoaderCompatibilityTest(
 
     @Test
     fun `'autoBuilder' is compatible with code generated `() = with(JapCompileTestDriver(
-        customProcessorClasspath = kaptClasspath,
+        customProcessorClasspath = version.kaptClasspath,
+        apiClasspath = version.apiClasspath,
         checkGoldenOutput = false,
     )) {
-        Assume.assumeTrue(version >= "1.2.0")  // Auto-builder was added in 1.2.0
+        Assume.assumeTrue(version >= Version.v1_2_0)  // Auto-builder was added in 1.2.0
 
         givenKotlinSource("test.TestCase", """
             import com.yandex.yatagan.*


### PR DESCRIPTION
[Api: Move Provides.conditionals API.](https://github.com/yandex/yatagan/commit/2e406c97db8313f0c634ea5bdce2f7a6c0989d5e) 

Instead of
`@Provides(Conditional(..), Conditional(..))`
it's now required to write `@Provides @conditional(..) @conditional(..)`.

That is done to fix IDE's issues with `OptIn`s,
where it could require the user to opt-in to
conditions usage, where none were used.

This also improves consistency with other parts
of the API where `Conditional` is a top-level annotation.

Edits in tests are necessary to separate the api
 classpath, as this CL introduces a breaking change.