### PR TITLE
[test] Fix LoaderCompatibilityTest

### DIFF
--- a/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/JapCompileTestDriver.kt
+++ b/testing/tests/src/main/kotlin/com/yandex/yatagan/testing/tests/JapCompileTestDriver.kt
@@ -28,8 +28,10 @@ class JapCompileTestDriver(
     override val checkGoldenOutput: Boolean = true,
     override val backendUnderTest: Backend = Backend.Kapt,
     apiClasspath: String = CurrentClasspath.ApiCompiled,
+    runtimeApiClasspath: String = apiClasspath,
 ): CompileTestDriverBase(
     apiClasspath = apiClasspath,
+    runtimeApiClasspath = runtimeApiClasspath,
 ) {
     override fun createCompilationArguments() = super.createCompilationArguments().copy(
         kaptProcessors = listOf(loadProcessorFromCustomClasspath() ?: JapYataganProcessor()),

--- a/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/LoaderCompatibilityTest.kt
+++ b/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/LoaderCompatibilityTest.kt
@@ -17,6 +17,7 @@
 package com.yandex.yatagan.testing.tests
 
 import com.yandex.yatagan.generated.ClasspathForCompatCheck
+import com.yandex.yatagan.generated.CurrentClasspath
 import org.junit.Assume
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,6 +50,7 @@ class LoaderCompatibilityTest(
     fun `'create' is compatible with code generated with `() = with(JapCompileTestDriver(
         customProcessorClasspath = version.kaptClasspath,
         apiClasspath = version.apiClasspath,
+        runtimeApiClasspath = CurrentClasspath.ApiCompiled,
         checkGoldenOutput = false,
     )) {
         givenKotlinSource("test.TestCase", """
@@ -75,6 +77,7 @@ class LoaderCompatibilityTest(
     fun `'builder' is compatible with code generated `() = with(JapCompileTestDriver(
         customProcessorClasspath = version.kaptClasspath,
         apiClasspath = version.apiClasspath,
+        runtimeApiClasspath = CurrentClasspath.ApiCompiled,
         checkGoldenOutput = false,
     )) {
         givenKotlinSource("test.TestCase", """
@@ -105,6 +108,7 @@ class LoaderCompatibilityTest(
     fun `'autoBuilder' is compatible with code generated `() = with(JapCompileTestDriver(
         customProcessorClasspath = version.kaptClasspath,
         apiClasspath = version.apiClasspath,
+        runtimeApiClasspath = CurrentClasspath.ApiCompiled,
         checkGoldenOutput = false,
     )) {
         Assume.assumeTrue(version >= Version.v1_2_0)  // Auto-builder was added in 1.2.0


### PR DESCRIPTION
Before the fix it used the runtime api from the version under test,
 completely against the test's purpose and rendering it useless.

The fix forces the runtime classpath to be the *current* api classpath,
 so the test serves its purpose.

Luckily the test itself was not red after being fixed.