### PR TITLE
Support KSP error types.

### DIFF
--- a/lang/ksp/src/main/kotlin/com/yandex/yatagan/lang/ksp/TypeMap.kt
+++ b/lang/ksp/src/main/kotlin/com/yandex/yatagan/lang/ksp/TypeMap.kt
@@ -27,6 +27,7 @@ import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.Nullability
 import com.google.devtools.ksp.symbol.Variance
+import com.yandex.yatagan.lang.ksp.TypeMap.normalizeType
 import com.yandex.yatagan.lang.scope.FactoryKey
 import com.yandex.yatagan.lang.scope.LexicalScope
 import com.yandex.yatagan.lang.scope.caching
@@ -83,8 +84,8 @@ internal object TypeMap {
     ): KSType {
         val originalType = typeReference.resolve()
 
-        // Early bail out for error types, as the following code is likely to fail with them
-        if (originalType.isError) return originalType
+        // Early bail out for error types, as the following code is likely to fail for KSP1 with them
+        if (originalType.isError && !Utils.isKsp2) return originalType
 
         // TODO: Support parameterized type-aliases, now broken
         val type = originalType.resolveAliasIfNeeded()
@@ -120,7 +121,7 @@ internal object TypeMap {
                     typeReference = argTypeReference,
                     bakeVarianceAsWildcard = false,  // Doesn't propagate for type parameters
                 )
-                if (mappedArgType.isError) {
+                if (mappedArgType.isError && !Utils.isKsp2) {
                     // Bail out of the mapping, as error type is present - it's known to cause crashes inside
                     // KSClassDeclaration.asType() invocation
                     return type

--- a/lang/ksp/src/main/kotlin/com/yandex/yatagan/lang/ksp/nameModels.kt
+++ b/lang/ksp/src/main/kotlin/com/yandex/yatagan/lang/ksp/nameModels.kt
@@ -52,8 +52,13 @@ private fun LexicalScope.nameModelImpl(
         JvmTypeInfo.Short -> KeywordTypeNameModel.Short
         JvmTypeInfo.Boolean -> KeywordTypeNameModel.Boolean
         JvmTypeInfo.Declared -> {
-            if (type == null || type.isError) {
+            if (type == null) {
                 return InvalidNameModel.Unresolved(null)
+            }
+            if (type.isError) {
+                return InvalidNameModel.Unresolved(
+                    hint = KspErrorTypeRegex.matchEntire(type.toString())?.groupValues?.get(1) ?: type.toString(),
+                )
             }
             val classDeclaration = type.classDeclaration()
                 ?: return if (type.declaration is KSTypeParameter) {
@@ -105,3 +110,5 @@ private fun ClassNameModel(declaration: KSClassDeclaration): ClassNameModel {
             ?.split('.') ?: listOf("<unnamed>"),
     )
 }
+
+private val KspErrorTypeRegex = "<ERROR TYPE: (.*)>".toRegex()

--- a/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/UnresolvedTypeTest.kt
+++ b/testing/tests/src/test/kotlin/com/yandex/yatagan/testing/tests/UnresolvedTypeTest.kt
@@ -61,7 +61,7 @@ class UnresolvedTypeTest {
     fun `unresolved types (KSP)`() = with(KspCompileTestDriver(useK2 = false)) {
         testNameRule.assignFrom(this@UnresolvedTypeTest.testNameRule)
 
-        // FIXME: Implement fully-qualified error types when KSP is ready.
+        // KSP1 still has some cases for error-types not covered.
         includeFromSourceSet(sources)
         compileRunAndValidate()
     }
@@ -70,7 +70,6 @@ class UnresolvedTypeTest {
     fun `unresolved types (KSP2)`() = with(KspCompileTestDriver(useK2 = true)) {
         testNameRule.assignFrom(this@UnresolvedTypeTest.testNameRule)
 
-        // FIXME: Implement fully-qualified error types when KSP is ready.
         includeFromSourceSet(sources)
         compileRunAndValidate()
     }

--- a/testing/tests/src/test/resources/golden/UnresolvedTypeTest/unresolved-types-KSP-.golden.txt
+++ b/testing/tests/src/test/resources/golden/UnresolvedTypeTest/unresolved-types-KSP-.golden.txt
@@ -68,14 +68,14 @@ Encountered:
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: Invalid/unresolved type: kotlin.collections.List<<unresolved: ???>>
+error: Invalid/unresolved type: kotlin.collections.List<<unresolved: UnresolvedEp>>
 NOTE: Types can be unresolved due to actually non-existent/misspelled/un-imported class; or the compilation classpath may be inconsistent: if the type is from the library, make sure the library is present in compilation classpath of the current module.
 Encountered:
   in graph for root-component test.TestComponent<<unresolved-type-var: T>>
-  in entry-point getEpList(): kotlin.collections.List<<unresolved: ???>>
-                              ^-[*1]------------------------------------
-  here: [1*] kotlin.collections.List<<unresolved: ???>>
-             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  in entry-point getEpList(): kotlin.collections.List<<unresolved: UnresolvedEp>>
+                              ^-[*1]---------------------------------------------
+  here: [1*] kotlin.collections.List<<unresolved: UnresolvedEp>>
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: Invalid/unresolved type: test.TestComponent<<unresolved-type-var: T>>
@@ -119,11 +119,11 @@ Encountered:
              ^~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: Missing binding for kotlin.collections.List<<unresolved: ???>>
+error: Missing binding for kotlin.collections.List<<unresolved: UnresolvedEp>>
 NOTE: No known way to infer the binding
 Encountered:
   in graph for root-component test.TestComponent<<unresolved-type-var: T>>
-  in entry-point getEpList: kotlin.collections.List<<unresolved: ???>>
-                            ^-[*1]------------------------------------
+  in entry-point getEpList: kotlin.collections.List<<unresolved: UnresolvedEp>>
+                            ^-[*1]---------------------------------------------
   here: [1*] <missing>
              ^~~~~~~~~

--- a/testing/tests/src/test/resources/golden/UnresolvedTypeTest/unresolved-types-KSP2-.golden.txt
+++ b/testing/tests/src/test/resources/golden/UnresolvedTypeTest/unresolved-types-KSP2-.golden.txt
@@ -68,13 +68,13 @@ Encountered:
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: Invalid/unresolved type: kotlin.collections.List<<unresolved: ???>>
+error: Invalid/unresolved type: java.util.List<<unresolved: UnresolvedEp>>
 NOTE: Types can be unresolved due to actually non-existent/misspelled/un-imported class; or the compilation classpath may be inconsistent: if the type is from the library, make sure the library is present in compilation classpath of the current module.
 Encountered:
   in graph for root-component test.TestComponent<<unresolved-type-var: T>>
-  in entry-point getEpList(): kotlin.collections.List<<unresolved: ???>>
+  in entry-point getEpList(): java.util.List<<unresolved: UnresolvedEp>>
                               ^-[*1]------------------------------------
-  here: [1*] kotlin.collections.List<<unresolved: ???>>
+  here: [1*] java.util.List<<unresolved: UnresolvedEp>>
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -119,11 +119,11 @@ Encountered:
              ^~~~~~~~~
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: Missing binding for kotlin.collections.List<<unresolved: ???>>
+error: Missing binding for java.util.List<<unresolved: UnresolvedEp>>
 NOTE: No known way to infer the binding
 Encountered:
   in graph for root-component test.TestComponent<<unresolved-type-var: T>>
-  in entry-point getEpList: kotlin.collections.List<<unresolved: ???>>
+  in entry-point getEpList: java.util.List<<unresolved: UnresolvedEp>>
                             ^-[*1]------------------------------------
   here: [1*] <missing>
              ^~~~~~~~~


### PR DESCRIPTION
KSP1 still has no support for error types in type arguments -
 the whole type is an error then.

Based on resolution of https://github.com/google/ksp/issues/1232