### PR TITLE
[minify] Keep legacy components.

### DIFF
--- a/api/public/src/main/resources/META-INF/proguard/yatagan.pro
+++ b/api/public/src/main/resources/META-INF/proguard/yatagan.pro
@@ -5,6 +5,13 @@
     public * builder();
 }
 
+# Keep legacy generated components as well.
+-keep class **.Yatagan$* {
+    public * autoBuilder();
+    public * create();
+    public * builder();
+}
+
 # Keep component interfaces, as their names must be be preserved to find correspondent implementation.
 -keep @com.yandex.yatagan.Component interface *
 


### PR DESCRIPTION
Also include legacy `create` method.

Follow-up to #193 