### PR TITLE
Api: Support dagger-compat mode.

### DIFF
--- a/codegen/impl/build.gradle.kts
+++ b/codegen/impl/build.gradle.kts
@@ -12,3 +12,11 @@ dependencies {
     implementation(libs.yataganDogFood.api)
     ksp(libs.yataganDogFood.ksp)
 }
+
+kotlin {
+    sourceSets.configureEach {
+        languageSettings {
+            optIn("com.yandex.yatagan.ConditionsApi")
+        }
+    }
+}

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/ComponentGenerator.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/ComponentGenerator.kt
@@ -54,6 +54,7 @@ internal class ComponentGenerator @Inject constructor(
         val enableThreadChecks: Boolean,
         val sortMethodsForTesting: Boolean,
         val generatedAnnotationClassName: ClassName?,
+        val enableDaggerCompatMode: Boolean,
     )
 
     init {

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/DaggerCompatBridgeGenerator.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/DaggerCompatBridgeGenerator.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.codegen.impl
+
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.TypeSpec
+import com.yandex.yatagan.Conditional
+import com.yandex.yatagan.codegen.poetry.buildClass
+import com.yandex.yatagan.core.graph.BindingGraph
+import com.yandex.yatagan.lang.compiled.ClassNameModel
+import com.yandex.yatagan.lang.compiled.ParameterizedNameModel
+import javax.inject.Inject
+import javax.inject.Singleton
+import javax.lang.model.element.Modifier
+
+@Singleton
+@Conditional(DaggerCompatEnabled::class)
+internal class DaggerCompatBridgeGenerator @Inject constructor(
+    private val componentImplName: ClassName,
+    private val graph: BindingGraph,
+    private val options: ComponentGenerator.Options,
+) {
+    val bridgeClassName: ClassName = graph.model.name.let {
+        val name = when (it) {
+            is ClassNameModel -> it
+            is ParameterizedNameModel -> it.raw
+            else -> throw AssertionError("Unexpected component name: $it")
+        }
+        // Name format is the same is dagger
+        ClassName.get(name.packageName, "Dagger" + name.simpleNames.joinToString(separator = "_"))
+    }
+
+    fun generate(): TypeSpec = buildClass(bridgeClassName) {
+        check(graph.isRoot)
+
+        modifiers(Modifier.FINAL, Modifier.PUBLIC)
+        annotation(Names.YataganGenerated)
+        options.generatedAnnotationClassName?.let {
+            annotation(it) { stringValue(value = "com.yandex.yatagan.codegen.impl.DaggerCompatBridgeGenerator") }
+        }
+
+        when(val factory = graph.model.factory) {
+            null -> {
+                method("create") {
+                    modifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    returnType(graph.model.typeName())
+                    +"return %T.autoBuilder().create()".formatCode(componentImplName)
+                }
+                // TODO: Maybe generate static dagger auto-builder?
+            }
+            else -> {
+                method("builder") {
+                    modifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    returnType(factory.typeName())
+                    +"return %T.builder()".formatCode(componentImplName)
+                }
+                method("factory") {
+                    modifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    returnType(factory.typeName())
+                    +"return builder()"
+                }
+            }
+        }
+    }
+}

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/GeneratorComponent.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/GeneratorComponent.kt
@@ -4,9 +4,11 @@ import com.squareup.javapoet.ClassName
 import com.yandex.yatagan.Binds
 import com.yandex.yatagan.BindsInstance
 import com.yandex.yatagan.Component
+import com.yandex.yatagan.ConditionExpression
 import com.yandex.yatagan.ConditionsApi
 import com.yandex.yatagan.IntoList
 import com.yandex.yatagan.Module
+import com.yandex.yatagan.Optional
 import com.yandex.yatagan.Provides
 import com.yandex.yatagan.base.api.Extensible
 import com.yandex.yatagan.core.graph.BindingGraph
@@ -21,6 +23,9 @@ internal annotation class MethodsNamespace
 
 @Qualifier
 internal annotation class SubcomponentsNamespace
+
+@ConditionExpression("getEnableDaggerCompatMode", ComponentGenerator.Options::class)
+internal annotation class DaggerCompatEnabled
 
 @Singleton
 @Component(modules = [
@@ -48,6 +53,8 @@ internal interface GeneratorComponent {
 
     @get:SubcomponentsNamespace
     val subcomponentsNamespace: Namespace
+
+    val daggerCompatGenerator: Optional<DaggerCompatBridgeGenerator>
 
     @Component.Builder
     interface Factory {

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/MapBindingGenerator.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/MapBindingGenerator.kt
@@ -16,7 +16,6 @@
 
 package com.yandex.yatagan.codegen.impl
 
-import com.yandex.yatagan.base.api.Extensible
 import com.yandex.yatagan.codegen.poetry.CodeBuilder
 import com.yandex.yatagan.codegen.poetry.ExpressionBuilder
 import com.yandex.yatagan.codegen.poetry.buildExpression
@@ -87,7 +86,7 @@ internal class MapBindingGenerator @Inject constructor(
         override fun visitByte(value: Byte) = with(builder) { +value.toString() }
         override fun visitShort(value: Short) = with(builder) { +value.toString() }
         override fun visitInt(value: Int) = with(builder) { +value.toString() }
-        override fun visitLong(value: Long) = with(builder) { +value.toString() }
+        override fun visitLong(value: Long) = with(builder) { +"%LL".formatCode(value) }
         override fun visitChar(value: Char) = with(builder) { +"'%L'".formatCode(value) }
         override fun visitFloat(value: Float) = with(builder) { +value.toString() }
         override fun visitDouble(value: Double) = with(builder) { +value.toString() }

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/Names.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/Names.kt
@@ -20,6 +20,7 @@ import com.squareup.javapoet.ClassName
 
 internal object Names {
     val Lazy: ClassName = ClassName.get("com.yandex.yatagan", "Lazy")
+    val LazyCompat: ClassName = ClassName.get("dagger", "Lazy")
     val Provider: ClassName = ClassName.get("javax.inject", "Provider")
     val Optional: ClassName = ClassName.get("com.yandex.yatagan", "Optional")
     val AutoBuilder: ClassName = ClassName.get("com.yandex.yatagan", "AutoBuilder")

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/ScopedProviderGenerator.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/ScopedProviderGenerator.kt
@@ -44,6 +44,10 @@ internal class ScopedProviderGenerator @Inject constructor(
         builder.nestedType {
             buildClass(name) {
                 implements(Names.Lazy)
+                if (options.enableDaggerCompatMode) {
+                    implements(Names.Provider)
+                    implements(Names.LazyCompat)
+                }
                 modifiers(PRIVATE, STATIC, FINAL)
                 field(componentImplName, "mDelegate") { modifiers(PRIVATE, FINAL) }
                 field(ClassName.INT, "mIndex") { modifiers(PRIVATE, FINAL) }

--- a/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/UnscopedProviderGenerator.kt
+++ b/codegen/impl/src/main/kotlin/com/yandex/yatagan/codegen/impl/UnscopedProviderGenerator.kt
@@ -29,6 +29,7 @@ import javax.lang.model.element.Modifier.STATIC
 @Singleton
 internal class UnscopedProviderGenerator @Inject constructor(
     private val componentImplName: ClassName,
+    private val options: ComponentGenerator.Options,
 ) : ComponentGenerator.Contributor {
     private var isUsed = false
     val name: ClassName = componentImplName.nestedClass("ProviderImpl")
@@ -39,6 +40,10 @@ internal class UnscopedProviderGenerator @Inject constructor(
         builder.nestedType {
             buildClass(name) {
                 implements(Names.Lazy)
+                if (options.enableDaggerCompatMode) {
+                    implements(Names.Provider)
+                    implements(Names.LazyCompat)
+                }
                 modifiers(/*package-private*/ STATIC, FINAL)
                 field(componentImplName, "mDelegate") {
                     modifiers(PRIVATE, FINAL)

--- a/core/model/impl/build.gradle.kts
+++ b/core/model/impl/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(project(":core:model:api"))
 
     implementation(project(":validation:format"))
+    implementation(project(":lang:common"))
     implementation(project(":base:impl"))
 
     implementation(libs.logicng)

--- a/core/model/impl/src/main/kotlin/com/yandex/yatagan/core/model/impl/ScopeModelImpl.kt
+++ b/core/model/impl/src/main/kotlin/com/yandex/yatagan/core/model/impl/ScopeModelImpl.kt
@@ -3,6 +3,7 @@ package com.yandex.yatagan.core.model.impl
 import com.yandex.yatagan.core.model.ScopeModel
 import com.yandex.yatagan.lang.Annotation
 import com.yandex.yatagan.lang.AnnotationDeclaration
+import com.yandex.yatagan.lang.BuiltinAnnotation
 
 @JvmInline
 internal value class ScopeModelImpl private constructor(
@@ -18,9 +19,9 @@ internal value class ScopeModelImpl private constructor(
     override fun toString() = impl.toString()
 
     companion object {
-        operator fun invoke(annotation: Annotation): ScopeModel = when (annotation.annotationClass.qualifiedName) {
-            Names.Reusable -> ScopeModel.Reusable
-            else -> ScopeModelImpl(annotation)
-        }
+        operator fun invoke(annotation: Annotation): ScopeModel =
+            annotation.asBuiltin(BuiltinAnnotation.Reusable)?.let {
+                return ScopeModel.Reusable
+            } ?: ScopeModelImpl(annotation)
     }
 }

--- a/core/model/impl/src/main/kotlin/com/yandex/yatagan/core/model/impl/coreUtil.kt
+++ b/core/model/impl/src/main/kotlin/com/yandex/yatagan/core/model/impl/coreUtil.kt
@@ -31,6 +31,7 @@ import com.yandex.yatagan.lang.Annotated
 import com.yandex.yatagan.lang.Annotation
 import com.yandex.yatagan.lang.BuiltinAnnotation
 import com.yandex.yatagan.lang.Type
+import com.yandex.yatagan.lang.common.isDaggerCompat
 import com.yandex.yatagan.validation.MayBeInvalid
 import com.yandex.yatagan.validation.Validator
 import com.yandex.yatagan.validation.format.TextColor
@@ -49,6 +50,9 @@ internal fun NodeDependency(
             Names.Lazy -> OptionalLazy
             Names.Provider -> OptionalProvider
             else -> Optional
+        }
+        Names.LazyCompat -> {
+            if (type.isDaggerCompat()) Lazy else Direct
         }
         else -> Direct
     }
@@ -71,15 +75,15 @@ internal fun NodeDependency(
 
 internal fun isFrameworkType(type: Type) = when (type.declaration.qualifiedName) {
     Names.Lazy, Names.Optional, Names.Provider -> true
+    Names.LazyCompat -> type.isDaggerCompat()
     else -> false
 }
 
 internal object Names {
     const val Lazy: String = "com.yandex.yatagan.Lazy"
+    const val LazyCompat: String = "dagger.Lazy"
     const val Provider: String = "javax.inject.Provider"
     const val Optional: String = "com.yandex.yatagan.Optional"
-
-    const val Reusable: String = "com.yandex.yatagan.Reusable"
 
     const val List: String = "java.util.List"
     const val Set: String = "java.util.Set"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ ksp = "1.9.23-1.0.20"
 # Must be compatible with 'kotlin'
 dokka = "1.9.20"
 
+dagger = "2.51.1"
+
 # Yatagan version used to build Yatagan
 yataganDogFood = "1.5.0"
 
@@ -37,3 +39,5 @@ yataganDogFood-ksp = { module = "com.yandex.yatagan:processor-ksp", version.ref 
 testing-roomCompileTesting = "androidx.room:room-compiler-processing-testing:2.6.0"
 testing-junit4 = "junit:junit:4.13.2"
 testing-assertj = "org.assertj:assertj-core:3.25.3"
+testing-dagger-api =  { module = "com.google.dagger:dagger", version.ref = "dagger" }
+testing-dagger-processor =  { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }

--- a/lang/api/api/api.api
+++ b/lang/api/api/api.api
@@ -88,7 +88,7 @@ public final class com/yandex/yatagan/lang/Callable$Visitor$DefaultImpls {
 	public static fun visitMethod (Lcom/yandex/yatagan/lang/Callable$Visitor;Lcom/yandex/yatagan/lang/Method;)Ljava/lang/Object;
 }
 
-public abstract interface class com/yandex/yatagan/lang/Constructor : com/yandex/yatagan/lang/Accessible, com/yandex/yatagan/lang/Annotated, com/yandex/yatagan/lang/Callable {
+public abstract interface class com/yandex/yatagan/lang/Constructor : com/yandex/yatagan/lang/Accessible, com/yandex/yatagan/lang/Annotated, com/yandex/yatagan/lang/Callable, com/yandex/yatagan/lang/scope/LexicalScope {
 	public abstract fun getConstructee ()Lcom/yandex/yatagan/lang/TypeDeclaration;
 }
 
@@ -186,7 +186,7 @@ public final class com/yandex/yatagan/lang/Method$DefaultImpls {
 	public static fun isAnnotatedWith (Lcom/yandex/yatagan/lang/Method;Ljava/lang/Class;)Z
 }
 
-public abstract interface class com/yandex/yatagan/lang/Parameter : com/yandex/yatagan/lang/Annotated {
+public abstract interface class com/yandex/yatagan/lang/Parameter : com/yandex/yatagan/lang/Annotated, com/yandex/yatagan/lang/scope/LexicalScope {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getType ()Lcom/yandex/yatagan/lang/Type;
 }

--- a/lang/api/src/main/kotlin/com/yandex/yatagan/lang/BuiltinAnnotation.kt
+++ b/lang/api/src/main/kotlin/com/yandex/yatagan/lang/BuiltinAnnotation.kt
@@ -321,4 +321,9 @@ public sealed interface BuiltinAnnotation {
             override val modelClass: Class<ValueOf> get() = ValueOf::class.java
         }
     }
+
+    @Internal
+    public object Reusable : CanBeCastedOut, Target.CanBeCastedOut<Reusable> {
+        override val modelClass: Class<Reusable> get() = Reusable::class.java
+    }
 }

--- a/lang/api/src/main/kotlin/com/yandex/yatagan/lang/Parameter.kt
+++ b/lang/api/src/main/kotlin/com/yandex/yatagan/lang/Parameter.kt
@@ -17,11 +17,12 @@
 package com.yandex.yatagan.lang
 
 import com.yandex.yatagan.base.api.Internal
+import com.yandex.yatagan.lang.scope.LexicalScope
 
 /**
  * Models a [Callable] parameter.
  */
-public interface Parameter : Annotated {
+public interface Parameter : Annotated, LexicalScope {
     /**
      * Parameter name.
      *

--- a/lang/common/src/main/kotlin/com/yandex/yatagan/lang/common/LangOptions.kt
+++ b/lang/common/src/main/kotlin/com/yandex/yatagan/lang/common/LangOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Yandex LLC
+ * Copyright 2024 Yandex LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,19 @@
  * limitations under the License.
  */
 
-package com.yandex.yatagan.lang
+package com.yandex.yatagan.lang.common
 
-import com.yandex.yatagan.base.api.Internal
+import com.yandex.yatagan.base.api.Extensible
 import com.yandex.yatagan.lang.scope.LexicalScope
 
 /**
- * Models a type constructor.
+ * Options structure, that is visible to lang implementations.
  */
-public interface Constructor : Callable, Annotated, Accessible, LexicalScope {
+class LangOptions(
     /**
-     * An owner and a constructed type of the constructor.
+     * Enables best-effort dagger compatibility mode - dagger annotations and framework types will be recognized.
      */
-    public val constructee: TypeDeclaration
-
-    /**
-     * Obtains framework annotation of the given kind.
-     *
-     * @return the annotation model or `null` if no such annotation is present.
-     */
-    @Internal
-    public fun <T : BuiltinAnnotation.OnConstructor> getAnnotation(
-        which: BuiltinAnnotation.Target.OnConstructor<T>
-    ): T?
+    val daggerCompatibilityMode: Boolean,
+) {
+    companion object : Extensible.Key<LangOptions, LexicalScope.Extensions>
 }

--- a/lang/common/src/main/kotlin/com/yandex/yatagan/lang/common/utils.kt
+++ b/lang/common/src/main/kotlin/com/yandex/yatagan/lang/common/utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Yandex LLC
+ * Copyright 2024 Yandex LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.yandex.yatagan.lang.compiled
+package com.yandex.yatagan.lang.common
 
-import com.yandex.yatagan.lang.Annotation
+import com.yandex.yatagan.lang.scope.LexicalScope
 
-internal inline fun <reified A : kotlin.Annotation> Annotation.hasType() = annotationClass.isClass(A::class.java)
-
-internal fun Annotation.hasType(qualifiedName: String) = annotationClass.qualifiedName == qualifiedName
+/**
+ * Whether dagger compatibility is enabled in this scope.
+ */
+fun LexicalScope.isDaggerCompat(): Boolean = ext[LangOptions].daggerCompatibilityMode

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtAnnotationBase.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtAnnotationBase.kt
@@ -17,6 +17,7 @@
 package com.yandex.yatagan.lang.compiled
 
 import com.yandex.yatagan.ConditionsApi
+import com.yandex.yatagan.Reusable
 import com.yandex.yatagan.ValueOf
 import com.yandex.yatagan.base.ifOrElseNull
 import com.yandex.yatagan.lang.Annotation
@@ -24,6 +25,7 @@ import com.yandex.yatagan.lang.Annotation.Value
 import com.yandex.yatagan.lang.BuiltinAnnotation
 import com.yandex.yatagan.lang.Type
 import com.yandex.yatagan.lang.common.AnnotationBase
+import com.yandex.yatagan.lang.common.isDaggerCompat
 
 /**
  * An [Annotation] which supports getting typed attribute values by name efficiently.
@@ -57,6 +59,8 @@ abstract class CtAnnotationBase : AnnotationBase() {
     override fun <T : BuiltinAnnotation.CanBeCastedOut> asBuiltin(which: BuiltinAnnotation.Target.CanBeCastedOut<T>): T? {
         return which.modelClass.cast(when(which) {
             BuiltinAnnotation.ValueOf -> ifOrElseNull(hasType<ValueOf>()) { CtValueOfAnnotationImpl(this) }
+            BuiltinAnnotation.Reusable -> ifOrElseNull(
+                hasType<Reusable>() || isDaggerCompat() && hasType(DaggerNames.REUSABLE)) { BuiltinAnnotation.Reusable }
         })
     }
 

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtAnnotationDeclarationBase.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtAnnotationDeclarationBase.kt
@@ -19,6 +19,7 @@ package com.yandex.yatagan.lang.compiled
 import com.yandex.yatagan.IntoMap
 import com.yandex.yatagan.lang.BuiltinAnnotation
 import com.yandex.yatagan.lang.common.AnnotationDeclarationBase
+import com.yandex.yatagan.lang.common.isDaggerCompat
 import javax.inject.Qualifier
 import javax.inject.Scope
 
@@ -30,7 +31,10 @@ abstract class CtAnnotationDeclarationBase : AnnotationDeclarationBase() {
     ): T? {
         val annotation: BuiltinAnnotation.OnAnnotationClass? = when(builtinAnnotation) {
             BuiltinAnnotation.IntoMap.Key -> (builtinAnnotation as BuiltinAnnotation.IntoMap.Key)
-                .takeIf { annotations.any { it.hasType<IntoMap.Key>() } }
+                .takeIf {
+                    annotations.any { it.hasType<IntoMap.Key>() } ||
+                            isDaggerCompat() && annotations.any { it.hasType(DaggerNames.MAP_KEY) }
+                }
             BuiltinAnnotation.Qualifier -> (builtinAnnotation as BuiltinAnnotation.Qualifier)
                 .takeIf { annotations.any { it.hasType<Qualifier>() } }
             BuiltinAnnotation.Scope -> (builtinAnnotation as BuiltinAnnotation.Scope)

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtConstructorBase.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtConstructorBase.kt
@@ -19,6 +19,7 @@ package com.yandex.yatagan.lang.compiled
 import com.yandex.yatagan.AssistedInject
 import com.yandex.yatagan.lang.BuiltinAnnotation
 import com.yandex.yatagan.lang.common.ConstructorBase
+import com.yandex.yatagan.lang.common.isDaggerCompat
 import javax.inject.Inject
 
 abstract class CtConstructorBase : ConstructorBase() {
@@ -26,8 +27,14 @@ abstract class CtConstructorBase : ConstructorBase() {
         which: BuiltinAnnotation.Target.OnConstructor<T>,
     ): T? {
         val value: BuiltinAnnotation.OnConstructor? = when (which) {
-            BuiltinAnnotation.AssistedInject -> (which as BuiltinAnnotation.AssistedInject)
-                .takeIf { annotations.any { it.hasType<AssistedInject>() } }
+            BuiltinAnnotation.AssistedInject -> {
+                val daggerCompat = isDaggerCompat()
+                (which as BuiltinAnnotation.AssistedInject)
+                    .takeIf {
+                        annotations.any { it.hasType<AssistedInject>() ||
+                                daggerCompat && it.hasType(DaggerNames.ASSISTED_INJECT) }
+                    }
+            }
 
             BuiltinAnnotation.Inject -> (which as BuiltinAnnotation.Inject)
                 .takeIf { annotations.any { it.hasType<Inject>() } }

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtMethodBase.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/CtMethodBase.kt
@@ -28,6 +28,7 @@ import com.yandex.yatagan.Multibinds
 import com.yandex.yatagan.Provides
 import com.yandex.yatagan.lang.BuiltinAnnotation
 import com.yandex.yatagan.lang.common.MethodBase
+import com.yandex.yatagan.lang.common.isDaggerCompat
 import javax.inject.Inject
 
 abstract class CtMethodBase : MethodBase() {
@@ -36,17 +37,30 @@ abstract class CtMethodBase : MethodBase() {
     override fun <T : BuiltinAnnotation.OnMethod> getAnnotation(
         which: BuiltinAnnotation.Target.OnMethod<T>
     ): T? {
+        val daggerCompat = isDaggerCompat()
         val annotation: BuiltinAnnotation.OnMethod? = when (which) {
             BuiltinAnnotation.Binds -> (which as BuiltinAnnotation.Binds)
-                .takeIf { annotations.any { it.hasType<Binds>() } }
+                .takeIf {
+                    annotations.any { it.hasType<Binds>() || daggerCompat && it.hasType(DaggerNames.BINDS) }
+                }
             BuiltinAnnotation.BindsInstance -> (which as BuiltinAnnotation.BindsInstance)
-                .takeIf { annotations.any { it.hasType<BindsInstance>() } }
+                .takeIf {
+                    annotations.any { it.hasType<BindsInstance>() ||
+                            daggerCompat && it.hasType(DaggerNames.BINDS_INSTANCE) }
+                }
             BuiltinAnnotation.Provides -> (which as BuiltinAnnotation.Provides)
-                .takeIf { annotations.any { it.hasType<Provides>() } }
+                .takeIf {
+                    annotations.any { it.hasType<Provides>() || daggerCompat && it.hasType(DaggerNames.PROVIDES) }
+                }
             BuiltinAnnotation.IntoMap -> (which as BuiltinAnnotation.IntoMap)
-                .takeIf { annotations.any { it.hasType<IntoMap>() } }
+                .takeIf {
+                    annotations.any { it.hasType<IntoMap>() || daggerCompat && it.hasType(DaggerNames.INTO_MAP) }
+                }
             BuiltinAnnotation.Multibinds -> (which as BuiltinAnnotation.Multibinds)
-                .takeIf { annotations.any { it.hasType<Multibinds>() } }
+                .takeIf {
+                    annotations.any { it.hasType<Multibinds>() ||
+                            daggerCompat && it.hasType(DaggerNames.MULTIBINDS) }
+                }
             BuiltinAnnotation.Inject -> (which as BuiltinAnnotation.Inject)
                 .takeIf { annotations.any { it.hasType<Inject>() } }
         }
@@ -60,11 +74,16 @@ abstract class CtMethodBase : MethodBase() {
         return when (which) {
             BuiltinAnnotation.IntoCollectionFamily -> buildList {
                 for (annotation in annotations) {
+                    val daggerCompat = isDaggerCompat()
                     when {
                         annotation.hasType<IntoList>() ->
                             add(which.modelClass.cast(CtIntoListAnnotationImpl(annotation)))
                         annotation.hasType<IntoSet>() ->
                             add(which.modelClass.cast(CtIntoSetAnnotationImpl(annotation)))
+                        daggerCompat && annotation.hasType(DaggerNames.INTO_SET) ->
+                            add(which.modelClass.cast(CtIntoSetAnnotationDaggerCompatImpl(annotation)))
+                        daggerCompat && annotation.hasType(DaggerNames.ELEMENTS_INTO_SET) ->
+                            add(which.modelClass.cast(CtElementsIntoSetAnnotationDaggerCompatImpl(annotation)))
                     }
                 }
             }

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/DaggerNames.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/DaggerNames.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.lang.compiled
+
+internal object DaggerNames {
+    const val REUSABLE = "dagger.Reusable"
+
+    const val MODULE = "dagger.Module"
+    const val COMPONENT = "dagger.Component"
+    const val SUBCOMPONENT = "dagger.Subcomponent"
+
+    val COMPONENT_BUILDERS = setOf(
+        "dagger.Component.Builder",
+        "dagger.Component.Factory",
+        "dagger.Subcomponent.Builder",
+        "dagger.Subcomponent.Factory",
+    )
+
+    const val BINDS = "dagger.Binds"
+    const val BINDS_INSTANCE = "dagger.BindsInstance"
+    const val PROVIDES = "dagger.Provides"
+    const val MAP_KEY = "dagger.MapKey"
+
+    const val ASSISTED = "dagger.assisted.Assisted"
+    const val ASSISTED_INJECT = "dagger.assisted.AssistedInject"
+    const val ASSISTED_FACTORY = "dagger.assisted.AssistedFactory"
+
+    const val INTO_MAP = "dagger.multibindings.IntoMap"
+    const val INTO_SET = "dagger.multibindings.IntoSet"
+    const val MULTIBINDS = "dagger.multibindings.Multibinds"
+    const val ELEMENTS_INTO_SET = "dagger.multibindings.ElementsIntoSet"
+}

--- a/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/daggerAdapterAnnotations.kt
+++ b/lang/compiled/src/main/kotlin/com/yandex/yatagan/lang/compiled/daggerAdapterAnnotations.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.lang.compiled
+
+import com.yandex.yatagan.lang.BuiltinAnnotation
+
+// dagger.Component
+internal class CtComponentAnnotationDaggerCompatImpl(
+    impl: CtAnnotationBase,
+) : CtBuiltinAnnotationBase(impl), BuiltinAnnotation.Component {
+    override val isRoot get() = true
+    override val modules get() = impl.getTypes("modules")
+    override val dependencies get() = impl.getTypes("dependencies")
+    override val variant get() = emptyList<Nothing>()
+    override val multiThreadAccess get() = true
+}
+
+// dagger.Subcomponent
+internal class CtSubcomponentAnnotationDaggerCompatImpl(
+    impl: CtAnnotationBase,
+) : CtBuiltinAnnotationBase(impl), BuiltinAnnotation.Component {
+    override val isRoot get() = false
+    override val modules get() = impl.getTypes("modules")
+    override val dependencies get() = emptyList<Nothing>()  // No dependencies
+    override val variant get() = emptyList<Nothing>()
+    override val multiThreadAccess get() = true
+}
+
+// dagger.multibindings.IntoSet
+internal class CtIntoSetAnnotationDaggerCompatImpl(
+    impl: CtAnnotationBase,
+) : CtBuiltinAnnotationBase(impl), BuiltinAnnotation.IntoCollectionFamily.IntoSet {
+    override val flatten get() = false
+}
+
+// dagger.multibindings.ElementsIntoSet
+internal class CtElementsIntoSetAnnotationDaggerCompatImpl(
+    impl: CtAnnotationBase,
+) : CtBuiltinAnnotationBase(impl), BuiltinAnnotation.IntoCollectionFamily.IntoSet {
+    override val flatten get() = true
+}

--- a/lang/jap/src/main/kotlin/com/yandex/yatagan/lang/jap/JavaxTypeDeclarationImpl.kt
+++ b/lang/jap/src/main/kotlin/com/yandex/yatagan/lang/jap/JavaxTypeDeclarationImpl.kt
@@ -201,7 +201,7 @@ internal class JavaxTypeDeclarationImpl private constructor(
 
     private inner class ConstructorImpl(
         override val platformModel: ExecutableElement,
-    ) : CtConstructorBase(), Annotated by JavaxAnnotatedImpl(this, platformModel) {
+    ) : CtConstructorBase(), Annotated by JavaxAnnotatedImpl(this, platformModel), LexicalScope by this {
         override val isEffectivelyPublic: Boolean get() = platformModel.isPublic
         override val constructee: TypeDeclaration get() = this@JavaxTypeDeclarationImpl
         override val parameters: Sequence<Parameter> = parametersSequenceFor(platformModel, type)

--- a/lang/ksp/src/main/kotlin/com/yandex/yatagan/lang/ksp/KspTypeDeclarationImpl.kt
+++ b/lang/ksp/src/main/kotlin/com/yandex/yatagan/lang/ksp/KspTypeDeclarationImpl.kt
@@ -394,7 +394,7 @@ internal class KspTypeDeclarationImpl private constructor(
 
     private inner class ConstructorImpl(
         override val platformModel: KSFunctionDeclaration,
-    ) : CtConstructorBase(), Annotated by KspAnnotatedImpl(this, platformModel) {
+    ) : CtConstructorBase(), Annotated by KspAnnotatedImpl(this, platformModel), LexicalScope by this {
         private val jvmSignature = JvmMethodSignature(platformModel)
 
         override val isEffectivelyPublic: Boolean

--- a/lang/rt/src/main/kotlin/com/yandex/yatagan/lang/rt/RtAnnotationImpl.kt
+++ b/lang/rt/src/main/kotlin/com/yandex/yatagan/lang/rt/RtAnnotationImpl.kt
@@ -18,6 +18,7 @@ package com.yandex.yatagan.lang.rt
 
 import com.yandex.yatagan.ConditionsApi
 import com.yandex.yatagan.IntoMap
+import com.yandex.yatagan.Reusable
 import com.yandex.yatagan.ValueOf
 import com.yandex.yatagan.lang.Annotated
 import com.yandex.yatagan.lang.Annotation.Value
@@ -56,6 +57,7 @@ internal class RtAnnotationImpl private constructor(
     override fun <T : BuiltinAnnotation.CanBeCastedOut> asBuiltin(which: BuiltinAnnotation.Target.CanBeCastedOut<T>): T? {
         return which.modelClass.cast(when(which) {
             BuiltinAnnotation.ValueOf -> RtValueOfAnnotationImpl(impl as? ValueOf ?: return null)
+            BuiltinAnnotation.Reusable -> which.takeIf { impl is Reusable }
         })
     }
 

--- a/lang/rt/src/main/kotlin/com/yandex/yatagan/lang/rt/RtTypeDeclarationImpl.kt
+++ b/lang/rt/src/main/kotlin/com/yandex/yatagan/lang/rt/RtTypeDeclarationImpl.kt
@@ -206,7 +206,7 @@ internal class RtTypeDeclarationImpl private constructor(
     private inner class ConstructorImpl(
         override val platformModel: ReflectConstructor,
         override val constructee: TypeDeclaration,
-    ) : ConstructorBase(), Annotated by RtAnnotatedImpl(constructee, platformModel) {
+    ) : ConstructorBase(), Annotated by RtAnnotatedImpl(constructee, platformModel), LexicalScope by this {
         private val parametersAnnotations by lazy { platformModel.parameterAnnotations }
         private val parametersTypes by lazy { platformModel.genericParameterTypes }
         private val parametersNames by lazy { platformModel.parameterNamesCompat() }

--- a/processor/common/build.gradle.kts
+++ b/processor/common/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(project(":core:graph:impl"))
     implementation(project(":core:model:impl"))
     implementation(project(":codegen:impl"))
+    implementation(project(":lang:common"))
 
     runtimeOnly(kotlin("reflect"))
 }

--- a/processor/common/src/main/kotlin/com/yandex/yatagan/processor/common/Options.kt
+++ b/processor/common/src/main/kotlin/com/yandex/yatagan/processor/common/Options.kt
@@ -54,6 +54,7 @@ enum class BooleanOption(
     AllConditionsLazy("yatagan.experimental.allConditionsLazy", default = false),
     OmitThreadChecks("yatagan.experimental.omitThreadChecks", default = false),
     OmitProvisionNullChecks("yatagan.experimental.omitProvisionNullChecks", default = false),
+    DaggerCompatibilityMode("yatagan.experimental.enableDaggerCompatibility", default = false),
     SortMethodsForTesting("yatagan.internal.testing.sortMethods", default = false),
 
     ;

--- a/processor/jap/src/main/kotlin/com/yandex/yatagan/processor/jap/JapYataganProcessor.kt
+++ b/processor/jap/src/main/kotlin/com/yandex/yatagan/processor/jap/JapYataganProcessor.kt
@@ -20,6 +20,7 @@ import com.yandex.yatagan.Component
 import com.yandex.yatagan.lang.TypeDeclaration
 import com.yandex.yatagan.lang.jap.JavaxLexicalScope
 import com.yandex.yatagan.lang.jap.asTypeElement
+import com.yandex.yatagan.processor.common.BooleanOption
 import com.yandex.yatagan.processor.common.Logger
 import com.yandex.yatagan.processor.common.Options
 import com.yandex.yatagan.processor.common.ProcessorDelegate
@@ -50,7 +51,11 @@ class JapYataganProcessor : AbstractProcessor(), ProcessorDelegate<TypeElement> 
         return SourceVersion.latestSupported()
     }
 
-    override fun getSupportedAnnotationTypes(): Set<String> = setOf(Component::class.java.canonicalName)
+    override fun getSupportedAnnotationTypes(): Set<String> = buildSet {
+        add(Component::class.java.canonicalName)
+        if (options[BooleanOption.DaggerCompatibilityMode])
+            add("dagger.Component")
+    }
 
     override fun getSupportedOptions(): Set<String> {
         return Options.all().mapTo(mutableSetOf()) { it.key }
@@ -74,7 +79,11 @@ class JapYataganProcessor : AbstractProcessor(), ProcessorDelegate<TypeElement> 
     }
 
     override fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
-        val elementsByAnnotation = roundEnv.getElementsAnnotatedWith(Component::class.java)
+        val elementsByAnnotation = buildList {
+            for (annotation in annotations) {
+                addAll(roundEnv.getElementsAnnotatedWith(annotation))
+            }
+        }
         process(
             sources = elementsByAnnotation
                 .map(Element::asTypeElement)

--- a/rt/engine/src/main/kotlin/com/yandex/yatagan/rt/engine/RuntimeEngine.kt
+++ b/rt/engine/src/main/kotlin/com/yandex/yatagan/rt/engine/RuntimeEngine.kt
@@ -23,6 +23,7 @@ import com.yandex.yatagan.core.graph.BindingGraph
 import com.yandex.yatagan.core.graph.impl.BindingGraph
 import com.yandex.yatagan.core.graph.impl.Options
 import com.yandex.yatagan.core.model.impl.ComponentModel
+import com.yandex.yatagan.lang.common.LangOptions
 import com.yandex.yatagan.lang.rt.RtLexicalScope
 import com.yandex.yatagan.rt.support.DynamicValidationDelegate
 import com.yandex.yatagan.rt.support.Logger
@@ -67,6 +68,10 @@ class RuntimeEngine(
             RtLexicalScope(classLoader).also {
                 it.ext[Options] = Options(
                     allConditionsLazy = params.allConditionsLazy,
+                )
+                it.ext[LangOptions] = LangOptions(
+                    // TODO: Support compat mode in RT
+                    daggerCompatibilityMode = false,
                 )
                 lexicalScopeCache[classLoader] = SoftReference(it)
             }

--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/CompileTestDriverBase.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/CompileTestDriverBase.kt
@@ -53,8 +53,7 @@ abstract class CompileTestDriverBase private constructor(
 
     override val testNameRule = TestNameRule()
 
-    protected open val checkGoldenOutput: Boolean
-        get() = true
+    protected abstract val checkGoldenOutput: Boolean
 
     final override fun givenPrecompiledModule(sources: SourceSet) {
         if (precompiledModuleOutputDirs != null) {

--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/JapCompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/JapCompileTestDriver.kt
@@ -20,6 +20,7 @@ import com.yandex.yatagan.generated.CompiledApiClasspath
 import com.yandex.yatagan.processor.jap.JapYataganProcessor
 import java.io.File
 import java.net.URLClassLoader
+import java.util.ServiceLoader
 import javax.annotation.processing.Processor
 
 class JapCompileTestDriver(
@@ -44,7 +45,6 @@ class JapCompileTestDriver(
         customProcessorClasspath ?: return null
         val kaptClassloader = URLClassLoader(customProcessorClasspath.split(File.pathSeparatorChar)
             .map { File(it).toURI().toURL() }.toTypedArray(), ClassLoader.getPlatformClassLoader())
-        val clazz = kaptClassloader.loadClass("com.yandex.yatagan.processor.jap.JapYataganProcessor")
-        return clazz.getConstructor().newInstance() as Processor
+        return ServiceLoader.load(Processor::class.java, kaptClassloader).toList().single()
     }
 }

--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/KspCompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/KspCompileTestDriver.kt
@@ -16,10 +16,16 @@
 
 package com.yandex.yatagan.testing.tests
 
+import com.yandex.yatagan.generated.CompiledApiClasspath
 import com.yandex.yatagan.processor.ksp.KspYataganProcessorProvider
 import java.io.File
 
-class KspCompileTestDriver : CompileTestDriverBase() {
+class KspCompileTestDriver(
+    override val checkGoldenOutput: Boolean = true,
+    apiClasspath: String = CompiledApiClasspath,
+) : CompileTestDriverBase(
+    apiClasspath = apiClasspath,
+) {
     override fun createCompilationArguments() = super.createCompilationArguments().copy(
         symbolProcessorProviders = listOf(KspYataganProcessorProvider()),
     )

--- a/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/DaggerCompatTest.kt
+++ b/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/DaggerCompatTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024 Yandex LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yandex.yatagan.testing.tests
+
+import com.yandex.yatagan.generated.DaggerApiClasspath
+import com.yandex.yatagan.generated.DaggerProcessorClasspath
+import com.yandex.yatagan.processor.common.BooleanOption
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import javax.inject.Provider
+
+@RunWith(Parameterized::class)
+class DaggerCompatTest(
+    driverProvider: Provider<CompileTestDriverBase>
+) : CompileTestDriver by driverProvider.get() {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters() = listOf(
+            object : Provider<CompileTestDriverBase> {
+                override fun toString() = "JAP"
+                override fun get() = JapCompileTestDriver(
+                    apiClasspath = DaggerApiClasspath,
+                )
+            },
+            object : Provider<CompileTestDriverBase> {
+                override fun toString() = "KSP"
+                override fun get() = KspCompileTestDriver(
+                    apiClasspath = DaggerApiClasspath,
+                )
+            },
+            object : Provider<CompileTestDriverBase> {
+                override fun toString() = "JAP(dagger-for-reference)"
+                override fun get() = JapCompileTestDriver(
+                    apiClasspath = DaggerApiClasspath,
+                    customProcessorClasspath = DaggerProcessorClasspath,
+                    checkGoldenOutput = false,
+                )
+            },
+        )
+    }
+
+    @Before
+    fun setUp() {
+        givenOption(BooleanOption.DaggerCompatibilityMode, true)
+    }
+
+    @Test
+    fun `basic test`() {
+        givenKotlinSource("test.TestCase", """
+            import dagger.*
+            import dagger.assisted.*
+            import dagger.multibindings.*
+            import javax.inject.*
+            import com.yandex.yatagan.Yatagan
+            
+            @Reusable class Foo @Inject constructor()         
+            @Singleton class Bar @Inject constructor()
+            @Scope annotation class MyScope
+            
+            @Module(subcomponents = [MySub2::class]) class MyModule {
+                @Provides fun a(): Int = 0
+            }
+
+            interface MyDep {
+                val foo: Foo
+            }
+
+            class AssistedClass @AssistedInject constructor(@Assisted("p1") i: Int, f: Foo)
+            @AssistedFactory interface MyAssistedFactory {
+                fun create(@Assisted("p1") i: Int): AssistedClass
+            }
+            
+            @Singleton @Component
+            interface MyDagger : MyDep {
+                override val foo: Foo
+                val bar: dagger.Lazy<Bar>
+                
+                fun createSub(mod: MyModule): MySub
+            }
+
+            class Top {
+                @MyScope
+                @Component(dependencies = [MyDep::class])
+                interface MyDaggerNested {
+                    val foo: Foo
+                    fun getI(): Int
+                    val af: MyAssistedFactory
+                    
+                    @Component.Factory
+                    interface Factory {
+                        fun create(@BindsInstance i: Int, dep: MyDep): MyDaggerNested
+                    }
+                }
+            }
+            
+            @Subcomponent(modules = [MyModule::class]) interface MySub {
+                val foo: Foo
+                val a: Provider<Int>
+                val s: MySub2.Builder
+            }
+
+            @Module object SubModule {
+                @Provides @IntoSet @Named("list")
+                fun intoSet(): Int = 3
+                @Provides @ElementsIntoSet @Named("list")
+                fun manyIntoSet(): Set<Int> = setOf(1, 2)
+
+                @Provides @IntoMap @LongKey(123_456_789_000L)
+                fun map1(): String = "big-num"
+
+                @Provides @IntoMap @LongKey(2L)
+                fun map2(): String = "small-num"
+            }
+            @Module(includes = [SubModule::class]) interface SubModuleI {
+                @Binds fun collection(@Named("list") i: Set<Int>): Collection<Int>
+            }
+
+            @Subcomponent(modules = [SubModuleI::class])
+            interface MySub2 {
+                val i: Char
+                @get:Named("list") val set: Set<Int>
+                val col: Collection<Int>
+                val map: Map<Long, String>
+                
+                @Subcomponent.Builder
+                interface Builder {
+                    @BindsInstance fun setChar(i: Char): Builder
+                    fun build(): MySub2
+                }
+            }
+            
+            fun test() {
+                DaggerMyDagger.create().run {
+                    foo; bar.get()
+                    createSub(MyModule()).run {
+                      foo; a.get()
+                      s.setChar('X').build().run {
+                        i; assert(set == setOf(1, 2, 3)); map
+                      }
+                    }
+                    DaggerTop_MyDaggerNested.factory().create(228, this).run {
+                        foo; getI(); af.create(1)
+                    }
+                }
+            }
+        """.trimIndent())
+
+        compileRunAndValidate()
+    }
+}

--- a/testing/tests/src/test/resources/golden/DaggerCompatTest/basic-test.golden-code.txt
+++ b/testing/tests/src/test/resources/golden/DaggerCompatTest/basic-test.golden-code.txt
@@ -1,0 +1,336 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/DaggerMyDagger.java
+package test;
+
+import com.yandex.yatagan.internal.YataganGenerated;
+import javax.annotation.processing.Generated;
+
+@YataganGenerated
+@Generated("com.yandex.yatagan.codegen.impl.DaggerCompatBridgeGenerator")
+public final class DaggerMyDagger {
+  public static MyDagger create() {
+    return Yatagan$MyDagger.autoBuilder().create();
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/DaggerTop_MyDaggerNested.java
+package test;
+
+import com.yandex.yatagan.internal.YataganGenerated;
+import javax.annotation.processing.Generated;
+
+@YataganGenerated
+@Generated("com.yandex.yatagan.codegen.impl.DaggerCompatBridgeGenerator")
+public final class DaggerTop_MyDaggerNested {
+  public static Top.MyDaggerNested.Factory builder() {
+    return Yatagan$Top$MyDaggerNested.builder();
+  }
+
+  public static Top.MyDaggerNested.Factory factory() {
+    return builder();
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$MyDagger.java
+package test;
+
+import com.yandex.yatagan.AutoBuilder;
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.ThreadAssertions;
+import com.yandex.yatagan.internal.YataganGenerated;
+import dagger.Lazy;
+import java.lang.AssertionError;
+import java.lang.Character;
+import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+import javax.inject.Provider;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+@YataganGenerated
+@Generated("com.yandex.yatagan.codegen.impl.ComponentGenerator")
+public final class Yatagan$MyDagger implements MyDagger {
+  private volatile Object mBarInstance = new UninitializedLock();
+
+  private Object mFooInstance;
+
+  private Yatagan$MyDagger() {
+  }
+
+  @Override
+  public Lazy<Bar> getBar() {
+    return new ProviderImpl(this, 0);
+  }
+
+  @Override
+  public Foo getFoo() {
+    return this.cacheFoo();
+  }
+
+  @Override
+  public MySub createSub(MyModule mod) {
+    return new MySubImpl(mod);
+  }
+
+  Object switch$$access(int slot) {
+    switch(slot) {
+      case 0: return this.cacheBar();
+      default: throw new AssertionError();
+    }
+  }
+
+  Bar cacheBar() {
+    Object local = this.mBarInstance;
+    if (local instanceof UninitializedLock) {
+      synchronized (local) {
+        local = this.mBarInstance;
+        if (local instanceof UninitializedLock) {
+          local = new Bar();
+          this.mBarInstance = local;
+        }
+      }
+    }
+    return (Bar) local;
+  }
+
+  Foo cacheFoo() {
+    Object local = this.mFooInstance;
+    if (local == null) {
+      ThreadAssertions.assertThreadAccess();
+      local = new Foo();
+      this.mFooInstance = local;
+    }
+    return (Foo) local;
+  }
+
+  public static AutoBuilder<Yatagan$MyDagger> autoBuilder() {
+    return new AutoBuilderImpl();
+  }
+
+  static final class MySubImpl implements MySub {
+    private Object mFooInstance;
+
+    final MyModule mMyModule;
+
+    MySubImpl(MyModule pMod) {
+      this.mMyModule = Checks.checkInputNotNull(pMod);
+    }
+
+    @Override
+    public Provider<Integer> getA() {
+      return new ProviderImpl(this, 0);
+    }
+
+    @Override
+    public Foo getFoo() {
+      return this.cacheFoo();
+    }
+
+    @Override
+    public MySub2.Builder getS() {
+      return new MySub2Impl.ComponentFactoryImpl();
+    }
+
+    Object switch$$access(int slot) {
+      switch(slot) {
+        case 0: return Checks.checkProvisionNotNull(this.mMyModule.a());
+        default: throw new AssertionError();
+      }
+    }
+
+    Foo cacheFoo() {
+      Object local = this.mFooInstance;
+      if (local == null) {
+        ThreadAssertions.assertThreadAccess();
+        local = new Foo();
+        this.mFooInstance = local;
+      }
+      return (Foo) local;
+    }
+
+    static final class MySub2Impl implements MySub2 {
+      final Character mSetChar;
+
+      MySub2Impl(Character pSetChar) {
+        this.mSetChar = Checks.checkInputNotNull(pSetChar);
+      }
+
+      @Override
+      public Collection<Integer> getCol() {
+        return this.accessJavaxInjectNamedValueListSetInteger();
+      }
+
+      @Override
+      public char getI() {
+        return this.mSetChar;
+      }
+
+      @Override
+      public Map<Long, String> getMap() {
+        return this.mapOfMapLongString();
+      }
+
+      @Override
+      public Set<Integer> getSet() {
+        return this.accessJavaxInjectNamedValueListSetInteger();
+      }
+
+      Set<Integer> accessJavaxInjectNamedValueListSetInteger() {
+        return this.manyOfSetInteger();
+      }
+
+      Set<Integer> manyOfSetInteger() {
+        final Set<Integer> c = new HashSet<>(2);
+        c.add(Checks.checkProvisionNotNull(SubModule.INSTANCE.intoSet()));
+        c.addAll(Checks.checkProvisionNotNull(SubModule.INSTANCE.manyIntoSet()));
+        return c;
+      }
+
+      Map<Long, String> mapOfMapLongString() {
+        final Map<Long, String> map = new HashMap<>(2);
+        map.put(123456789000L, Checks.checkProvisionNotNull(SubModule.INSTANCE.map1()));
+        map.put(2L, Checks.checkProvisionNotNull(SubModule.INSTANCE.map2()));
+        return map;
+      }
+
+      private static final class ComponentFactoryImpl implements MySub2.Builder {
+        private Character mSetChar;
+
+        ComponentFactoryImpl() {
+        }
+
+        @Override
+        public MySub2.Builder setChar(char i) {
+          this.mSetChar = i;
+          return this;
+        }
+
+        @Override
+        public MySub2 build() {
+          return new MySub2Impl(this.mSetChar);
+        }
+      }
+    }
+
+    static final class ProviderImpl implements com.yandex.yatagan.Lazy, Provider, Lazy {
+      private final MySubImpl mDelegate;
+
+      private final int mIndex;
+
+      ProviderImpl(MySubImpl delegate, int index) {
+        this.mDelegate = delegate;
+        this.mIndex = index;
+      }
+
+      @Override
+      public Object get() {
+        return this.mDelegate.switch$$access(this.mIndex);
+      }
+    }
+  }
+
+  private static final class UninitializedLock {
+  }
+
+  static final class ProviderImpl implements com.yandex.yatagan.Lazy, Provider, Lazy {
+    private final Yatagan$MyDagger mDelegate;
+
+    private final int mIndex;
+
+    ProviderImpl(Yatagan$MyDagger delegate, int index) {
+      this.mDelegate = delegate;
+      this.mIndex = index;
+    }
+
+    @Override
+    public Object get() {
+      return this.mDelegate.switch$$access(this.mIndex);
+    }
+  }
+
+  private static final class AutoBuilderImpl implements AutoBuilder<Yatagan$MyDagger> {
+    @Override
+    public final <I> AutoBuilder<Yatagan$MyDagger> provideInput(I input, Class<I> inputClass) {
+      Checks.reportUnexpectedAutoBuilderInput(input.getClass(), Collections.emptyList());
+      return this;
+    }
+
+    @Override
+    public final Yatagan$MyDagger create() {
+      return new Yatagan$MyDagger();
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Name: test/Yatagan$Top$MyDaggerNested.java
+package test;
+
+import com.yandex.yatagan.internal.Checks;
+import com.yandex.yatagan.internal.YataganGenerated;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import javax.annotation.processing.Generated;
+
+@SuppressWarnings({"unchecked", "rawtypes", "NullableProblems"})
+@YataganGenerated
+@Generated("com.yandex.yatagan.codegen.impl.ComponentGenerator")
+public final class Yatagan$Top$MyDaggerNested implements Top.MyDaggerNested {
+  final Integer mI;
+
+  final MyDep mMyDep;
+
+  Yatagan$Top$MyDaggerNested(Integer pI, MyDep pDep) {
+    this.mI = Checks.checkInputNotNull(pI);
+    this.mMyDep = Checks.checkInputNotNull(pDep);
+  }
+
+  @Override
+  public MyAssistedFactory getAf() {
+    return this.new MyAssistedFactoryImpl();
+  }
+
+  @Override
+  public Foo getFoo() {
+    return this.mMyDep.getFoo();
+  }
+
+  @Override
+  public int getI() {
+    return this.mI;
+  }
+
+  public static Top.MyDaggerNested.Factory builder() {
+    return new ComponentFactoryImpl();
+  }
+
+  private final class MyAssistedFactoryImpl implements MyAssistedFactory {
+    @Override
+    public AssistedClass create(int i) {
+      return new AssistedClass(i, Yatagan$Top$MyDaggerNested.this.mMyDep.getFoo());
+    }
+  }
+
+  private static final class ComponentFactoryImpl implements Top.MyDaggerNested.Factory {
+    @Override
+    public Top.MyDaggerNested create(int i, MyDep dep) {
+      return new Yatagan$Top$MyDaggerNested(i, dep);
+    }
+  }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Api: Support dagger-compat mode.

This newly introduced mode can now be
enabled with `yatagan.experimental.enableDaggerCompatibility` option.

This mode is designed for yatagan to be a drop-in replacement of
dagger, with *minimal* migration work. And all the necessary
migration actions will keep the code compatible with the
vanilla dagger.
  
If active, all dagger annotations and types that
have supported functionality in yatagan are recognized, while
yatagan annotations and types can be used interchangeably.

Components can be created with `Dagger<class-name>` generated facades;
`Yatagan.*` entry-points are also available, but only
for classes, that are annotated with `com.yandex.yatagan.Component` annotations.

One can keep both dagger and yatagan annotations on declarations; 
the yatagan ones have priority over dagger ones.

RT support: possible, but TBD.